### PR TITLE
I found this handy.

### DIFF
--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -134,6 +134,14 @@ class Api(object):
 
             options['callback'] = callback
 
+        if 'javascript' in desired_format or 'json' in desired_format:
+            try:
+                options['indent'] = int(request.GET.get('indent'))
+            except ValueError:
+                raise BadRequest('indent must be an integer.')
+            except TypeError:
+                options['indent'] = None
+
         serialized = serializer.serialize(available_resources, desired_format, options)
         return HttpResponse(content=serialized, content_type=build_content_type(desired_format))
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -324,6 +324,14 @@ class Resource(object):
 
             options['callback'] = callback
 
+        if 'javascript' in format or 'json' in format:
+            try:
+                options['indent'] = int(request.GET.get('indent'))
+            except ValueError:
+                raise BadRequest('indent must be an integer.')
+            except TypeError:
+                options['indent'] = None
+
         return self._meta.serializer.serialize(data, format, options)
 
     def deserialize(self, request, data, format='application/json'):

--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -300,7 +300,7 @@ class Serializer(object):
         """
         options = options or {}
         data = self.to_simple(data, options)
-        return simplejson.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True)
+        return simplejson.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True, indent = options['indent'])
 
     def from_json(self, content):
         """


### PR DESCRIPTION
add support for indent={{num}} in the url for json and jsonp requests, which formats the return for readability
