### PR TITLE
Fields with null=True should dehydrate to None before returning the default

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -102,13 +102,12 @@ class ApiField(object):
                 current_object = getattr(current_object, attr, None)
 
                 if current_object is None:
-                    if self.has_default():
-                        current_object = self._default
+                    if self.null:
                         # Fall out of the loop, given any further attempts at
                         # accesses will fail miserably.
                         break
-                    elif self.null:
-                        current_object = None
+                    if self.has_default():
+                        current_object = self._default
                         # Fall out of the loop, given any further attempts at
                         # accesses will fail miserably.
                         break

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -47,3 +47,13 @@ class MediaBit(models.Model):
     
     def __unicode__(self):
         return self.title
+
+
+class NoteEdit(models.Model):
+    note = models.ForeignKey(Note, related_name='edits')
+    diff = models.TextField(blank=True)
+    age = models.IntegerField(null=True, blank=True, default=0,
+                              help_text='In seconds')
+
+    def __unicode__(self):
+        return u'Edit for %s' % self.note

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -7,7 +7,7 @@ from tastypie.bundle import Bundle
 from tastypie.exceptions import ApiFieldError, NotFound
 from tastypie.fields import *
 from tastypie.resources import ModelResource
-from core.models import Note, Subject, MediaBit
+from core.models import Note, Subject, MediaBit, NoteEdit
 
 
 class ApiFieldTestCase(TestCase):
@@ -241,6 +241,25 @@ class IntegerFieldTestCase(TestCase):
 
         field_3 = IntegerField(default=18.5)
         self.assertEqual(field_3.dehydrate(bundle), 18)
+
+    def test_dehydrate_check_null_allowed_first(self):
+        note = Note.objects.get(pk=1)
+        note_edit = NoteEdit.objects.create(note=note, age=None)
+
+        bundle = Bundle(obj=note_edit)
+
+        # Simulate the field the ModelResource metaclass would create based
+        # on the Note model's fields
+        field = NoteEdit._meta.get_field_by_name('age')[0]
+        age_field = IntegerField(
+            attribute='age',
+            null=field.null,
+            blank=field.blank,
+            default=field.default
+        )
+
+        # Should be None because null=True
+        self.assertEqual(age_field.dehydrate(bundle), None)
 
 
 class FloatFieldTestCase(TestCase):

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -23,7 +23,7 @@ from tastypie.resources import Resource, ModelResource, ALL, ALL_WITH_RELATIONS,
 from tastypie.serializers import Serializer
 from tastypie.throttle import CacheThrottle
 from tastypie.validation import Validation, FormValidation
-from core.models import Note, Subject, MediaBit
+from core.models import Note, Subject, MediaBit, NoteEdit
 from core.tests.mocks import MockRequest
 from core.utils import SimpleHandler
 try:
@@ -921,6 +921,13 @@ class PerObjectNoteResource(NoteResource):
 # End per object authorization bits.
 
 
+class AgeOnlyNoteEditResource(ModelResource):
+    class Meta:
+        resource_name = 'ageonlynoteedit'
+        queryset = NoteEdit.objects.all()
+        fields = ('age',)
+
+
 class ModelResourceTestCase(TestCase):
     fixtures = ['note_testdata.json']
     urls = 'core.tests.field_urls'
@@ -1408,6 +1415,16 @@ class ModelResourceTestCase(TestCase):
 
         resp = resource.get_detail(request, pk=300)
         self.assertEqual(resp.status_code, 404)
+
+    def test_get_detail_with_nullable_field_allowed(self):
+        NoteEdit.objects.create(note=self.note_1, age=None)
+        resource = AgeOnlyNoteEditResource()
+        request= HttpRequest()
+        request.GET = {'format': 'json'}
+
+        resp = resource.get_detail(request, pk=1)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, '{"age": null, "resource_uri": ""}')
 
     def test_put_list(self):
         resource = NoteResource()


### PR DESCRIPTION
In the current code, when dehydrating a field on a `ModelResource` that has `null=True`, `None` should be returned before the default. This is a simple change that just inverts the current logic in `ApiField.dehydrate`.

Lets say you have Django model like:

```
class Person(models.Model):
    age = models.IntegerField(null=True, blank=True, default=0)
```

And a standard `ModelResource` for it.

If `one_person.age is None`, then dehydrating the corresponding `tastypie.fields.IntegerField.dehydrate` should return `None`, not the default, 0.

In Django, `default` only matters when creating new objects.

Let me know what you think about this reasoning (even though I would always need to use a patched version because we must distinguish between an integer and `None`).

I've added tests which involved adding a model to the core tests so I could use an `django.db.models.IntegerField`.

One test failed before and after the patch:

```
FAIL: test_build_schema (core.tests.resources.ResourceTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ryan/src/my-django-tastypie/tests/core/tests/resources.py", line 475, in test_build_schema
    'default_format': 'application/json'
 AssertionError: {'fields': {'view_count': {'nullable': False, 'default': 0, 'readonly': False, '
    [truncated]... != {'fields': {'view_count': {'help_text': 'Integer data. Ex: 2673', 'readonly': Fa [truncated]...
 Diff is 2793 characters long. Set self.maxDiff to None to see it.
```
