### PR TITLE
Patch to allow "initial data" on created objects

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -26,19 +26,21 @@ Adding initial data when creating objects
 
 When using Django ModelForms you can provide_ initial data to populate model
 fields which were not specified on the form. To achieve this behaviour with
-Tastypie you can specify an initial_data method in your ModelResource's
-Meta class. This method should return a dict, which will be passed as kwargs
-when instantiating the model.
+Tastypie you can override the :meth:`~tastypie.initial.InitialData.get_data`
+method. This method returns a dictionary containing field names and values 
+which will be used when creating new objects via this resource. 
 
 For example, to automatically set the "created_by" field on your model to the
-currently logged in user, you would do::
+currently logged in user::
 
-    def get_initial_data(bundle, request):
-        return {"created_by": request.user}
+    from tastypie.initial import InitialData
+    class SetUserInitialData(InitialData):
+        def get_data(request):
+            return {"created_by": request.user}
 
-    class MyModelResource(ModelResource):
-        class Meta:
-            initial_data = get_initial_data
+        class MyModelResource(ModelResource):
+            class Meta:
+                initial_data = SetUserInitialData()
 
 .. _provide: http://docs.djangoproject.com/en/dev/ref/forms/api/#django.forms.Form.initial
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -14,6 +14,7 @@ from tastypie.constants import ALL, ALL_WITH_RELATIONS
 from tastypie.exceptions import NotFound, BadRequest, InvalidFilterError, HydrationError, InvalidSortError, ImmediateHttpResponse
 from tastypie.fields import *
 from tastypie.http import *
+from tastypie.initial import InitialData
 from tastypie.paginator import Paginator
 from tastypie.serializers import Serializer
 from tastypie.throttle import BaseThrottle
@@ -49,6 +50,7 @@ class ResourceOptions(object):
     throttle = BaseThrottle()
     validation = Validation()
     paginator_class = Paginator
+    initial_data = InitialData()
     allowed_methods = ['get', 'post', 'put', 'delete']
     list_allowed_methods = None
     detail_allowed_methods = None
@@ -65,7 +67,6 @@ class ResourceOptions(object):
     excludes = []
     include_resource_uri = True
     include_absolute_url = False
-    initial_data = None
     
     def __new__(cls, meta=None):
         overrides = {}
@@ -1470,15 +1471,8 @@ class ModelResource(Resource):
         A ORM-specific implementation of ``obj_create``.
         """
 
-        if self._meta.initial_data:
-            if callable(self._meta.initial_data):
-                initial_data = self._meta.initial_data.im_func(bundle, request)
-            else:
-                initial_data = self._meta.initial_data
-        else:
-            initial_data = {}
-
-        bundle.obj = self._meta.object_class(**initial_data)
+        initial_data = self._meta.initial_data.get_data(request)
+        bundle.obj = self._meta.object_class(kwargs=initial_data)
         
         for key, value in kwargs.items():
             setattr(bundle.obj, key, value)

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -14,6 +14,7 @@ from tastypie.authentication import BasicAuthentication
 from tastypie.authorization import Authorization
 from tastypie.bundle import Bundle
 from tastypie.exceptions import InvalidFilterError, InvalidSortError, ImmediateHttpResponse, BadRequest, NotFound
+from tastypie.initial import InitialData
 from tastypie import fields
 from tastypie.paginator import Paginator
 from tastypie.resources import Resource, ModelResource, ALL, ALL_WITH_RELATIONS
@@ -533,14 +534,15 @@ class CustomPageNoteResource(NoteResource):
         paginator_class = CustomPaginator
         queryset = Note.objects.all()
 
-def get_initial_data(bundle, request):
-    from datetime import datetime
-    return {"title": "The Cat Is Back",
-            "created": datetime(2010, 04, 03, 20, 05)}
+class TestInitialData(InitialData):
+    def get_data(self, request, **kwargs):
+        from datetime import datetime
+        return {"title": "The Cat Is Back",
+                "created": datetime(2010, 04, 03, 20, 05)}
 
 class WithInitialDataNoteResource(NoteResource):
     class Meta:
-        initial_data = get_initial_data
+        initial_data = TestInitialData()
         resource_name = "notialdata"
         queryset = Note.objects.all()
 


### PR DESCRIPTION
Hi,

I needed to specify some initial data on the objects created by Tastypie, specifically to automatically set the "created_by" field to request.user. I could not find a clean way to do this so I wrote this patch. It lets you specify a dict or callable which is used when the object is instantiated in obj_create.

A basic example and test are included.
