### PR TITLE
ModelResource: obj_get_list BadRequest instead of NotFound

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1418,7 +1418,7 @@ class ModelResource(Resource):
         try:
             return self.get_object_list(request).filter(**applicable_filters)
         except ValueError, e:
-            raise NotFound("Invalid resource lookup data provided (mismatched type).")
+            raise BadRequest("Invalid resource lookup data provided (mismatched type).")
     
     def obj_get(self, request=None, **kwargs):
         """


### PR DESCRIPTION
This changes the HTTP response from 404 to 400 when a ValueError is raised while retrieving a resource list.
