### PR TITLE
Fix for ToManyField.dehydrate() when <field>.attribute is a callable

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -593,11 +593,14 @@ class ToOneField(RelatedField):
         self.fk_resource = None
 
     def dehydrate(self, bundle):
-        try:
-            foreign_obj = getattr(bundle.obj, self.attribute)
-        except ObjectDoesNotExist:
-            foreign_obj = None
-
+        if isinstance(self.attribute, basestring):
+            try:
+                foreign_obj = getattr(bundle.obj, self.attribute)
+            except ObjectDoesNotExist:
+                foreign_obj = None
+        elif callable(self.attribute):
+            foreign_obj = self.attribute(bundle)
+        
         if not foreign_obj:
             if not self.null:
                 raise ApiFieldError("The model '%r' has an empty attribute '%s' and doesn't allow a null value." % (bundle.obj, self.attribute))
@@ -615,6 +618,7 @@ class ToOneField(RelatedField):
             return value
 
         return self.build_related_resource(value, request=bundle.request)
+
 
 class ForeignKey(ToOneField):
     """


### PR DESCRIPTION
When defining a `ToManyField` with a callable `attribute` (see the comment at [http://django-tastypie.readthedocs.org/en/latest/fields.html#tomanyfield]), the `dehydrate()` fails because of the ambiguous `the_m2ms` that is sometimes a manager, sometimes a list of objects.

Reworked the null checks a little and renamed the ambiguous `the_m2ms` to `related_mngr` and `m2m_objs` respectively.

Also added the option to pass a callable attribute to ToOneField for consistency (and because it is just as useful there as it is in ToManyField!)
