### PR TITLE
Teeny patch to allow internal usage.

### DIFF
--- a/tastypie/utils/mime.py
+++ b/tastypie/utils/mime.py
@@ -14,6 +14,10 @@ def determine_format(request, serializer, default_format='application/json'):
     If still no format is found, returns the ``default_format`` (which defaults
     to ``application/json`` if not provided).
     """
+    # Zeroeth, check to see if we have a request to play with.
+    # Otherwise, just use the default format
+    if not request: return default_format
+
     # First, check if they forced the format.
     if request.GET.get('format'):
         if request.GET['format'] in serializer.formats:


### PR DESCRIPTION
Adding a small check which will allow us to do the API directly from Django.  e.g. SomeResource().get_detail(None, whatever=something)

We'd like to be able to use TastyPie from within the Django app.  Kinda eat your own dog food by using the Resources rather than using the ORM's Models.
