### PR TITLE
Doc fixes

### DIFF
--- a/docs/authentication_authorization.rst
+++ b/docs/authentication_authorization.rst
@@ -68,8 +68,8 @@ As an alternative to requiring sensitive data like a password, the
 machine-generated api key. Tastypie ships with a special ``Model`` just for
 this purpose, so you'll need to ensure ``tastypie`` is in ``INSTALLED_APPS``.
 
-Tastypie includes a signal function you can use to auto-create ``ApiKey``s.
-Hooking it up looks like::
+Tastypie includes a signal function you can use to auto-create ``ApiKey``
+objects. Hooking it up looks like::
 
     from django.contrib.auth.models import User
     from django.db import models
@@ -78,7 +78,7 @@ Hooking it up looks like::
     models.signals.post_save.connect(create_api_key, sender=User)
 
 ``DigestAuthentication``
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This authentication scheme uses HTTP Digest Auth to check a user's
 credentials.  The username is their ``django.contrib.auth.models.User``


### PR DESCRIPTION
Two warnings that were spat out as I rebuilt the documentation just now. The underline one is obvious. The "`ApiKeys`s" one is due to an issue in docutils or Sphinx (I think the former). It wants the literal end marker to be followed by a whitespace, so the trailing 's' confuses things. Using slightly more verbose English routes around the difficulty.
