### PR TITLE
Added TestCase showing error introduced by commit 1988c7

### DIFF
--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -3,7 +3,7 @@ from tastypie import fields
 from tastypie.resources import ModelResource
 from tastypie.authorization import Authorization
 from core.models import Note
-from related_resource.models import Category
+from related_resource.models import Category, Tag, ExtraData, Taggable, TaggableTag
 
 
 class UserResource(ModelResource):
@@ -15,7 +15,7 @@ class UserResource(ModelResource):
 
 class NoteResource(ModelResource):
     author = fields.ForeignKey(UserResource, 'author')
-    
+
     class Meta:
         resource_name = 'notes'
         queryset = Note.objects.all()
@@ -24,9 +24,60 @@ class NoteResource(ModelResource):
 
 class CategoryResource(ModelResource):
     parent = fields.ToOneField('self', 'parent', null=True)
-    
+
     class Meta:
         resource_name = 'category'
         queryset = Category.objects.all()
+        authorization = Authorization()
+
+
+class TagResource(ModelResource):
+    taggabletags = fields.ToManyField(
+            'related_resource.api.resources.TaggableTagResource', 'taggabletags',
+            null=True)
+
+    extradata = fields.ToOneField(
+            'related_resource.api.resources.ExtraDataResource', 'extradata',
+            null=True, full=True)
+
+    class Meta:
+        resource_name = 'tag'
+        queryset = Tag.objects.all()
+        authorization = Authorization()
+
+
+class TaggableResource(ModelResource):
+    taggabletags = fields.ToManyField(
+            'related_resource.api.resources.TaggableTagResource', 'taggabletags',
+            null=True)
+
+    class Meta:
+        resource_name = 'taggable'
+        queryset = Taggable.objects.all()
+        authorization = Authorization()
+
+
+class TaggableTagResource(ModelResource):
+    tag = fields.ToOneField(
+            'related_resource.api.resources.TagResource', 'tag',
+            null=True)
+    taggable = fields.ToOneField(
+            'related_resource.api.resources.TaggableResource', 'taggable',
+            null=True)
+
+    class Meta:
+        resource_name = 'taggabletag'
+        queryset = TaggableTag.objects.all()
+        authorization = Authorization()
+
+
+class ExtraDataResource(ModelResource):
+    tag = fields.ToOneField(
+            'related_resource.api.resources.TagResource', 'tag',
+            null=True)
+
+    class Meta:
+        resource_name = 'extradata'
+        queryset = ExtraData.objects.all()
         authorization = Authorization()
 

--- a/tests/related_resource/api/urls.py
+++ b/tests/related_resource/api/urls.py
@@ -1,10 +1,16 @@
 from django.conf.urls.defaults import *
 from tastypie.api import Api
-from related_resource.api.resources import NoteResource, UserResource, CategoryResource
+from related_resource.api.resources import NoteResource, UserResource, \
+        CategoryResource, TagResource, TaggableTagResource, TaggableResource, \
+        ExtraDataResource
 
 api = Api(api_name='v1')
 api.register(NoteResource(), canonical=True)
 api.register(UserResource(), canonical=True)
 api.register(CategoryResource(), canonical=True)
+api.register(TagResource(), canonical=True)
+api.register(TaggableResource(), canonical=True)
+api.register(TaggableTagResource(), canonical=True)
+api.register(ExtraDataResource(), canonical=True)
 
 urlpatterns = api.urls

--- a/tests/related_resource/models.py
+++ b/tests/related_resource/models.py
@@ -9,3 +9,49 @@ class Category(models.Model):
     def __unicode__(self):
         return u"%s (%s)" % (self.name, self.parent)
 
