### PR TITLE
JSONP support for top_level view in the Api class

### DIFF
--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -5,7 +5,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from tastypie.exceptions import NotRegistered
 from tastypie.serializers import Serializer
-from tastypie.utils import trailing_slash
+from tastypie.utils import trailing_slash, is_valid_jsonp_callback_value
 from tastypie.utils.mime import determine_format, build_content_type
 
 
@@ -124,7 +124,17 @@ class Api(object):
             }
         
         desired_format = determine_format(request, serializer)
-        serialized = serializer.serialize(available_resources, desired_format)
+
+        options = {}
+        if 'text/javascript' in desired_format:
+            callback = request.GET.get('callback', 'callback')
+            if not is_valid_jsonp_callback_value(callback):
+                raise BadRequest('JSONP callback name is invalid.')
+            
+            options['callback'] = callback
+
+
+        serialized = serializer.serialize(available_resources, desired_format, options)
         return HttpResponse(content=serialized, content_type=build_content_type(desired_format))
     
     def _build_reverse_url(self, name, args=None, kwargs=None):

--- a/tests/core/tests/api.py
+++ b/tests/core/tests/api.py
@@ -128,3 +128,17 @@ class ApiTestCase(TestCase):
         resp = api.top_level(request)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content, '{"notes": {"list_endpoint": "/api/v1/notes/", "schema": "/api/v1/notes/schema/"}, "users": {"list_endpoint": "/api/v1/users/", "schema": "/api/v1/users/schema/"}}')
+
+    def test_top_level_jsonp(self):
+        api = Api()
+        api.register(NoteResource())
+        api.register(UserResource())
+        request = HttpRequest()
+        request.META = {'HTTP_ACCEPT': 'text/javascript'}
+        request.GET = {'callback': 'foo'}
+        
+        resp = api.top_level(request)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp['content-type'].split(';')[0], 'text/javascript')
+        self.assertEqual(resp.content, 'foo({"notes": {"list_endpoint": "/api/v1/notes/", "schema": "/api/v1/notes/schema/"}, "users": {"list_endpoint": "/api/v1/users/", "schema": "/api/v1/users/schema/"}})')
+


### PR DESCRIPTION
When trying to access the `top_level` view of the `Api` class using JSONP, I got a 500. It came from a `KeyError` on the in the `Serializer.serialize` method. 

This patch translates the JSONP callback code from the `Resource.serialize` method to this view, and adds a test. 
