### PR TITLE
Return HTTP 400 Bad Request for invalid filters

### DIFF
--- a/tastypie/exceptions.py
+++ b/tastypie/exceptions.py
@@ -53,7 +53,7 @@ class BlueberryFillingFound(TastypieError):
     pass
 
 
-class InvalidFilterError(TastypieError):
+class InvalidFilterError(BadRequest):
     """
     Raised when the end user attempts to use a filter that has not be
     explicitly allowed.


### PR DESCRIPTION
This simply change's InvalidFilter's parent to BadRequest so clients get an HTTP 400 response. The one further addition which might be useful would be extending wrap_view to get the negotiated response type which _handle_500 performs (e.g. return `{'error': "Field foo does not allow filtering"}' for JSON requests rather than text/html for everything) but that's probably a more general task as it'd make sense for e.g. ValidationError as well.
