### PR TITLE
Use setuptools in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='django-tastypie',


### PR DESCRIPTION
This one-line change prevents an ``install_requires`` warning when running ``python setup.py install`` and adds support for running ``python setup.py develop``.