### PR TITLE
Change ApiField to check if an attribute is present with hasattr() before invoking getattr() on hydrate/dehydrate

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -99,7 +99,10 @@ class ApiField(object):
 
             for attr in attrs:
                 previous_object = current_object
-                current_object = getattr(current_object, attr, None)
+                if hasattr(current_object, attr):
+                    current_object = getattr(current_object, attr, None)
+                else:
+                    current_object = None
 
                 if current_object is None:
                     if self.has_default():


### PR DESCRIPTION
This is my first pull request, so please be gentle. :-)

I've modified the _hydrate()_ and _dehydrate()_ methods of ApiField to check the existence of an attribute before using _getattr()_ on it, as it can raise an exception when doing so on a non-existent OneToOneField. I've documented the problem in [issue #260](https://github.com/toastdriven/django-tastypie/issues/260).
