### PR TITLE
Add verbose_name to schema

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -24,7 +24,7 @@ class ApiField(object):
     dehydrated_type = 'string'
     help_text = ''
     
-    def __init__(self, attribute=None, default=NOT_PROVIDED, null=False, blank=False, readonly=False, unique=False, help_text=None):
+    def __init__(self, attribute=None, default=NOT_PROVIDED, null=False, blank=False, readonly=False, unique=False, help_text=None, verbose_name=None):
         """
         Sets up the field. This is generally called when the containing
         ``Resource`` is initialized.
@@ -53,6 +53,9 @@ class ApiField(object):
         Optionally accepts ``help_text``, which lets you provide a
         human-readable description of the field exposed at the schema level.
         Defaults to the per-Field definition.
+        
+        Optionally accepts ``verbose_name``, which lets you provide a
+        more verbose name of the field exposed at the schema level.
         """
         # Track what the index thinks this field is called.
         self.instance_name = None
@@ -64,6 +67,7 @@ class ApiField(object):
         self.readonly = readonly
         self.value = None
         self.unique = unique
+        self.verbose_name = verbose_name
         
         if help_text:
             self.help_text = help_text

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -385,7 +385,7 @@ class RelatedField(ApiField):
     self_referential = False
     help_text = 'A related resource. Can be either a URI or set of nested resource data.'
     
-    def __init__(self, to, attribute, related_name=None, default=NOT_PROVIDED, null=False, blank=False, readonly=False, full=False, unique=False, help_text=None):
+    def __init__(self, to, attribute, related_name=None, default=NOT_PROVIDED, null=False, blank=False, readonly=False, full=False, unique=False, help_text=None, verbose_name=None):
         """
         Builds the field and prepares it to access to related data.
         
@@ -420,6 +420,9 @@ class RelatedField(ApiField):
         Optionally accepts ``help_text``, which lets you provide a
         human-readable description of the field exposed at the schema level.
         Defaults to the per-Field definition.
+        
+        Optionally accepts ``verbose_name``, which lets you provide a
+        more verbose name of the field exposed at the schema level.
         """
         self.instance_name = None
         self._resource = None
@@ -435,6 +438,7 @@ class RelatedField(ApiField):
         self.resource_name = None
         self.unique = unique
         self._to_class = None
+        self.verbose_name = verbose_name
         
         if self.to == 'self':
             self.self_referential = True

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -133,7 +133,7 @@ class DeclarativeMetaclass(type):
         
         if getattr(new_class._meta, 'include_resource_uri', True):
             if not 'resource_uri' in new_class.base_fields:
-                new_class.base_fields['resource_uri'] = CharField(readonly=True)
+                new_class.base_fields['resource_uri'] = CharField(readonly=True, verbose_name="resource uri")
         elif 'resource_uri' in new_class.base_fields and not 'resource_uri' in attrs:
             del(new_class.base_fields['resource_uri'])
         
@@ -766,7 +766,10 @@ class Resource(object):
                 'nullable': field_object.null,
                 'readonly': field_object.readonly,
                 'help_text': field_object.help_text,
+                'verbose_name': field_object.verbose_name,
             }
+            if not field_object.verbose_name:
+                data['fields'][field_name]['verbose_name'] = field_name.replace("_", " ")
         
         return data
     
@@ -1370,6 +1373,7 @@ class ModelResource(Resource):
             kwargs = {
                 'attribute': f.name,
                 'help_text': f.help_text,
+                'verbose_name': f.verbose_name,
             }
             
             if f.null is True:

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -5,7 +5,7 @@ from django.db import models
 
 class Note(models.Model):
     author = models.ForeignKey(User, related_name='notes', blank=True, null=True)
-    title = models.CharField(max_length=100)
+    title = models.CharField("The Title", max_length=100)
     slug = models.SlugField()
     content = models.TextField(blank=True)
     is_active = models.BooleanField(default=True)

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -43,7 +43,7 @@ class TestObject(object):
 
 
 class BasicResource(Resource):
