### PR TITLE
Don't clear/save readonly m2m

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1733,6 +1733,9 @@ class ModelResource(Resource):
             
             if not field_object.attribute:
                 continue
+              
+            if field_object.readonly:
+                continue
             
             # Get the manager.
             related_mngr = getattr(bundle.obj, field_object.attribute)


### PR DESCRIPTION
Avoid trying to clear/save m2m fields that are `readonly`.
