### PR TITLE
Removed a mutable default param in Serializer.serialize().

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -125,12 +125,14 @@ class Serializer(object):
 
         return data.isoformat()
 
-    def serialize(self, bundle, format='application/json', options={}):
+    def serialize(self, bundle, format='application/json', options=None):
         """
         Given some data and a format, calls the correct method to serialize
         the data and returns the result.
         """
         desired_format = None
+        if options is None:
+            options = {}
 
         for short_format, long_format in self.content_types.items():
             if format == long_format:


### PR DESCRIPTION
I haven't seen this pop up explicitly as a bug in code; only noticed it
through code inspection.

There's a small chance somebody might stash something in the default provided "options" dictionary and it will be there for all future calls to serialize(), typically causing much confusion for the developer making the function call. A quick grep though the code does show empty dictionaries being used anywhere else as a default argument.
