### PR TITLE
Generic relations

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -440,7 +440,7 @@ class RelatedField(ApiField):
         if self.contenttype_field and not isinstance(self.to, dict):
             raise ValueError(
                 "to argument must be a dictionary " + 
-                "when used with contenttype_attribute")
+                "when used with contenttype_field")
 
         if self.contenttype_field and not issubclass(type(self.contenttype_field), ToOneField):
             raise ValueError(
@@ -647,7 +647,7 @@ class ToOneField(RelatedField):
             if related_content_type:
                 resource_type = self.to[related_content_type.obj.model_class()]
             else:
-                # check to see if the obj know's it's content type
+                # check to see if the obj knows its content type
                 try:
                     if hasattr(bundle.obj, self.contenttype_field.attribute):
                         resource_type = getattr(bundle.obj, self.contenttype_field.attribute)

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -7,7 +7,7 @@ from django.utils import datetime_safe, importlib
 from tastypie.bundle import Bundle
 from tastypie.exceptions import ApiFieldError, NotFound
 from tastypie.utils import dict_strip_unicode_keys
-from tastypie.resource import ModelResource
+from tastypie.resources import ModelResource
 
 class NOT_PROVIDED:
     pass

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -7,7 +7,6 @@ from django.utils import datetime_safe, importlib
 from tastypie.bundle import Bundle
 from tastypie.exceptions import ApiFieldError, NotFound
 from tastypie.utils import dict_strip_unicode_keys
-from tastypie.resources import ModelResource
 
 class NOT_PROVIDED:
     pass
@@ -493,6 +492,9 @@ class RelatedField(ApiField):
         if not isinstance(self.to, basestring):
             if isinstance(self.to, dict):
                 # we're expected to return a functioning resource class
+                # import is here because at top it creates a circular import to 
+                # resources
+                from tastypie.resources import ModelResource
                 self._to_class = ModelResource
             else:
                 self._to_class = self.to

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -5,7 +5,7 @@ import re
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.utils import datetime_safe, importlib
 from tastypie.bundle import Bundle
-from tastypie.exceptions import ApiFieldError, NotFound
+from tastypie.exceptions import ApiFieldError, NotFound, BadRequest
 from tastypie.utils import dict_strip_unicode_keys
 
 class NOT_PROVIDED:
@@ -568,7 +568,7 @@ class RelatedField(ApiField):
             # if the api is used in this way.
             if not resource_type and isinstance(self.to, dict):
                 if self.contenttype_field:
-                    raise ApiFieldError("You must set the %s field when setting a GenericForeignKey in this way" % (self.contenttype_field.instance_name))
+                    raise BadRequest("You must set the %s field when setting a GenericForeignKey in this way" % (self.contenttype_field.instance_name))
             # Try to hydrate the data provided.
             value = dict_strip_unicode_keys(value)
                 
@@ -645,7 +645,7 @@ class ToOneField(RelatedField):
             # find out the class of model we're looking at from this field
             related_content_type = self.contenttype_field.hydrate(bundle)
             if related_content_type:
-                resource_type = self.to[related_content_type.model_class()]
+                resource_type = self.to[related_content_type.obj.model_class()]
             
         return self.build_related_resource(value, request=bundle.request,
                                            resource_type=resource_type)

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -464,7 +464,7 @@ class RelatedField(ApiField):
         """
         related_resource = self.to_class()
         
-        if contenttype_attribute:
+        if self.contenttype_attribute:
             # we're using a dict for self.to. we also finally know the 
             # actual type of the related object
             self._to_class = type(related_instance)    

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -646,7 +646,18 @@ class ToOneField(RelatedField):
             related_content_type = self.contenttype_field.hydrate(bundle)
             if related_content_type:
                 resource_type = self.to[related_content_type.obj.model_class()]
-            
+            else:
+                # check to see if the obj know's it's content type
+                try:
+                    if hasattr(bundle.obj, self.contenttype_field.attribute):
+                        resource_type = getattr(bundle.obj, self.contenttype_field.attribute)
+                        if resource_type:
+                            resource_type = self.to[resource_type.model_class()]
+                except ObjectDoesNotExist:
+                    resource_type = None
+        if 'content_type' in bundle.data and not 'content_object' in bundle.data:
+            raise BadRequest("You must supply a content_object when setting content_type")
+        
         return self.build_related_resource(value, request=bundle.request,
                                            resource_type=resource_type)
 

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -594,8 +594,8 @@ class ToOneField(RelatedField):
     """
     help_text = 'A single related resource. Can be either a URI or set of nested resource data.'
     
-    def __init__(self, to, attribute, related_name=None, default=NOT_PROVIDED, null=False, blank=False, readonly=False, full=False, unique=False, help_text=None):
-        super(ToOneField, self).__init__(to, attribute, related_name=related_name, default=default, null=null, blank=blank, readonly=readonly, full=full, unique=unique, help_text=help_text)
+    def __init__(self, to, attribute, related_name=None, default=NOT_PROVIDED, null=False, blank=False, readonly=False, full=False, unique=False, help_text=None, contenttype_field=None):
+        super(ToOneField, self).__init__(to, attribute, related_name=related_name, default=default, null=null, blank=blank, readonly=readonly, full=full, unique=unique, help_text=help_text, contenttype_field=contenttype_field)
         self.fk_resource = None
     
     def dehydrate(self, bundle):

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -549,6 +549,7 @@ class RelatedField(ApiField):
             except ObjectDoesNotExist:
                 raise ApiFieldError("Could not find the provided object via resource URI '%s'." % value)
         elif hasattr(value, 'items'):
+            # TODO this likely still does not work
             # Try to hydrate the data provided.
             value = dict_strip_unicode_keys(value)
             self.fk_bundle = self.fk_resource.build_bundle(data=value, request=request)

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -490,7 +490,7 @@ class RelatedField(ApiField):
         if self._to_class:
             return self._to_class
         
-        if not isinstance(self.to, basestring):\
+        if not isinstance(self.to, basestring):
             if isinstance(self.to, dict):
                 # we're expected to return a functioning resource class
                 self._to_class = ModelResource

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -697,6 +697,10 @@ class ToManyField(RelatedField):
     Note that the ``hydrate`` portions of this field are quite different than
     any other field. ``hydrate_m2m`` actually handles the data and relations.
     This is due to the way Django implements M2M relationships.
+    
+    Can be used to represent a ``GenericRelation`` 
+    (reverse of ``GenericForeignKey``).  Simply set ``to`` to the resource 
+    which represents the other end of the relation.
     """
     is_m2m = True
     help_text = 'Many related resources. Can be either a list of URIs or list of individually nested resource data.'

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1815,6 +1815,8 @@ class ContentTypeResource(ModelResource):
         from django.contrib.contenttypes.models import ContentType
         self.Meta.queryset = ContentType.objects.all()
         self.Meta.object_class = self.Meta.queryset.model
+        self._meta.queryset = ContentType.objects.all()
+        self._meta.object_class = self.Meta.queryset.model
         super(ContentTypeResource,self).__init__(*args, **kwargs)
         
     class Meta:

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1805,6 +1805,23 @@ class ModelResource(Resource):
         return self._build_reverse_url("api_dispatch_detail", kwargs=kwargs)
 
 
+class ContentTypeResource(ModelResource):
+    """
+    Convenience model to represent ContentType model
+    """
+    # import here since otherwise importing TastyPie.resources will cause an
+    # error unless django.contrib.contenttypes is enabled
+    def __init__(self, *args, **kwargs):
+        from django.contrib.contenttypes.models import ContentType
+        self.Meta.queryset = ContentType.objects.all()
+        self.Meta.object_class = self.Meta.queryset.model
+        super(ContentTypeResource,self).__init__(*args, **kwargs)
+        
+    class Meta:
+        fields = ['model']
+        detail_allowed_methods = ['get',]
+        list_allowed_methods = ['get',]
+    
 class NamespacedModelResource(ModelResource):
     """
     A ModelResource subclass that respects Django namespaces.

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -210,6 +210,8 @@ class Resource(object):
                 # error message.
                 return self._handle_500(request, e)
         
+        # make it easier to find out what resource the view belongs to
+        wrapper.parent_resource = self
         return wrapper
     
     def _handle_500(self, request, exception):
@@ -625,10 +627,10 @@ class Resource(object):
         except Resolver404:
             raise NotFound("The URL provided '%s' was not a link to a valid resource." % uri)
         
-        # view's im_class will be us (self) unless this isn't the 
-        # correct Resource for uri in which case the correct one will be used
+        # view's parent_resource will always give us the correct resource for
+        # that view
         # TODO maybe this should be a class method now
-        return view.im_class.obj_get(**self.remove_api_resource_names(kwargs))
+        return view.parent_resource.obj_get(**self.remove_api_resource_names(kwargs))
     
     # Data preparation.
     

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -625,7 +625,10 @@ class Resource(object):
         except Resolver404:
             raise NotFound("The URL provided '%s' was not a link to a valid resource." % uri)
         
-        return self.obj_get(**self.remove_api_resource_names(kwargs))
+        # view's im_class will be us (self) unless this isn't the 
+        # correct Resource for uri in which case the correct one will be used
+        # TODO maybe this should be a class method now
+        return view.im_class.obj_get(**self.remove_api_resource_names(kwargs))
     
     # Data preparation.
     

--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -3,7 +3,7 @@ from tastypie import fields
 from tastypie.resources import ModelResource
 from tastypie.authorization import Authorization
 from core.models import Note
-from related_resource.models import Category, Tag, ExtraData, Taggable, TaggableTag
+from related_resource.models import Category, Tag, ExtraData, Taggable, TaggableTag, GenericTag
 
 
 class UserResource(ModelResource):
@@ -81,3 +81,11 @@ class ExtraDataResource(ModelResource):
         queryset = ExtraData.objects.all()
         authorization = Authorization()
 
+class GenericTagResource(ModelResource):
+    content_object = fields.ToOneField(
+        {Category : CategoryResource, Taggable : TaggableResource}, attribute="content_object")
+    
+    class Meta:
+        resource_name = 'generictag'
+        queryset = GenericTag.objects.all()
+        authorization = Authorization()

--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -24,7 +24,7 @@ class NoteResource(ModelResource):
 
 class CategoryResource(ModelResource):
     parent = fields.ToOneField('self', 'parent', null=True)
-
+    tags = fields.ToManyField('related_resource.api.resources.GenericTagResource', attribute="tags", null=True, blank=True)
     class Meta:
         resource_name = 'category'
         queryset = Category.objects.all()

--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -82,8 +82,9 @@ class ExtraDataResource(ModelResource):
         authorization = Authorization()
 
 class GenericTagResource(ModelResource):
+    content_type = fields.ContentTypeField()
     content_object = fields.ToOneField(
-        {Category : CategoryResource, Taggable : TaggableResource}, attribute="content_object")
+        {Category : CategoryResource, Taggable : TaggableResource}, attribute="content_object", contenttype_field=content_type)
     
     class Meta:
         resource_name = 'generictag'

