### PR TITLE
switch to using setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from ez_setup import use_setuptools
+    use_setuptools()
+    from setuptools import setup
 
 setup(
     name='django-tastypie',


### PR DESCRIPTION
This allows you to do things like 'python setup.py develop' instead of installing the code.
