### PR TITLE
Error logging

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -240,7 +240,8 @@ class Resource(object):
             else:
                 import logging
                 logger = logging.getLogger('tastypie')
-                logger.exception('Internal Server Error: %s' % request.path,
+                logger.error('Internal Server Error: %s' % request.path,
+                    exc_info=sys.exc_info(),
                     extra={'status_code': 500, 'request':request})
         
         # Prep the data going out.


### PR DESCRIPTION
Use python logging instead of the default sending emails to admin, except if SEND_BROKEN_LINK_EMAILS is True.
