### PR TITLE
Indent JSON when suitable

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -300,7 +300,8 @@ class Serializer(object):
         """
         options = options or {}
         data = self.to_simple(data, options)
-        return simplejson.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True)
+        return simplejson.dumps(data, cls=json.DjangoJSONEncoder,
+	                        sort_keys=True, indent=4 if settings.DEBUG else 0)
 
     def from_json(self, content):
         """


### PR DESCRIPTION
Updated `Serializer.to_json()` to indent the JSON if `settings.DEBUG` is `True`.
