### PR TITLE
Null updates

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -614,7 +614,7 @@ class Resource(object):
             if field_object.attribute:
                 value = field_object.hydrate(bundle)
                 
-                if value is not None:
+                if value is not None or field_object.null:
                     # We need to avoid populating M2M data here as that will
                     # cause things to blow up.
                     if not getattr(field_object, 'is_related', False):

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -93,6 +93,14 @@ class NoUriBasicResource(BasicResource):
         include_resource_uri = False
 
 
+class NullableNameResource(Resource):
+    name = fields.CharField(attribute='name', null=True)
+
+    class Meta:
+        object_class = TestObject
+        resource_name = 'nullable_name'
+
+
 class ResourceTestCase(TestCase):
     def test_fields(self):
         basic = BasicResource()
@@ -257,6 +265,33 @@ class ResourceTestCase(TestCase):
         self.assertEqual(hydrated.obj.view_count, 6)
         self.assertEqual(hydrated.obj.date_joined, datetime.datetime(2010, 2, 15, 12, 0, 0))
         self.assertEqual(hydrated.obj.bar, 'O HAI BAR!')
+
+
+        # Test that a nullable value with a previous non-null value
+        # can be set to None
+        
+        nullable = NullableNameResource()
+
+        obj = nullable._meta.object_class()
+        obj.name = "Daniel"
+
+        null_bundle = Bundle(obj=obj, data={'name': None})
+        hydrated = nullable.full_hydrate(null_bundle)
+
+        self.assertTrue(hydrated.obj.name is None)
+
+    
+        # Test that a nullable value with a previous non-null value
+        # is not overridden if no value was given
+
+        obj = nullable._meta.object_class()
+        obj.name = "Daniel"
+
+        empty_null_bundle = Bundle(obj=obj, data={})
+        hydrated = nullable.full_hydrate(empty_null_bundle)
+
+        self.assertEquals(hydrated.obj.name, "Daniel")
+    
     
     def test_obj_get_list(self):
         basic = BasicResource()
@@ -1945,4 +1980,3 @@ class BustedResourceTestCase(TestCase):
         self.assertEqual(resp.content, '{"error_message": "Oops, you bwoke it."}')
         self.assertEqual(len(mail.outbox), 3)
         mail.outbox = []
-    


### PR DESCRIPTION
This is a fix for toastdriven/django-tastypie#73

It allows for `Resource.full_hydrate` to update an object with an attribute with a non-`None` value to `None`. If the field is absent from `bundle.data`, however, it will not alter the current value. 
