### PR TITLE
Fix to allow API keys to be used in test fixtures

### DIFF
--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -56,4 +56,4 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
         A signal for hooking up automatic ``ApiKey`` creation.
         """
         if kwargs.get('created') is True:
-            ApiKey.objects.create(user=kwargs.get('instance'))
+            ApiKey.objects.get_or_create(user=kwargs.get('instance'))


### PR DESCRIPTION
Fix to allow API keys to be prepopulated in test fixtures, when the create_api_key signal hook is used.  