--- a/tests/related_resource/api/urls.py
+++ b/tests/related_resource/api/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls.defaults import *
 from tastypie.api import Api
 from related_resource.api.resources import NoteResource, UserResource, \
         CategoryResource, TagResource, TaggableTagResource, TaggableResource, \
-        ExtraDataResource
+        ExtraDataResource, GenericTagResource
 
 api = Api(api_name='v1')
 api.register(NoteResource(), canonical=True)
@@ -12,5 +12,5 @@ api.register(TagResource(), canonical=True)
 api.register(TaggableResource(), canonical=True)
 api.register(TaggableTagResource(), canonical=True)
 api.register(ExtraDataResource(), canonical=True)
-
+api.register(GenericTagResource(), canonical=True)
 urlpatterns = api.urls

--- a/tests/related_resource/api/urls.py
+++ b/tests/related_resource/api/urls.py
@@ -3,6 +3,7 @@ from tastypie.api import Api
 from related_resource.api.resources import NoteResource, UserResource, \
         CategoryResource, TagResource, TaggableTagResource, TaggableResource, \
         ExtraDataResource, GenericTagResource
+from tastypie.resources import ContentTypeResource
 
 api = Api(api_name='v1')
 api.register(NoteResource(), canonical=True)
@@ -13,4 +14,5 @@ api.register(TaggableResource(), canonical=True)
 api.register(TaggableTagResource(), canonical=True)
 api.register(ExtraDataResource(), canonical=True)
 api.register(GenericTagResource(), canonical=True)
