### PR TITLE
When the api receives requests without a content type, the server responds with a 500.  This patch allows for a default content type to be set in the settings file. 

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -130,7 +130,7 @@ class Serializer(object):
         Given some data and a format, calls the correct method to serialize
         the data and returns the result.
         """
-        desired_format = None
+        desired_format = getattr(settings, 'TASTYPIE_DEFAULT_CONTENT_FORMAT', None)
         
         for short_format, long_format in self.content_types.items():
             if format == long_format:
@@ -149,7 +149,7 @@ class Serializer(object):
         Given some data and a format, calls the correct method to deserialize
         the data and returns the result.
         """
-        desired_format = None
+        desired_format = getattr(settings, 'TASTYPIE_DEFAULT_CONTENT_FORMAT', None)
 
         format = format.split(';')[0]
 

--- a/tests/basic/tests/http.py
+++ b/tests/basic/tests/http.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from tests.testcases import TestServerTestCase
 import httplib
 try:
@@ -63,3 +65,23 @@ class HTTPTestCase(TestServerTestCase):
         self.assertEqual(obj['content'], 'A new post.')
         self.assertEqual(obj['is_active'], True)
         self.assertEqual(obj['user'], '/api/v1/users/1/')
+
+    def test_post_object_no_headers_no_default(self):
+        """ posting to a resource without headers yields a system error (500).
+        """
+        connection = self.get_connection()
+        post_data = '{"content": "A new post.", "is_active": true, "title": "New Title", "slug": "new-title", "user": "/api/v1/users/1/"}'
+        connection.request('POST', '/api/v1/notes/', body=post_data, headers={})
+        response = connection.getresponse()
+        self.assertEqual(response.status, 500)
+
+    def test_post_object_no_headers_with_default(self):
+        """ posting to a resource without headers yields a system error (500), however setting a default content type for
+            the service prevents an internal error.
+        """
+        setattr(settings, 'TASTYPIE_DEFAULT_CONTENT_FORMAT', 'json')
+        connection = self.get_connection()
+        post_data = '{"content": "A new post.", "is_active": true, "title": "New Title", "slug": "new-title", "user": "/api/v1/users/1/"}'
+        connection.request('POST', '/api/v1/notes/', body=post_data, headers={})
+        response = connection.getresponse()
+        self.assertEqual(response.status, 201)


### PR DESCRIPTION
Allows a default content type to prevent 500 errors. Unit tests included.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/django-tastypie/django-tastypie/254)
<!-- Reviewable:end -->
