### PR TITLE
Use exception message to describe Error 500 instead of 'This request could not be processed'.

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -254,6 +254,11 @@ class Resource(object):
         data = {
             "error_message": getattr(settings, 'TASTYPIE_CANNED_ERROR', "Sorry, this request could not be processed. Please try again later."),
         }
+
+        # If the exception comes with an error, show that instead of "Sorry, this request..."
+        if getattr(exception, 'message', None):
+            data["error_message"] = exception.message
+
         desired_format = self.determine_format(request)
         serialized = self.serialize(request, data, desired_format)
         return response_class(content=serialized, content_type=build_content_type(desired_format))


### PR DESCRIPTION
This patch expands on https://github.com/toastdriven/django-tastypie/commit/93ae0b3e for issue #11.

Whenever an exception raises an HTTP 500 Error, and that exception comes with a message, show *that message* as a description of the HTTP 500 Error, instead of a generic "Sorry, this request could not be processed. Please try again later."
