### PR TITLE
A specific error message for JSON decoding problems

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -253,7 +253,7 @@ class Resource(object):
         # Value errors that trace up this far are almost always due to JSON parsing problems
         if isinstance(exception, (ValueError)):
             data = {
-                "error_message": "The server had a problem processing your request. Check that your JSON is not malformed."
+                "error_message": "Sorry, this request could not be processed. Check that your JSON is not malformed. The exception message was: " + exception.message
             }
             
         else:


### PR DESCRIPTION
My company uses Tastypie to power our restful, JSON-based API. For the most part, it works great! We do have one issue, however.

A few users of our API have complained that we do not return descriptive error messages when we receive malformed JSON in a post request -- this makes it hard for people writing applications using our API to debug. Because Tastypie decodes JSON before the API request is sent to Django, there isn't really a way for us customize our error message without modifying Tastypie. 

The commit in this pull request adds a specific error message for JSON decoding problems. The only change is the addition of a few lines to resources/Resource._handle_500 that check if an incoming exception is of the type thrown by the JSON decoder when it fails. If so, the error message directs to user to check their JSON syntax.
