### PR TITLE
Untitled

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -548,7 +548,9 @@ class ToOneField(RelatedField):
     
     def hydrate(self, bundle):
         if bundle.data.get(self.instance_name) is None:
-            if self.null:
+            if self.instance_name and hasattr(bundle.obj, self.instance_name):
+                return getattr(bundle.obj, self.instance_name)
+            elif self.null:
                 return None
             else:
                 raise ApiFieldError("The '%s' field has no data and doesn't allow a null value." % self.instance_name)

--- a/tests/related_resource/tests.py
+++ b/tests/related_resource/tests.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from django.test import TestCase
+from core.models import Note
 from core.tests.mocks import MockRequest
 from related_resource.api.resources import NoteResource, UserResource
 from related_resource.api.urls import api
@@ -32,3 +33,14 @@ class RelatedResourceTest(TestCase):
         resp = resource.post_list(request)
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(User.objects.get(id=self.user.id).username, self.user.username)
+
+    def test_related_resource_partial_update(self):
+        note = Note.objects.create(author=self.user, content="Note Content", title="Note Title", slug="note-title")
+        resource = api.canonical_resource_for('notes')
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'PUT'
+        request.raw_post_data = '{"content": "The note has been changed"}'
+        resp = resource.put_detail(request, pk=note.pk)
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(Note.objects.get(id=note.id).content, "The note has been changed")


### PR DESCRIPTION
I've written a small patch to allow obj_update from put_detail to update resources containing ToOne fields.

Without this, a PUT request that does not contain explicit values for all ToOne fields will fail with an ApiFieldError raised in ToOneField.hydrate. This patch allows the hydrated object to take the FK value from the existing resource, like ApiField.hydrate does for other field types.

(Test case included :) )