+
+# A taggable model. Just that.
+class Taggable(models.Model):
+    name = models.CharField(max_length=32)
+
+
+# Explicit intermediary 'through' table
+class TaggableTag(models.Model):
+    tag = models.ForeignKey(
+            'Tag',
+            related_name='taggabletags',
+            null=True, blank=True, # needed at creation time
+        )
+    taggable = models.ForeignKey(
+            'Taggable',
+            related_name='taggabletags',
+            null=True, blank=True, # needed at creation time
+    )
+
+
+# Tags to Taggable model through explicit M2M table
+class Tag(models.Model):
+    name = models.CharField(max_length=32)
+    tagged = models.ManyToManyField(
+        'Taggable',
+        through='TaggableTag',
+        related_name='tags',
+    )
+
+    def __unicode__(self):
+        return u"%s" % (self.name)
+
+
+# A model that contains additional data for Tag
+class ExtraData(models.Model):
+    name = models.CharField(max_length=32)
+    tag = models.OneToOneField(
+        'Tag',
+        related_name='extradata',
+        null=True, blank=True,
+    )
+
+    def __unicode__(self):
+        return u"%s" % (self.name)
+
+

--- a/tests/related_resource/tests.py
+++ b/tests/related_resource/tests.py
@@ -2,17 +2,21 @@ import json
 from django.contrib.auth.models import User
 from django.test import TestCase
 from core.tests.mocks import MockRequest
-from related_resource.api.resources import NoteResource, UserResource, CategoryResource
+from django.conf import settings
+from related_resource.api.resources import UserResource, \
+        CategoryResource, TagResource, TaggableResource, TaggableTagResource, \
+        ExtraDataResource
 from related_resource.api.urls import api
-from related_resource.models import Category
+from related_resource.models import Category, Tag, Taggable, TaggableTag, ExtraData
 
+settings.DEBUG = True
 
 class RelatedResourceTest(TestCase):
     urls = 'related_resource.api.urls'
-    
+
     def setUp(self):
         self.user = User.objects.create(username="testy_mctesterson")
-    
+
     def test_cannot_access_user_resource(self):
         resource = api.canonical_resource_for('users')
         request = MockRequest()
@@ -20,17 +24,17 @@ class RelatedResourceTest(TestCase):
         request.method = 'PUT'
         request.raw_post_data = '{"username": "foobar"}'
         resp = resource.wrap_view('dispatch_detail')(request, pk=self.user.pk)
-        
+
         self.assertEqual(resp.status_code, 405)
         self.assertEqual(User.objects.get(id=self.user.id).username, self.user.username)
-    
+
     def test_related_resource_authorization(self):
         resource = api.canonical_resource_for('notes')
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'POST'
         request.raw_post_data = '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00", "author": {"id": %s, "username": "foobar"}}' % self.user.id
-        
+
         resp = resource.post_list(request)
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(User.objects.get(id=self.user.id).username, self.user.username)
@@ -38,47 +42,114 @@ class RelatedResourceTest(TestCase):
 
 class CategoryResourceTest(TestCase):
     urls = 'related_resource.api.urls'
-    
+
     def setUp(self):
         super(CategoryResourceTest, self).setUp()
         self.parent_cat_1 = Category.objects.create(parent=None, name='Dad')
         self.parent_cat_2 = Category.objects.create(parent=None, name='Mom')
         self.child_cat_1 = Category.objects.create(parent=self.parent_cat_1, name='Son')
         self.child_cat_2 = Category.objects.create(parent=self.parent_cat_2, name='Daughter')
-    
+
     def test_correct_relation(self):
         resource = api.canonical_resource_for('category')
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'GET'
         resp = resource.wrap_view('dispatch_detail')(request, pk=self.parent_cat_1.pk)
-        
+
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.content)
         self.assertEqual(data['parent'], None)
         self.assertEqual(data['name'], 'Dad')
-        
+
         # Now try a child.
         resp = resource.wrap_view('dispatch_detail')(request, pk=self.child_cat_2.pk)
-        
+
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.content)
         self.assertEqual(data['parent'], '/v1/category/2/')
         self.assertEqual(data['name'], 'Daughter')
-    
+
     def test_put_null(self):
         resource = api.canonical_resource_for('category')
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
         request.raw_post_data = '{"parent": null, "name": "Son"}'
-        
+
         # Before the PUT, there should be a parent.
         self.assertEqual(Category.objects.get(pk=self.child_cat_1.pk).parent.pk, self.parent_cat_1.pk)
-        
+
         # After the PUT, the parent should be ``None``.
         resp = resource.put_detail(request, pk=self.child_cat_1.pk)
         self.assertEqual(resp.status_code, 204)
         self.assertEqual(Category.objects.get(pk=self.child_cat_1.pk).name, 'Son')
         self.assertEqual(Category.objects.get(pk=self.child_cat_1.pk).parent, None)
 
