### PR TITLE
__getattr__ should raise AttributeError when an attribute isn't found

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -158,6 +158,7 @@ class Resource(object):
     def __getattr__(self, name):
         if name in self.fields:
             return self.fields[name]
+        raise AttributeError
     
     def wrap_view(self, view):
         """


### PR DESCRIPTION
Currently, hasattr(resource_instance, attr) for any value of attr will return True, which is undesirable.
