### PR TITLE
Handling request values with multiple values per key

### DIFF
--- a/tastypie/paginator.py
+++ b/tastypie/paginator.py
@@ -138,9 +138,16 @@ class Paginator(object):
         
         request_params = self.request_data.copy()
         request_params.update({'limit': limit, 'offset': offset})
+
+        try:
+            # QueryDict has a urlencode method that can handle multiple values for the same key
+            encoded_params = request_params.urlencode()
+        except AttributeError:
+            encoded_params = urlencode(request_params)
+
         return '%s?%s' % (
             self.resource_uri,
-            urlencode(request_params)
+            encoded_params
         )
 
     def page(self):

--- a/tests/core/tests/paginator.py
+++ b/tests/core/tests/paginator.py
@@ -5,6 +5,7 @@ from tastypie.paginator import Paginator
 from core.models import Note
 from core.tests.resources import NoteResource
 from django.db import reset_queries
+from django.http import QueryDict
 
 
 class PaginatorTestCase(TestCase):
@@ -142,3 +143,12 @@ class PaginatorTestCase(TestCase):
         # differently.
         page = paginator.page()
         self.assertEqual(page['objects'], ['foo', 'bar'])
+
+    def test_multiple(self):
+        request = QueryDict('a=1&a=2')
+        paginator = Paginator(request, self.data_set, resource_uri='/api/v1/notes/', limit=2, offset=2)
+        meta = paginator.page()['meta']
+        self.assertEqual(meta['limit'], 2)
+        self.assertEqual(meta['offset'], 2)
+        self.assertEqual(meta['previous'], '/api/v1/notes/?a=1&a=2&limit=2&offset=0')
+        self.assertEqual(meta['next'], '/api/v1/notes/?a=1&a=2&limit=2&offset=4')


### PR DESCRIPTION
I discovered that the next and previous URI's don't get generated properly when you have multiple values per key.  

For example: `/api/v1/myresource?a=1&a=2`

`a` retains only the value `2`, not the list `[1, 2]` as is the case elsewhere in Django.
