### PR TITLE
Dehydrate bundle when always_return_data is True

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1102,6 +1102,8 @@ class Resource(object):
             if not self._meta.always_return_data:
                 return HttpNoContent()
             else:
+                updated_bundle = self.full_dehydrate(updated_bundle.obj)
+                updated_bundle = self.alter_detail_data_to_serialize(request, updated_bundle)
                 return self.create_response(request, updated_bundle, response_class=HttpAccepted)
         except (NotFound, MultipleObjectsReturned):
             updated_bundle = self.obj_create(bundle, request=request, pk=kwargs.get('pk'))
@@ -1110,6 +1112,8 @@ class Resource(object):
             if not self._meta.always_return_data:
                 return HttpCreated(location=location)
             else:
+                updated_bundle = self.full_dehydrate(updated_bundle.obj)
+                updated_bundle = self.alter_detail_data_to_serialize(request, updated_bundle)
                 return self.create_response(request, updated_bundle, response_class=HttpCreated, location=location)
     
     def post_list(self, request, **kwargs):
@@ -1133,6 +1137,8 @@ class Resource(object):
         if not self._meta.always_return_data:
             return HttpCreated(location=location)
         else:
+            updated_bundle = self.full_dehydrate(updated_bundle.obj)
+            updated_bundle = self.alter_detail_data_to_serialize(request, updated_bundle)
             return self.create_response(request, updated_bundle, response_class=HttpCreated, location=location)
     
     def post_detail(self, request, **kwargs):

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1366,8 +1366,15 @@ class ModelResourceTestCase(TestCase):
         always_resource = AlwaysDataNoteResource()
         resp = always_resource.put_detail(request, pk=10)
         self.assertEqual(resp.status_code, 202)
-        self.assertEqual(resp.content, '{"content": "The cat is gone again. I think it was the rabbits that ate him this time.", "created": "2010-04-03 20:05:00", "is_active": true, "pk": 10, "slug": "cat-is-back", "title": "The Cat Is Gone", "updated": "2010-04-03 20:05:00"}')
-    
+        data = json.loads(resp.content)
+        self.assertTrue("id" in data)
+        self.assertEqual(data["id"], "10")
+        self.assertTrue("content" in data)
+        self.assertEqual(data["content"], "The cat is gone again. I think it was the rabbits that ate him this time.")
+        self.assertTrue("resource_uri" in data)
+        self.assertTrue("title" in data)
+        self.assertTrue("is_active" in data)
+
     def test_post_list(self):
         self.assertEqual(Note.objects.count(), 6)
         resource = NoteResource()
@@ -1385,8 +1392,15 @@ class ModelResourceTestCase(TestCase):
         always_resource = AlwaysDataNoteResource()
         resp = always_resource.post_list(request)
         self.assertEqual(resp.status_code, 201)
-        self.assertEqual(resp.content, '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"}')
-    
+        data = json.loads(resp.content)
+        self.assertTrue("id" in data)
+        self.assertEqual(data["id"], "8")
+        self.assertTrue("content" in data)
+        self.assertEqual(data["content"], "The cat is back. The dog coughed him up out back.")
+        self.assertTrue("resource_uri" in data)
+        self.assertTrue("title" in data)
+        self.assertTrue("is_active" in data)
+
     def test_post_detail(self):
         resource = NoteResource()
         request = HttpRequest()


### PR DESCRIPTION
Return fully dehydrated bundle when `always_return_data` is `True`to ensure that the whole data is in the response. Also fix issue #179 and #183.
