### PR TITLE
Unicode problems in _generate_uri

### DIFF
--- a/tastypie/paginator.py
+++ b/tastypie/paginator.py
@@ -136,7 +136,7 @@ class Paginator(object):
         if self.resource_uri is None:
             return None
         
-        request_params = self.request_data.copy()
+        request_params = dict([k, v.encode('utf-8')] for k, v in self.request_data.items())
         request_params.update({'limit': limit, 'offset': offset})
         return '%s?%s' % (
             self.resource_uri,


### PR DESCRIPTION
When trying to use api with unicode (non ASCII) data in filters, a `UnicodeDecodeError` is raised.
This pull request is related to issue #77.
