### PR TITLE
Fix ToOneField.hydrate() not raising ApiFieldError when it should

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -141,7 +141,7 @@ class ApiField(object):
         if self.readonly:
             return None
         
-        if not bundle.data.has_key(self.instance_name):
+        if not self.instance_name in bundle.data:
             if self.blank:
                 return None
             elif self.attribute and getattr(bundle.obj, self.attribute, None):


### PR DESCRIPTION
`ToOneField.hydrate` inadvertently called super().hydrate (in Resource), which raises an ObjectDoesNotExist if a required related field was not posted.

This fix omits the call to super, instead makes ToOneField.hydrate check bundle.data first and correctly raises ApiFieldError if required data was not present in the bundle (analogous to how hydrate_m2m does it).

(and I've replaced a deprecated `<dict>.has_key(<key>)` call with proper `<key> not in <dict>`)
