### PR TITLE
CURL post with username, api_key and payload on --data option

### DIFF
--- a/docs/authentication_authorization.rst
+++ b/docs/authentication_authorization.rst
@@ -77,6 +77,22 @@ objects. Hooking it up looks like::
     
     models.signals.post_save.connect(create_api_key, sender=User)
 
+.. warning::
+
+  If you need to test your api with username and api_key parameters and
+  you are using curl, you can't provide a url with more than 2 parameters
+  like 'username=<username>&api_key=<api_key>. To solve this you need to
+  pass in your curl data parameter your payload with paramenter name
+  'payload' and your username and api_key. Tastypie will verify your user
+  agent and if it's curl will check 'payload' paramenter to get your 
+  data in order to deserialized it.
+
+
+Let me ilustrate this behaviour::
+    
+    curl --dump-header - -H "Content-Type: application/json" -X POST --data 'payload={"body": "This will prbbly be my lst post.", "pub_date": "2011-05-22T00:46:38", "slug": "another-post", "title": "Another Post"}&username=<username>&api_key=<api_key>' http://localhost:8000/api/v1/entry/
+
+
 ``DigestAuthentication``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1055,7 +1055,13 @@ class Resource(object):
         Return ``HttpAccepted`` (202 Accepted) if
         ``Meta.always_return_data = True``.
         """
-        deserialized = self.deserialize(request, request.raw_post_data, format=request.META.get('CONTENT_TYPE', 'application/json'))
+        data = request.raw_post_data
+
+        #if user-agent is CURL, get payload parameter from POST instead of raw_post_data
+        if 'HTTP_USER_AGENT' in request.META and request.META['HTTP_USER_AGENT'][:4] == "curl" and 'payload' in request.POST:
+            data = request.POST['payload']
+        
+        deserialized = self.deserialize(request, data, format=request.META.get('CONTENT_TYPE', 'application/json'))
         deserialized = self.alter_deserialized_list_data(request, deserialized)
         
         if not 'objects' in deserialized:


### PR DESCRIPTION
CURL post with username and api_key on --data option. User should specify a payload parameter as well username and api_key. Check Auth & Autho docs

Tests are OK.