-    name = fields.CharField(attribute='name')
+    name = fields.CharField(attribute='name', verbose_name="Basic name")
     view_count = fields.IntegerField(attribute='view_count', default=0)
     date_joined = fields.DateTimeField(null=True)
     
@@ -386,24 +386,28 @@ class ResourceTestCase(TestCase):
             'fields': {
                 'view_count': {
                     'help_text': 'Integer data. Ex: 2673',
+                    'verbose_name': "view count",
                     'readonly': False,
                     'type': 'integer',
                     'nullable': False
                 },
                 'date_joined': {
                     'help_text': 'A date & time as a string. Ex: "2010-11-10T03:07:43"',
+                    'verbose_name': "date joined",
                     'readonly': False,
                     'type': 'datetime',
                     'nullable': True
                 },
                 'name': {
                     'help_text': 'Unicode string data. Ex: "Hello World"',
+                    'verbose_name': "Basic name",
                     'readonly': False,
                     'type': 'string',
                     'nullable': False
                 },
                 'resource_uri': {
                     'help_text': 'Unicode string data. Ex: "Hello World"',
+                    'verbose_name': "resource uri",
                     'readonly': True,
                     'type': 'string',
                     'nullable': False
@@ -419,24 +423,28 @@ class ResourceTestCase(TestCase):
             'fields': {
                 'view_count': {
                     'help_text': 'Integer data. Ex: 2673',
+                    'verbose_name': "view count",
                     'readonly': False,
                     'type': 'integer',
                     'nullable': False
                 },
                 'date_joined': {
                     'help_text': 'A date & time as a string. Ex: "2010-11-10T03:07:43"',
+                    'verbose_name': "date joined",
                     'readonly': False,
                     'type': 'datetime',
                     'nullable': True
                 },
                 'name': {
                     'help_text': 'Unicode string data. Ex: "Hello World"',
+                    'verbose_name': "Basic name",
                     'readonly': False,
                     'type': 'string',
                     'nullable': False
                 },
                 'resource_uri': {
                     'help_text': 'Unicode string data. Ex: "Hello World"',
+                    'verbose_name': "resource uri",
                     'readonly': True,
                     'type': 'string',
                     'nullable': False
@@ -1646,7 +1654,7 @@ class ModelResourceTestCase(TestCase):
         
         resp = resource.get_schema(request)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.content, '{"default_format": "application/json", "fields": {"content": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string"}, "created": {"help_text": "A date & time as a string. Ex: \\"2010-11-10T03:07:43\\"", "nullable": false, "readonly": false, "type": "datetime"}, "id": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string"}, "is_active": {"help_text": "Boolean data. Ex: True", "nullable": false, "readonly": false, "type": "boolean"}, "resource_uri": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": true, "type": "string"}, "slug": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string"}, "title": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string"}, "updated": {"help_text": "A date & time as a string. Ex: \\"2010-11-10T03:07:43\\"", "nullable": false, "readonly": false, "type": "datetime"}}, "filtering": {"content": ["startswith", "exact"], "slug": ["exact"], "title": 1}, "ordering": ["title", "slug", "resource_uri"]}')
+        self.assertEqual(resp.content, '{"default_format": "application/json", "fields": {"content": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string", "verbose_name": "content"}, "created": {"help_text": "A date & time as a string. Ex: \\"2010-11-10T03:07:43\\"", "nullable": false, "readonly": false, "type": "datetime", "verbose_name": "created"}, "id": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string", "verbose_name": "ID"}, "is_active": {"help_text": "Boolean data. Ex: True", "nullable": false, "readonly": false, "type": "boolean", "verbose_name": "is active"}, "resource_uri": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": true, "type": "string", "verbose_name": "resource uri"}, "slug": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string", "verbose_name": "slug"}, "title": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string", "verbose_name": "The Title"}, "updated": {"help_text": "A date & time as a string. Ex: \\"2010-11-10T03:07:43\\"", "nullable": false, "readonly": false, "type": "datetime", "verbose_name": "updated"}}, "filtering": {"content": ["startswith", "exact"], "slug": ["exact"], "title": 1}, "ordering": ["title", "slug", "resource_uri"]}')
     
     def test_get_multiple(self):
         resource = NoteResource()

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -457,6 +457,7 @@ class ResourceTestCase(TestCase):
                 'name': ALL,
             }
         })
