### PR TITLE
fixed ToManyField to properly handle django orm specific behaviour

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -138,6 +138,11 @@ Covers both ``models.FileField`` and ``models.ImageField``.
 
 A floating point field.
 
+``DecimalField``
+----------------
+
+A decimal data field.
+
 ``IntegerField``
 ----------------
 

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -1,5 +1,6 @@
 from dateutil.parser import parse
 import re
+import decimal
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.db.models.manager import Manager
 from django.utils import datetime_safe, importlib
@@ -230,6 +231,23 @@ class FloatField(ApiField):
             return None
         
         return float(value)
+
+
+class DecimalField(ApiField):
+    """
+    A decimal field.
+    """
+    dehydrated_type = 'decimal'
+    help_text = 'Decimal data. Ex: 26.73'
+
+    def dehydrate(self, obj):
+        return self.convert(super(DecimalField, self).dehydrate(obj))
+
+    def convert(self, value):
+        if value is None:
+            return None
+
+        return decimal.Decimal(value)
 
 
 class BooleanField(ApiField):

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1191,8 +1191,10 @@ class ModelResource(Resource):
             result = DateTimeField
         elif f.get_internal_type() in ('BooleanField', 'NullBooleanField'):
             result = BooleanField
-        elif f.get_internal_type() in ('DecimalField', 'FloatField'):
+        elif f.get_internal_type() == 'FloatField':
             result = FloatField
+        elif f.get_internal_type() == 'DecimalField':
+            result = DecimalField
         elif f.get_internal_type() in ('IntegerField', 'PositiveIntegerField', 'PositiveSmallIntegerField', 'SmallIntegerField'):
             result = IntegerField
         elif f.get_internal_type() in ('FileField', 'ImageField'):

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -1,4 +1,5 @@
 import datetime
+from decimal import Decimal
 from dateutil.tz import *
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -235,6 +236,32 @@ class FloatFieldTestCase(TestCase):
         
         field_2 = IntegerField(default=18.5)
         self.assertEqual(field_2.dehydrate(bundle), 18)
+
+
+class DecimalFieldTestCase(TestCase):
+    fixtures = ['note_testdata.json']
+
+    def test_init(self):
+        field_1 = DecimalField()
+        self.assertEqual(field_1.help_text, 'Decimal data. Ex: 26.73')
+
+        field_2 = DecimalField(help_text="Custom.")
+        self.assertEqual(field_2.help_text, 'Custom.')
+
+    def test_dehydrated_type(self):
+        field_1 = DecimalField()
+        self.assertEqual(field_1.dehydrated_type, 'decimal')
+
+    def test_dehydrate(self):
+        note = Note.objects.get(pk=1)
+        bundle = Bundle(obj=note)
+
+        field_1 = DecimalField(default=Decimal("20"))
+        self.assertEqual(field_1.dehydrate(bundle), Decimal("20.0"))
+
+        field_2 = IntegerField(default=Decimal("18.5"))
+        self.assertEqual(field_2.dehydrate(bundle), 18)
+
 
 
 class BooleanFieldTestCase(TestCase):


### PR DESCRIPTION
Tastypie did not handle the retrieving of the default manager object very well, for example ToManyField failed on http://paste.pocoo.org/show/2uE8p0nlWaCD7dTvo2tw/

This commit fixes it.
