### PR TITLE
Fixes a bug in ApiField.hydrate

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -139,6 +139,8 @@ class ApiField(object):
         if not bundle.data.has_key(self.instance_name):
             if self.attribute and hasattr(bundle.obj, self.attribute):
                 return getattr(bundle.obj, self.attribute)
+            if not self.attribute and self.instance_name and hasattr(bundle.obj, self.instance_name):
+                return getattr(bundle.obj, self.instance_name)
             elif self.has_default():
                 if callable(self._default):
                     return self._default()

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -125,6 +125,11 @@ class ApiFieldTestCase(TestCase):
         field_7.instance_name = 'notinbundle'
         self.assertEqual(field_7.hydrate(bundle), u'First Post!')
 
+        # Make sure it falls back to instance name if there is no attribute
+        field_8 = ApiField()
+        field_8.instance_name = 'title'
+        self.assertEqual(field_7.hydrate(bundle), u'First Post!')
+
 
 class CharFieldTestCase(TestCase):
     fixtures = ['note_testdata.json']


### PR DESCRIPTION
It was attempting to get the instance_name on the bundle.obj rather then the attribute.
I changed it so it first attempts to get the attribute and only uses instance name if the field doesn't have an attribute

I'm not sure if this is the correct behaviour so check out the logic
