### PR TITLE
Fields with null=True should dehydrate to None before returning the default

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -102,13 +102,12 @@ class ApiField(object):
                 current_object = getattr(current_object, attr, None)
 
                 if current_object is None:
-                    if self.has_default():
-                        current_object = self._default
+                    if self.null:
                         # Fall out of the loop, given any further attempts at
                         # accesses will fail miserably.
                         break
-                    elif self.null:
-                        current_object = None
+                    elif self.has_default():
+                        current_object = self._default
                         # Fall out of the loop, given any further attempts at
                         # accesses will fail miserably.
                         break

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -77,6 +77,19 @@ class ApiFieldTestCase(TestCase):
         field_6 = ApiField(attribute='what_time_is_it', default=True)
         self.assertEqual(field_6.dehydrate(bundle), datetime.datetime(2010, 4, 1, 0, 48))
 
+        # Wrong attribute with default and null=True should yield null
+        field_7 = ApiField(attribute='foo', null=True, default='bar')
+        self.assertEqual(field_7.dehydrate(bundle), None)
+
+        # Correct attribute with value of None, a default, and null=True
+        # should yield null
+        original_author = note.author
+        note.author = None
+        note.save()
+        field_8 = ApiField(attribute='author', null=True,
+                           default=original_author)
+        self.assertEqual(field_8.dehydrate(bundle), None)
+
     def test_convert(self):
         field_1 = ApiField()
         self.assertEqual(field_1.convert('foo'), 'foo')


### PR DESCRIPTION
I previously [submitted this issue](https://github.com/toastdriven/django-tastypie/pull/269) but closed it because I wanted to refactor the tests.

The current tests located in `tests.core.fields.ApiFieldTestCase.test_dehydrate` test for a lot of conditions, but not when a field has `null=True` and `default=True`.

The logic in `fields.ApiField.dehydrate` specifies that if the field has a `default` then it takes precedence over null (`None`). This means that if you have a Django model like

```
class Comment(models.Model):
    times_viewed = models.IntegerField(null=True, default=0)
```

and an object with `times_viewed=None`, `ApiField.dehydrate` will return the default, 0, instead of None.

My patch inverts the checks for a default and null. The default will only be returned if `null=False`.

One issue that I am making an assumption about has to do with when `ApiField.attribute` is wrong or missing. This is [tested](https://github.com/ryankask/django-tastypie/blob/11a5adb087c4d0e80c6082089a2f5ffc49f8ad72/tests/core/tests/fields.py#L38) for a bunch of times but never when `null=True` _and_ a `default` is set. I didn't think about this the first time I posted this issue. This is the [relevent line](https://github.com/ryankask/django-tastypie/blob/11a5adb087c4d0e80c6082089a2f5ffc49f8ad72/tastypie/fields.py#L94):

```
current_object = getattr(current_object, attr, None)
```

My patch's `dehydrate` will return `None` (null). I chose this because I think if null is allowed, it should take precedence over a default. I personally think `default` should only matter for the creation of objects, which matches Django. A default _may_ be useful when working with plain resources but I haven't needed it for GET requests.

One alternative would be to return the default if `ApiField.attribute` is missing or wrong. The code would have to stop conflating `None` as the absence of a value on a valid attribute and `None` returned `getattr` because of an `AttributeError`. Something like:

```
try:
    current_object = getattr(current_object, attr)
except AttributeError:
    use_default = True
else:
    use_default = False
```

and then update the logic below accordingly.

This issue shouldn't change the fact that if the database stores null, then a field with `default` set shouldn't override that; `None` should be returned.
