### PR TITLE
Update docs/resources.rst to reflect how `hydrate_FOO` actually works.

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -377,9 +377,10 @@ A simple example::
             queryset = Note.objects.all()
 
         def hydrate_title(self, bundle):
-            return bundle.data['title'].lower()
+            bundle.obj.title = bundle.data['title'].lower()
+            return bundle
 
-The return value is updated in the ``bundle.obj``.
+The method should return the bundle.
 
 Per-field ``hydrate``
 ~~~~~~~~~~~~~~~~~~~~~
@@ -389,7 +390,7 @@ method. If it knows how to access data (say, given the ``attribute`` kwarg), it
 will attempt to take data from the ``bundle.data`` & assign it on the data
 model.
 
-The return value is put in the ``bundle.obj`` attribute for that fieldname.
+The method should return the bundle.
 
 
 Reverse "Relationships"


### PR DESCRIPTION
I noticed that in the documentation, the example for hydrate_FOO returns the transformed value. However, from looking at [the source code](https://github.com/toastdriven/django-tastypie/blob/master/tastypie/resources.py#L691), it seems the return value should be the bundle, with the new value set on it.

I'm not sure which is the correct way, but this pull request has the documentation updated to reflect that the bundle should be returned.
