### PR TITLE
adjusted setup.py to install tastypie.management.commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     packages=[
         'tastypie',
         'tastypie.utils',
+        'tastypie.management',
         'tastypie.management.commands',
     ],
     package_data={


### PR DESCRIPTION
I noticed that I wasn't getting the handy backfill_api_keys when doing a

```
pip install https://github.com/toastdriven/django-tastypie/tarball/master
```

Because they weren't be installed by `setup.py`. After adding `tastypie.management` and `tastypie.management.commands` to `packages` in `setup.py` they installed and I can use them now.