+
     
     def test_subclassing(self):
         class CommonMeta:
@@ -1656,6 +1657,72 @@ class ModelResourceTestCase(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content, '{"default_format": "application/json", "fields": {"content": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string", "verbose_name": "content"}, "created": {"help_text": "A date & time as a string. Ex: \\"2010-11-10T03:07:43\\"", "nullable": false, "readonly": false, "type": "datetime", "verbose_name": "created"}, "id": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string", "verbose_name": "ID"}, "is_active": {"help_text": "Boolean data. Ex: True", "nullable": false, "readonly": false, "type": "boolean", "verbose_name": "is active"}, "resource_uri": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": true, "type": "string", "verbose_name": "resource uri"}, "slug": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string", "verbose_name": "slug"}, "title": {"help_text": "Unicode string data. Ex: \\"Hello World\\"", "nullable": false, "readonly": false, "type": "string", "verbose_name": "The Title"}, "updated": {"help_text": "A date & time as a string. Ex: \\"2010-11-10T03:07:43\\"", "nullable": false, "readonly": false, "type": "datetime", "verbose_name": "updated"}}, "filtering": {"content": ["startswith", "exact"], "slug": ["exact"], "title": 1}, "ordering": ["title", "slug", "resource_uri"]}')
     
+        related = RelatedNoteResource()
+        self.assertEqual(related.build_schema(), {
+            "fields": {
+                "content": {
+                    'help_text': 'Unicode string data. Ex: "Hello World"',
+                    'nullable': False,
+                    'readonly': False,
+                    'type': 'string',
+                    'verbose_name': 'content',
+                },
+                'created': {
+                    'help_text': 'A date & time as a string. Ex: "2010-11-10T03:07:43"',
+                    'nullable': False,
+                    'readonly': False,
+                    'type': 'datetime',
+                    'verbose_name': 'created'
+                },
+                'is_active': {
+                    'help_text': 'Boolean data. Ex: True',
+                    'nullable': False,
+                    'readonly': False,
+                    'type': 'boolean',
+                    'verbose_name': 'is active'
+                },
+                'resource_uri': {
+                    'help_text': 'Unicode string data. Ex: "Hello World"',
+                    'nullable': False,
+                    'readonly': True,
+                    'type': 'string',
+                    'verbose_name': 'resource uri'
+                },
+                'slug': {
+                    'help_text': 'Unicode string data. Ex: "Hello World"',
+                    'nullable': False,
+                    'readonly': False,
+                    'type': 'string',
+                    'verbose_name': 'slug'
+                },
+                'title': {
+                    'help_text': 'Unicode string data. Ex: "Hello World"',
+                    'nullable': False,
+                    'readonly': False,
+                    'type': 'string',
+                    'verbose_name': 'The Title'
+                },
+                'author': {
+                    'help_text': 'A single related resource. Can be either a URI or set of nested resource data.',
+                    'verbose_name': 'author',
+                    'readonly': False,
+                    'type': 'related',
+                    'nullable': False
+                },
+                'subjects': {
+                    'help_text': 'Many related resources. Can be either a list of URIs or list of individually nested resource data.',
+                    'verbose_name': 'subjects',
+                    'readonly': False,
+                    'type': 'related',
+                    'nullable': False
+                }
+            },
+            'default_format': 'application/json',
+            'filtering': {
+                'author': ALL,
+                'subjects': ALL_WITH_RELATIONS,
+            },
+        })
     def test_get_multiple(self):
         resource = NoteResource()
         request = HttpRequest()


### PR DESCRIPTION
This patch adds `verbose_name` from django's models.Field or Tastypie Field into API's `get_schema` view.

It can be usefull to build automatics forms with this API schema with a more verbose name than resource's field name.

Hope it can be usefull.