+
+class ExplicitM2MResourceRegressionTest(TestCase):
+    urls = 'related_resource.api.urls'
+
+    def setUp(self):
+        super(ExplicitM2MResourceRegressionTest, self).setUp()
+        self.tag_1 = Tag.objects.create(name='important')
+        self.taggable_1 = Taggable.objects.create(name='exam')
+
+        # Create relations between tags and taggables through the explicit m2m table
+        self.taggabletag_1 = TaggableTag.objects.create(tag=self.tag_1, taggable=self.taggable_1)
+
+        # Give each tag some extra data (the lookup of this data is what makes the test fail)
+        self.extradata_1 = ExtraData.objects.create(tag=self.tag_1, name='additional')
+
+
+    def test_correct_setup(self):
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'GET'
+
+        # Verify the explicit 'through' relationships has been created correctly
+        resource = api.canonical_resource_for('taggabletag')
+        resp = resource.wrap_view('dispatch_detail')(request, pk=self.taggabletag_1.pk)
+        data = json.loads(resp.content)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(data['tag'], '/v1/tag/1/')
+        self.assertEqual(data['taggable'], '/v1/taggable/1/')
+
+        resource = api.canonical_resource_for('taggable')
+        resp = resource.wrap_view('dispatch_detail')(request, pk=self.taggable_1.pk)
+        data = json.loads(resp.content)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(data['name'], 'exam')
+
+        resource = api.canonical_resource_for('tag')
+        resp = resource.wrap_view('dispatch_detail')(request, pk=self.tag_1.pk)
+        data = json.loads(resp.content)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(data['name'], 'important')
+
+        # and check whether the extradata is present
+        self.assertEqual(data['extradata']['name'], u'additional')
+
+
+    def test_post_new_tag(self):
+        resource = api.canonical_resource_for('tag')
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'POST'
+        request.raw_post_data = '{"name": "school", "taggabletags": [ ]}'
+
+        # The following POST fails since commit 1988c7, and OKs in earlier commits.
+        # Simple remedy is reverse the changes from that post (2 lines), but the
+        # trouble is that I don't know what other bugs that commit fixes
+        resp = resource.wrap_view('dispatch_list')(request)
+        self.assertEqual(resp.status_code, 201)
+
+        # GET the created object (through its headers.location)
+        self.assertTrue(resp.has_header('location'))
+        location = dict(resp.items())['Location']  # other way to get headers?
+
+        resp = self.client.get(location, data={'format': 'json'})
+        self.assertEqual(resp.status_code, 200)
+        deserialized = json.loads(resp.content)
+        self.assertEqual(len(deserialized), 5)
+        self.assertEqual(deserialized['name'], 'school')


### PR DESCRIPTION
Commit 1988c7 introduced an error in our real-world case (backbone.js extended with our backbone-relational.js frontend) that wasn't there before.

Since I'm not sure what errors commit 1988c7 fixes and I'm not a savvy programmer, maybe you can have a look at it. I've added the test to tests/related_resource/tests.py (and update models, resources and urls accordingly).

UPDATE: it's correlated with the 'nullable ToOne' fix in commit 2a6c0 that adds an elif to full_hydrate: if you remove the first additional IF statement added in line 141 in fields.py in commit 1988c7: the nullable ToOne fix breaks. I'd like to contribute a fix but can't seem to wrap my mind around it: any help greatly appreciated.

Running related_resource.tests.ExplicitM2MResourceRegressionTest on commit 606a or earlier passes, on 1988c7 up fails (404 or 500).

(I know this is probably a too extensive testcase, but I'm trying to stay close to our API calls)
## Environment:
-  Taggable objects can be Tag'ged through the explicit M2M TaggableTag relationship (that has intentionally nullable fields for our non-normalized case that contains more Taggable types)
-  Tag objects can have additional data ExtraData (ToOne)
## Setup:
-  Create a Taggable, tagged with Tag through TaggableTag and with additional ExtraData
  (probably not even required, but I use it for other tests)
## Test:
-  Create an additional Tag through a POST -> kaboom (404/500) after 1988c7 on ExtraData, that shouldn't be involved at all.
