### PR TITLE
Fixed the automatic prefixing of the MEDIA_URL

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -186,7 +186,10 @@ class FileField(ApiField):
         if value is None:
             return None
         
-        return value.url
+        try:
+            return value.url
+        except ValueError:
+            return None
 
 
 class IntegerField(ApiField):


### PR DESCRIPTION
Doing this breaks Django's support for using custom storage backends for files and images.  If not otherwise specified, Django's default storage is set up to include the MEDIA_URL prefix already, so this should not break
any existing code.
