### PR TITLE
Pointed to the correct documentation url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ supports all CRUD operations in a RESTful way. JSON/XML/YAML support is already
 there, and it's easy to add related data/authentication/caching.
 
 You can find more in the documentation at
-http://toastdriven.github.com/django-tastypie/.
+http://django-tastypie.readthedocs.org/.
 
 
 Why tastypie?


### PR DESCRIPTION
So all the documentation links would point to the right place
