### PR TITLE
django-tastypie installation is fixed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=1.0.0
 mimeparse>=0.1.3
-python-dateutil
+python-dateutil==1.5
 lxml
 PyYAML

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,11 @@ setup(
     },
     requires=[
         'mimeparse',
-        'python_dateutil',
+        'python_dateutil(>=1.5, < 2.0)',
     ],
     install_requires=[
         'mimeparse',
-        'python_dateutil',
+        'python_dateutil >= 1.5, < 2.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
python_dateutil 2.0 was released some time ago and it is python3 - only. This leads to weirdest errors I've ever seen.

https://bugs.launchpad.net/dateutil/+bug/746550
