### PR TITLE
CacheThrottle won't work with Django's DummyCache

### DIFF
--- a/docs/throttling.rst
+++ b/docs/throttling.rst
@@ -57,7 +57,7 @@ common logic and serves as an api-compatible plug. Very useful for development.
 ~~~~~~~~~~~~~~~~~
 
 This uses just the cache to manage throttling. Fast but prone to cache misses
-and/or cache restarts.
+and/or cache restarts. Cannot be used with Django's DummyCache backend.
 
 ``CacheDBThrottle``
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
It's just a minor issue, but Tastypie Cache Throttle does not work if the type of cache chosen in the Django settings is [DummyCache](https://docs.djangoproject.com/en/1.3/topics/cache/#dummy-caching-for-development). The tests fail too.

I understand that Cache Throttle is not even *supposed* to work in this case (it's just a dummy cache), but I suggest you add this to the documentation, so people understand why they get the following error:

    TypeError: 'NoneType' object is not iterable, throttle.py, line 87

if, by change, they have DummyCache set in their Django settings file.