### PR TITLE
Delete Content-Type header from HttpAccepted (204 No Content) responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django>=1.0.0
 mimeparse>=0.1.3
-python-dateutil
+python-dateutil==1.5
 lxml
 PyYAML

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,11 @@ setup(
     },
     requires=[
         'mimeparse',
-        'python_dateutil',
+        'python_dateutil(>=1.5, < 2.0)',
     ],
     install_requires=[
         'mimeparse',
-        'python_dateutil',
+        'python_dateutil >= 1.5, < 2.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tastypie/http.py
+++ b/tastypie/http.py
@@ -6,18 +6,22 @@ from django.http import HttpResponse
 
 class HttpCreated(HttpResponse):
     status_code = 201
-    
+
     def __init__(self, *args, **kwargs):
         if 'location' in kwargs:
             location = kwargs['location']
             del(kwargs['location'])
-        
+
         super(HttpCreated, self).__init__(*args, **kwargs)
         self['Location'] = location
 
 
 class HttpAccepted(HttpResponse):
     status_code = 204
+
+    def __init__(self, *args, **kwargs):
+        super(HttpAccepted, self).__init__(*args, **kwargs)
+        del self['Content-Type']
 
 
 class HttpMultipleChoices(HttpResponse):


### PR DESCRIPTION
This header can be returned with HttpAccepted according to rfc2616, but it is useless (so removing it will slightly decrease bandwidth usage) and lint tools can complain about this header (e.g. Ian Bicking's wsgi lint middleware included in WebTest raises AssertionError for 204 responses with Content-Type header).