### PR TITLE
patch for sorting and filtering by fields with attribute names like "related_set"

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1547,10 +1547,10 @@ class ModelResource(Resource):
             if self.fields[field_name].attribute is None:
                 raise InvalidSortError("The '%s' field has no 'attribute' for ordering with." % field_name)
             
-            if not self.fields[field_name].attribute.endswith('_set') and getattr(self.fields[field_name], 'is_related', False):
-                order_by_args.append("%s%s" % (order, LOOKUP_SEP.join([self.fields[field_name].attribute] + order_by_bits[1:])))
-            else:
+            if self.fields[field_name].attribute.endswith('_set') and getattr(self.fields[field_name], 'is_related', False):
                 order_by_args.append("%s%s" % (order, LOOKUP_SEP.join([self.fields[field_name].attribute.rpartition('_set')[0]] + order_by_bits[1:])))
+            else:
+                order_by_args.append("%s%s" % (order, LOOKUP_SEP.join([self.fields[field_name].attribute] + order_by_bits[1:])))
         
         return obj_list.order_by(*order_by_args)
     


### PR DESCRIPTION
sorting and filtering by field attributes with names like "related_set" don't work because they refer to the manager of the related model, fields like that can only be filtered/sorted on only based on the name without the "_set" suffix.

``` python
MyModel.objects.filter(related_set__field__contains="value")
```

would not work instead 

``` python
MyModel.objects.filter(related__field__contains="value")
```

works.

This commit patches check_filters and apply_sorting to remove the _set from the field names before filtering/sorting.
