### PR TITLE
pass request thru get_via_uri to obj_get to allow for django object level authorization

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -518,7 +518,7 @@ class RelatedField(ApiField):
         if isinstance(value, basestring):
             # We got a URI. Load the object and assign it.
             try:
-                obj = self.fk_resource.get_via_uri(value)
+                obj = self.fk_resource.get_via_uri(value, request=request)
                 bundle = self.fk_resource.build_bundle(obj=obj, request=request)
                 return self.fk_resource.full_dehydrate(bundle)
             except ObjectDoesNotExist:

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -606,7 +606,7 @@ class Resource(object):
         except NoReverseMatch:
             return None
     
-    def get_via_uri(self, uri):
+    def get_via_uri(self, uri, request=None):
         """
         This pulls apart the salient bits of the URI and populates the
         resource via a ``obj_get``.
@@ -625,7 +625,7 @@ class Resource(object):
         except Resolver404:
             raise NotFound("The URL provided '%s' was not a link to a valid resource." % uri)
         
-        return self.obj_get(**self.remove_api_resource_names(kwargs))
+        return self.obj_get(request=request, **self.remove_api_resource_names(kwargs))
     
     # Data preparation.
     


### PR DESCRIPTION
Hi Daniel,

We're doing object level authorization with custom managers in Django. 
They need the request.user passed in, which we achieve by lightly overriding get_object_list. 

However, we also need build_related_resource to pass on request to get_obj (via get_via_uri), otherwise get_object_list doesn't get a user and hence returns an empty queryset, which makes post_list justly spit out a 404.

This patch introduces changes to only 3 lines of code to pass on the already available request object in build_related_resource. Shouldn't hurt anyone AFAICS so it'd be great if you could reel this in.

KR - Marcel.