+api.register(ContentTypeResource())
 urlpatterns = api.urls

--- a/tests/related_resource/models.py
+++ b/tests/related_resource/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-
+from django.contrib.contenttypes import generic
 
 # A self-referrential model to test regressions.
 class Category(models.Model):
@@ -54,4 +54,13 @@ class ExtraData(models.Model):
     def __unicode__(self):
         return u"%s" % (self.name)
 
-
+# Tag which can be applied to any other model (will be tested on Categories and
+# Taggable)
+class GenericTag(models.Model):
+    name = models.CharField(max_length = 30)
+    object_id = models.PositiveIntegerField()
+    content_type = models.ForeignKey(generic.ContentType)
+    content_object = generic.GenericForeignKey()
+    
+    def __unicode__(self):
+        return u"%s" % (self.name)

--- a/tests/related_resource/models.py
+++ b/tests/related_resource/models.py
@@ -5,7 +5,7 @@ from django.contrib.contenttypes import generic
 class Category(models.Model):
     parent = models.ForeignKey('self', null=True)
     name = models.CharField(max_length=32)
-
+    tags = generic.GenericRelation('related_resource.GenericTag')
     def __unicode__(self):
         return u"%s (%s)" % (self.name, self.parent)
 


### PR DESCRIPTION
I've added support for Generic Relations in the API by modifying the RelatedField to allow the ```to``` field to be a dictionary which maps django models to Resources.  Basic usage is as follows:

