### PR TITLE
Added a note about the possibility to set `API_LIMIT_PER_PAGE` to 0 

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -22,6 +22,10 @@ An example::
 
     API_LIMIT_PER_PAGE = 50
 
+If you don't want to limit the number of records by default, you can set this setting to 0::
+
+    API_LIMIT_PER_PAGE = 0
+
 Defaults to 20.
 
 


### PR DESCRIPTION
Added a note about the possibility to set `API_LIMIT_PER_PAGE` to 0 to provide unlimited lists by default.
