### PR TITLE
resource urls now accept alphanumeric primary keys

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -275,8 +275,8 @@ class Resource(object):
         return [
             url(r"^(?P<resource_name>%s)%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('dispatch_list'), name="api_dispatch_list"),
             url(r"^(?P<resource_name>%s)/schema%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('get_schema'), name="api_get_schema"),
-            url(r"^(?P<resource_name>%s)/set/(?P<pk_list>\w[\w/;-]*)/$" % self._meta.resource_name, self.wrap_view('get_multiple'), name="api_get_multiple"),
-            url(r"^(?P<resource_name>%s)/(?P<pk>\w[\w/-]*)%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
+            url(r"^(?P<resource_name>%s)/set/(?P<pk_list>.*?)/$" % self._meta.resource_name, self.wrap_view('get_multiple'), name="api_get_multiple"),
+            url(r"^(?P<resource_name>%s)/(?P<pk>.*?)%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
         ]
 
     def override_urls(self):


### PR DESCRIPTION
I have an app with a Model imported from a table (inspectdb) with a CharField primary key. The patch supports other types as primary key with backwards compatibility.

By trying to get the object with a RESTful call, i was unable to get a object by primary key:

```
/api/v1/model/my_primary_key/?format=xml
```

After applying this patch it works and tests passed for me.

Best Regards,
Jordi