Django Model:

```python
class GenericTag(models.Model):
    name = models.CharField(max_length = 30)
    object_id = models.PositiveIntegerField()
    content_type = models.ForeignKey(generic.ContentType)
    content_object = generic.GenericForeignKey()
    
    def __unicode__(self):
        return u"%s" % (self.name)
```

Resource:

```python
class GenericTagResource(ModelResource):
    content_type = fields.ContentTypeField()
    content_object = fields.ToOneField(
        {Category : CategoryResource, Taggable : TaggableResource}, attribute="content_object", contenttype_field=content_type)

    class Meta:
        resource_name = 'generictag'
        queryset = GenericTag.objects.all()
        authorization = Authorization()
```

The ```to``` field dictionary tells the ```RelatedField``` class what Resources to use when hydrating/dehydrating.  A ```contenttype_field``` reference must also be passed if writing is allowed which allows for the proper type object to be written.  Two new classes were added, ```ContentTypeField``` which provides a shortcut for this purpose and ```ContentTypeResource``` which users can subclass to customize.  I've left it up to users to add ```ContentTypeResource``` to their urlconf by using ```Api.register``` or some other method.  All functionality is supported including POST/PUT with nested resources.  I've also written tests for the code in the ```GenericForeignKeyTest``` class inside ```tests/related_resource/tests.py``` The reverse ```GenericRelation``` is supported by using the ```ToManyField```.  All tests pass when run with ```tests/run_all_tests.sh```