### PR TITLE
Remove api resource names for obj_create and obj_update

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1072,7 +1072,7 @@ class Resource(object):
                 self.rollback(bundles_seen)
                 raise
             
-            self.obj_create(bundle, request=request, **kwargs)
+            self.obj_create(bundle, request=request, **self.remove_api_resource_names(kwargs))
             bundles_seen.append(bundle)
         
         if not self._meta.always_return_data:
@@ -1108,7 +1108,7 @@ class Resource(object):
         self.is_valid(bundle, request)
         
         try:
-            updated_bundle = self.obj_update(bundle, request=request, **kwargs)
+            updated_bundle = self.obj_update(bundle, request=request, **self.remove_api_resource_names(kwargs))
             
             if not self._meta.always_return_data:
                 return HttpNoContent()
@@ -1117,7 +1117,7 @@ class Resource(object):
                 updated_bundle = self.alter_detail_data_to_serialize(request, updated_bundle)
                 return self.create_response(request, updated_bundle, response_class=HttpAccepted)
         except (NotFound, MultipleObjectsReturned):
-            updated_bundle = self.obj_create(bundle, request=request, **kwargs)
+            updated_bundle = self.obj_create(bundle, request=request, **self.remove_api_resource_names(kwargs))
             location = self.get_resource_uri(updated_bundle)
             
             if not self._meta.always_return_data:
@@ -1142,7 +1142,7 @@ class Resource(object):
         deserialized = self.alter_deserialized_detail_data(request, deserialized)
         bundle = self.build_bundle(data=dict_strip_unicode_keys(deserialized), request=request)
         self.is_valid(bundle, request)
-        updated_bundle = self.obj_create(bundle, request=request, **kwargs)
+        updated_bundle = self.obj_create(bundle, request=request, **self.remove_api_resource_names(kwargs))
         location = self.get_resource_uri(updated_bundle)
         
         if not self._meta.always_return_data:


### PR DESCRIPTION
This is necessary after the change to use pure kwargs for obj_create and obj_update.
