### PR TITLE
Fix obj_delete_list calling list.delete() instead of obj.delete() in loop

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1684,7 +1684,7 @@ class ModelResource(Resource):
             authed_object_list.delete()
         else:
             for authed_obj in authed_object_list:
-                authed_object_list.delete()
+                authed_obj.delete()
     
     def obj_delete(self, request=None, **kwargs):
         """


### PR DESCRIPTION
`obj_delete_list` first tries the delete method on the list and falls back to looping over objects and deleting them.

This fixes a typo where the loop still calls list.delete() instead of obj.delete()
