### PR TITLE
Validate if `ApiKey` may already exist before creating a new one.

### DIFF
--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -56,4 +56,4 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
         A signal for hooking up automatic ``ApiKey`` creation.
         """
         if kwargs.get('created') is True:
-            ApiKey.objects.create(user=kwargs.get('instance'))
+            ApiKey.objects.get_or_create(user=kwargs.get('instance'))


### PR DESCRIPTION
I was having troubles executing certain unit tests for my project with SQLite that used fixtures with a pre-defined user. When trying to test I always ran into an 
    IntegrityError: column user_id is not unique
for the `ApiKey` table. Sorry I didn't have the time to dig any deeper what the exact reason for the `ApiKey` being created twice is (most probably the `created` check doesn't work), but changing `create()` to `get_or_create()` solves the problem for me and shouldn't have any bad side effects except one extra db call when creating a new user!