### PR TITLE
This patch adds support for using object permission authentication backends

### DIFF
--- a/tastypie/authorization.py
+++ b/tastypie/authorization.py
@@ -74,4 +74,4 @@ class DjangoAuthorization(Authorization):
         if not hasattr(request, 'user'):
             return False
 
-        return request.user.has_perm(permission_code)
+        return request.user.has_perm(permission_code, object)

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -353,7 +353,15 @@ class Resource(object):
             raise ImmediateHttpResponse(response=HttpNotImplemented())
         
         self.is_authenticated(request)
-        self.is_authorized(request)
+        if request_type == 'detail':
+            try:
+                lookup_keys = self.remove_api_resource_names(kwargs)
+                instance = self._meta.object_class.objects.get(**lookup_keys)
+            except ObjectDoesNotExist:
+                instance = None
+            self.is_authorized(request, object=instance)
+        else:
+            self.is_authorized(request)
         self.throttle_check(request)
         
         # All clear. Process the request.

--- a/tests/core/tests/__init__.py
+++ b/tests/core/tests/__init__.py
@@ -4,6 +4,7 @@ warnings.simplefilter('ignore', Warning)
 from core.tests.api import *
 from core.tests.authentication import *
 from core.tests.authorization import *
+from core.tests.objectperms import *
 from core.tests.cache import *
 from core.tests.commands import *
 from core.tests.fields import *

--- a/tests/core/tests/objectperms.py
+++ b/tests/core/tests/objectperms.py
@@ -1,0 +1,63 @@
+from django.conf import settings
+from django.test import TestCase
+from django.http import HttpRequest
+from django.contrib.auth.models import User
+from tastypie.api import Api
+from django.contrib.auth.backends import ModelBackend
+from core.models import Note
+from tastypie.authorization import DjangoAuthorization
+from tastypie.resources import ModelResource
+
+
+class NoteAuthorBackend(ModelBackend):
+    """
+    NoteAuthorBackend is a Django authentication backend that answers True on
+    all has_perm requests on Notes of which the user is the author.
+    """
+    supports_object_permissions = True
+    supports_anonymous_user = False
+    supports_anonymous_user_inactive_user = False
+
+    def has_perm(self, user_obj, perm, obj=None):
+        # Only check extra permissions for specific note instances
+        if (obj is None or not isinstance(obj, Note)):
+            return False
+
+        # Finally, give add/modify/delete permissions to the author of the
+        # article
+        return obj.author == user_obj
+
+
+class DjangoNoteResource(ModelResource):
+    class Meta:
+        resource_name = 'notes'
+        queryset = Note.objects.filter(is_active=True)
+        authorization = DjangoAuthorization()
+
+
+class ObjectPermissionTestCase(TestCase):
+    fixtures = ['note_testdata']
+
+    def setUp(self):
+        settings.AUTHENTICATION_BACKENDS = ('core.tests.NoteAuthorBackend',)
+        api = Api()
+        api.register(DjangoNoteResource())
+
+    def test_delete_allowed_for_own_notes(self):
+        request = HttpRequest()
+        request.user = User.objects.get(username='johndoe')
+        note1 = Note.objects.get(pk=1)
+        note2 = Note.objects.get(pk=2)
+        for method in ('GET', 'POST', 'PUT', 'DELETE'):
+            request.method = method
+            self.assertTrue(DjangoNoteResource()._meta.authorization.is_authorized(request, note1))
+            self.assertTrue(DjangoNoteResource()._meta.authorization.is_authorized(request, note2))
+
+    def test_delete_denied_for_others_notes(self):
+        request = HttpRequest()
+        request.user = User.objects.get(username='johndoe')
+        note3 = Note.objects.get(pk=3)  # Jane's note
+        for method in ('POST', 'PUT', 'DELETE'):  # 'GET' is free for anyone
+            request.method = method
+            self.assertFalse(DjangoNoteResource()._meta.authorization.is_authorized(request, note3))
+


### PR DESCRIPTION
With this patch, the dispatch method will use the `kwargs` dict to lookup the target object for `detail` request types, and pass the object to the `is_authorized()` method (if found). This makes it possible for object-permissions enabled backends to apply detailed authorization logic to allow/deny the request.

I've included a testcase that should be illustrative for the patch. It declares a custom `NoteAuthorBackend` that answers `True` to all `has_perm()` calls for users on specific `Note` instances. This means John Doe may only change/delete his own notes and not Jane's.
