### PR TITLE
Fix for issue #159

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -606,7 +606,7 @@ class Resource(object):
         """
         prefix = get_script_prefix()
         chomped_uri = uri
-        if chomped_uri.startswith(prefix):
+        if prefix and chomped_uri.startswith(prefix):
             chomped_uri = chomped_uri[len(prefix)-1:]
         try:
             view, args, kwargs = resolve(chomped_uri)


### PR DESCRIPTION
Fixes the following by retrieving the script prefix and chomping it out of the url if a script prefix exists.
https://github.com/toastdriven/django-tastypie/issues/159
