### PR TITLE
allow both classes and instances of Resource to be registered in Api

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -48,7 +48,7 @@ be named any string.
 
 .. method:: Api.register(self, resource, canonical=True):
 
-Registers an instance of a ``Resource`` subclass with the API.
+Registers a subclass or instance of ``Resource`` with the API.
 
 Optionally accept a ``canonical`` argument, which indicates that the
 resource being registered is the canonical variant. Defaults to

--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -3,6 +3,7 @@ from django.conf.urls.defaults import *
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
+import inspect
 from tastypie.exceptions import NotRegistered
 from tastypie.serializers import Serializer
 from tastypie.utils import trailing_slash, is_valid_jsonp_callback_value
@@ -28,12 +29,15 @@ class Api(object):
     
     def register(self, resource, canonical=True):
         """
-        Registers an instance of a ``Resource`` subclass with the API.
+        Registers a subclass or instance of ``Resource`` with the API.
         
         Optionally accept a ``canonical`` argument, which indicates that the
         resource being registered is the canonical variant. Defaults to
         ``True``.
         """
+        if inspect.isclass(resource):
+            resource = resource()
+        
         resource_name = getattr(resource._meta, 'resource_name', None)
         
         if resource_name is None:

--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -1,9 +1,9 @@
+import inspect
 import warnings
 from django.conf.urls.defaults import *
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
-import inspect
 from tastypie.exceptions import NotRegistered
 from tastypie.serializers import Serializer
 from tastypie.utils import trailing_slash, is_valid_jsonp_callback_value

--- a/tests/core/tests/api.py
+++ b/tests/core/tests/api.py
@@ -26,6 +26,10 @@ class ApiTestCase(TestCase):
         api = Api()
         self.assertEqual(len(api._registry), 0)
         
+        api.register(NoteResource)
+        self.assertEqual(len(api._registry), 1)
+        self.assertEqual(sorted(api._registry.keys()), ['notes'])
+        
         api.register(NoteResource())
         self.assertEqual(len(api._registry), 1)
         self.assertEqual(sorted(api._registry.keys()), ['notes'])
@@ -35,6 +39,10 @@ class ApiTestCase(TestCase):
         self.assertEqual(sorted(api._registry.keys()), ['notes', 'users'])
         
         api.register(UserResource())
+        self.assertEqual(len(api._registry), 2)
+        self.assertEqual(sorted(api._registry.keys()), ['notes', 'users'])
+        
+        api.register(UserResource)
         self.assertEqual(len(api._registry), 2)
         self.assertEqual(sorted(api._registry.keys()), ['notes', 'users'])
         
@@ -48,6 +56,10 @@ class ApiTestCase(TestCase):
         api = Api()
         self.assertEqual(len(api._registry), 0)
         
+        api.register(NoteResource)
+        self.assertEqual(len(api._registry), 1)
+        self.assertEqual(sorted(api._registry.keys()), ['notes'])
+        
         api.register(NoteResource())
         self.assertEqual(len(api._registry), 1)
         self.assertEqual(sorted(api._registry.keys()), ['notes'])
@@ -57,6 +69,10 @@ class ApiTestCase(TestCase):
         self.assertEqual(sorted(api._registry.keys()), ['notes', 'users'])
         
         api.register(UserResource())
+        self.assertEqual(len(api._registry), 2)
+        self.assertEqual(sorted(api._registry.keys()), ['notes', 'users'])
+        
+        api.register(UserResource)
         self.assertEqual(len(api._registry), 2)
         self.assertEqual(sorted(api._registry.keys()), ['notes', 'users'])
         


### PR DESCRIPTION
Since model ForeignKeys and ManyToManyFields use classes as the key, and so do resource ToOneField and ToManyField, both options would be nice. No reason to type the extra () to construct an instance.