### PR TITLE
ResourceOptions initialization refactor

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -83,9 +83,6 @@ class ResourceOptions(object):
         if overrides.get('detail_allowed_methods', None) is None:
             overrides['detail_allowed_methods'] = allowed_methods
         
-        if not overrides.get('queryset', None) is None:
-            overrides['object_class'] = overrides['queryset'].model
-        
         return object.__new__(type('ResourceOptions', (cls,), overrides))
 
 
@@ -1094,6 +1091,11 @@ class Resource(object):
 
 class ModelDeclarativeMetaclass(DeclarativeMetaclass):
     def __new__(cls, name, bases, attrs):
+        meta = attrs.get('Meta')
+
+        if meta and hasattr(meta, 'queryset'):
+          setattr(meta, 'object_class', meta.queryset.model)
+
         new_class = super(ModelDeclarativeMetaclass, cls).__new__(cls, name, bases, attrs)
         fields = getattr(new_class._meta, 'fields', [])
         excludes = getattr(new_class._meta, 'excludes', [])


### PR DESCRIPTION
I recently started work on integrating mongoengine documents into tastypie so that apis. I ran into a bit of a snag though when attempting to instantiate my mongo based resource though. It appears that the ResourceOptions class assumes that the queryset it is passed is a django (or at least django-like) query set and will attempt to initialize the object_class using: queryset.model. I simply removed this functionality from the options themselves and placed it in the ModelResource's metaclass.
