### PR TITLE
Add an authentication method based on a temporary token.

### DIFF
--- a/docs/authentication_authorization.rst
+++ b/docs/authentication_authorization.rst
@@ -99,7 +99,7 @@ just for this purpose, so you'll need to sensure ``tastypie`` is in ``INSTALLED_
 To use this mechanism, the end user needs to specify an ``Authorization`` header. 
 Example::
 
-  Authorization: ApiToken 44b91beebc43209488502499d258b5b27bc7088e9e0e05cdd68ac4335f43a9172afd815e796e4dea
+  Authorization: Token 44b91beebc43209488502499d258b5b27bc7088e9e0e05cdd68ac4335f43a9172afd815e796e4dea
 
 The period time in which the token is valid can be set with the variable 
 ``TOKEN_VALID_TIME`` in ``settings.py``. Default is 3600 seconds (1 hour).
@@ -108,13 +108,26 @@ The user must create an ApiToken previously to start an interaction with the API
 A possible way is to define a ``SessionResource`` authenticated with any other method, 
 and define the ``ApiToken`` as a field in the session, then any other resource can be authenticated with temporary tokens, and only one endpoint (the ``SessionResource``)will receive sensitive data as username or password.
 
+Here we use an ``UserResource`` that just can list and show the users, you can made an resource that signup users or signup user in other way.
+
 Example::
 
     from tastypie.models import ApiToken
+    from tastypie.resources import ModelResource
     from tastypie.authorization import Authorization
     from tastypie.authentication import BasicAuthentication
     from tastypie.authentication import ApiTokenAuthentication
     from tastypie import fields
+    from django.contrib.auth.models import User
+
+    class UserResource(ModelResource):
+        class Meta(object):
+	    queryset = User.objects.all()
+	    resource_name = 'users'
+	    fields = ['username', 'email']
+	    allowed_methods = ['get']
+	    authorization = Authorization()
+	    authentication = ApiTokenAuthentication()
 
     class PublicSessionResource(ModelResource):
         user = fields.ToOneField(

--- a/docs/authentication_authorization.rst
+++ b/docs/authentication_authorization.rst
@@ -88,6 +88,79 @@ objects. Hooking it up looks like::
 
     models.signals.post_save.connect(create_api_key, sender=User)
 
+``ApiTokenAuthentication``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Another alternative to requiring sensitive data like password and even username, the 
+``ApiTokenAuthentication`` allows to collect a temporary token previously generated
+that will be valid for some period of time. Tastypie ships with a special  ``Model``
+just for this purpose, so you'll need to sensure ``tastypie`` is in ``INSTALLED_APPS``.
+
+To use this mechanism, the end user needs to specify an ``Authorization`` header. 
+Example::
+
+  Authorization: ApiToken 44b91beebc43209488502499d258b5b27bc7088e9e0e05cdd68ac4335f43a9172afd815e796e4dea
+
+The period time in which the token is valid can be set with the variable 
+``TOKEN_VALID_TIME`` in ``settings.py``. Default is 3600 seconds (1 hour).
+
+The user must create an ApiToken previously to start an interaction with the API.
+A possible way is to define a ``SessionResource`` authenticated with any other method, 
+and define the ``ApiToken`` as a field in the session, then any other resource can be authenticated with temporary tokens, and only one endpoint (the ``SessionResource``)will receive sensitive data as username or password.
+
+Example::
+
+    from tastypie.models import ApiToken
+    from tastypie.authorization import Authorization
+    from tastypie.authentication import BasicAuthentication
+    from tastypie.authentication import ApiTokenAuthentication
+    from tastypie import fields
+
+    class PublicSessionResource(ModelResource):
+        user = fields.ToOneField(
+	    'api.resources.UserResource', 'user', full=True)
+
+        class Meta(object):
+            queryset = ApiToken.objects.all()
+	    resource_name = 'public/sessions'
+	    fields = ['user', 'token']
+	    allowed_methods = ['post']
+	    authorization = Authorization()
+	    authentication = BasicAuthentication()
+	    always_return_data = True
+
+	def obj_create(self, bundle, request=None, **kwargs):
+	    " Create a new token for the session."
+	    bundle.obj = ApiToken.objects.create(user=request.user)
+	    return bundle
+
+	def dehydrate_resource_uri(self, bundle):
+	    return SessionResource().get_resource_uri(bundle.obj)
+
+    class SessionResource(ModelResource):
+        #: Information of the user.
+        user = fields.ToOneField(
+	    'api.resources.UserResource', 'user', full=True)
+
+        class Meta(object): 
+            queryset = ApiToken.objects.all()
+	    resource_name = 'sessions'
+    	    fields = ['user', 'token']
+	    allowed_methods = ['get', 'delete']
+            authorization = Authorization()
+            authentication = ApiTokenAuthentication()
+            always_return_data = True
+
+    class AnyResource(ModelResource)
+        class Meta(object): 
+            queryset = AnyModel.objects.all()
+	    resource_name = 'any'
+	    fields = ['field1', 'field2']
+	    allowed_methods = ['get', 'delete', 'post', 'put']
+            authorization = Authorization()
+            authentication = ApiTokenAuthentication()
+
+
 ``DigestAuthentication``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -125,6 +125,50 @@ class BasicAuthentication(Authentication):
         return request.META.get('REMOTE_USER', 'nouser')
 
 
+class ApiTokenAuthentication(Authentication):
+    """
+    Handles API Token auth, in which an user provide just a temporary
+    token using the 'HTTP-X' headers.
+    """
+
+    def _unauthorized(self):
+        response = HttpUnauthorized()
+        response['WWW-Authenticate'] = 'Token'
+        return response
+
+    def is_authenticated(self, request, **kwargs):
+        """
+        Finds the user with the API Token.
+        """
+
+        if not request.META.get('HTTP_AUTHORIZATION'):
+            return self._unauthorized()
+
+        try:
+            http_authorization = request.META['HTTP_AUTHORIZATION']
+            (auth_type, data) = http_authorization.split(' ', 1)
+
+            if auth_type != 'Token':
+                return self._unauthorized()
+        except:
+            return self._unauthorized()
+
+        # Get api_token.
+        from tastypie.models import ApiToken
+
+        try:
+            api_token = ApiToken.objects.get(token=data)
+        except ApiToken.DoesNotExist:
+            return self._unauthorized()
+
+        # Check if still valid.
+        if not api_token.is_valid():
+            return self._unauthorized()
+
+        request.user = api_token.user
+        return True
+
+
 class ApiKeyAuthentication(Authentication):
     """
     Handles API key auth, in which a user provides a username & API key.

--- a/tastypie/migrations/0002_auto__add_apitoken.py
+++ b/tastypie/migrations/0002_auto__add_apitoken.py
@@ -1,0 +1,88 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding model 'ApiToken'
+        db.create_table('tastypie_apitoken', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('user', self.gf('django.db.models.fields.related.ForeignKey')(related_name='api_tokens', to=orm['auth.User'])),
+            ('token', self.gf('django.db.models.fields.CharField')(default='', max_length=256, blank=True)),
+            ('last', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+        ))
+        db.send_create_signal('tastypie', ['ApiToken'])
+
+
+    def backwards(self, orm):
+        
+        # Deleting model 'ApiToken'
+        db.delete_table('tastypie_apitoken')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'blank': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'blank': 'True'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'blank': 'True'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'tastypie.apiaccess': {
+            'Meta': {'object_name': 'ApiAccess'},
+            'accessed': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'identifier': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'request_method': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '10', 'blank': 'True'}),
+            'url': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '255', 'blank': 'True'})
+        },
+        'tastypie.apikey': {
+            'Meta': {'object_name': 'ApiKey'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '256', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'api_key'", 'unique': 'True', 'to': "orm['auth.User']"})
+        },
+        'tastypie.apitoken': {
+            'Meta': {'object_name': 'ApiToken'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'token': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '256', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'api_tokens'", 'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['tastypie']

--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -16,10 +16,10 @@ class ApiAccess(models.Model):
     url = models.CharField(max_length=255, blank=True, default='')
     request_method = models.CharField(max_length=10, blank=True, default='')
     accessed = models.PositiveIntegerField()
-    
+
     def __unicode__(self):
         return u"%s @ %s" % (self.identifer, self.accessed)
-    
+
     def save(self, *args, **kwargs):
         self.accessed = int(time.time())
         return super(ApiAccess, self).save(*args, **kwargs)
@@ -29,31 +29,67 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
     import uuid
     from django.conf import settings
     from django.contrib.auth.models import User
-    
+
     class ApiKey(models.Model):
         user = models.OneToOneField(User, related_name='api_key')
         key = models.CharField(max_length=256, blank=True, default='')
         created = models.DateTimeField(default=datetime.datetime.now)
-        
+
         def __unicode__(self):
             return u"%s for %s" % (self.key, self.user)
-        
+
         def save(self, *args, **kwargs):
             if not self.key:
                 self.key = self.generate_key()
-            
+
             return super(ApiKey, self).save(*args, **kwargs)
-        
+
         def generate_key(self):
             # Get a random UUID.
             new_uuid = uuid.uuid4()
             # Hmac that beast.
             return hmac.new(str(new_uuid), digestmod=sha1).hexdigest()
-    
-    
+
     def create_api_key(sender, **kwargs):
         """
         A signal for hooking up automatic ``ApiKey`` creation.
         """
         if kwargs.get('created') is True:
             ApiKey.objects.create(user=kwargs.get('instance'))
+
+    class ApiToken(models.Model):
+        user = models.ForeignKey(User, related_name='api_tokens')
+        token = models.CharField(max_length=256, blank=True, default='')
+        last = models.DateTimeField(auto_now_add=True)
+
+        def __unicode__(self):
+            return u"Token %s for %s used at %s" % (
+                self.token, self.user, self.last)
+
+        def generate_token(self):
+            # Concatenate two uuids.
+            uuids = [uuid.uuid4() for i in range(2)]
+
+            # Get the hmac.
+            hmacs = [hmac.new(str(u), digestmod=sha1) for u in uuids]
+
+            # Return the concatenation.
+            return ''.join([h.hexdigest() for h in hmacs])
+
+        def save(self, *args, **kwargs):
+            if not self.token:
+                self.token = self.generate_token()
+
+            return super(ApiToken, self).save(*args, **kwargs)
+
+        def is_valid(self, now=datetime.datetime.now()):
+            " Check if token is still valid."
+
+            # Get valid period.
+            valid_time = int(getattr(settings, 'TOKEN_VALID_TIME', '3600'))
+
+            if (now - self.last) < datetime.timedelta(seconds=valid_time):
+                self.last = now
+                self.save()
+                return True
+            return False

--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -86,7 +86,7 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
             " Check if token is still valid."
 
             # Get valid period.
-            valid_time = int(getattr(settings, 'TOKEN_VALID_TIME', '3600'))
+            valid_time = getattr(settings, 'TOKEN_VALID_TIME', 3600)
 
             if (now - self.last) < datetime.timedelta(seconds=valid_time):
                 self.last = now

--- a/tests/core/tests/authentication.py
+++ b/tests/core/tests/authentication.py
@@ -1,11 +1,12 @@
 import base64
 import time
 import warnings
+import datetime
 from django.contrib.auth.models import User
 from django.core import mail
 from django.http import HttpRequest
 from django.test import TestCase
-from tastypie.authentication import Authentication, BasicAuthentication, ApiKeyAuthentication, DigestAuthentication, OAuthAuthentication
+from tastypie.authentication import Authentication, BasicAuthentication, ApiKeyAuthentication, DigestAuthentication, OAuthAuthentication, ApiTokenAuthentication
 from tastypie.http import HttpUnauthorized
 from tastypie.models import ApiKey, create_api_key
 
@@ -77,6 +78,46 @@ class BasicAuthenticationTestCase(TestCase):
         john_doe.save()
         request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % base64.b64encode('johndoe:pass:word')
         self.assertEqual(auth.is_authenticated(request), True)
+
+
+class ApiTokenAuthenticationTestCase(TestCase):
+    fixtures = ['note_testdata.json']
+
+    def setUp(self):
+        super(ApiTokenAuthenticationTestCase, self).setUp()
+        ApiKey.objects.all().delete()
+
+    def test_is_authenticated(self):
+        auth = ApiTokenAuthentication()
+        request = HttpRequest()
+
+        # Simulate sending the signal.
+        john_doe = User.objects.get(username='johndoe')
+        api_token = john_doe.api_tokens.create()
+
+        # No HTTP Basic auth details should fail.
+        auth_request = auth.is_authenticated(request)
+        self.assertEqual(isinstance(auth_request, HttpUnauthorized), True)
+
+        # HttpUnauthorized with auth type.
+        self.assertEqual(auth_request['WWW-Authenticate'].find('Token'), 0)
+
+        # No api_token details should fail.
+        self.assertEqual(isinstance(auth.is_authenticated(request), HttpUnauthorized), True)
+
+        # Wrong api_token details.
+        request.META['HTTP_AUTHORIZATION'] = 'Token aaaa'
+        self.assertEqual(isinstance(auth.is_authenticated(request), HttpUnauthorized), True)
+
+        # Correct api_token.
+        request.META['HTTP_AUTHORIZATION'] = 'Token %s' % (api_token.token, )
+        self.assertEqual(auth.is_authenticated(request), True)
+
+        # Invalid api_token.
+        api_token.last = datetime.datetime.now() - datetime.timedelta(1)
+        api_token.save()
+        request.META['HTTP_AUTHORIZATION'] = 'Token %s' % (api_token.token, )
+        self.assertEqual(isinstance(auth.is_authenticated(request), HttpUnauthorized), True)
 
 
 class ApiKeyAuthenticationTestCase(TestCase):


### PR DESCRIPTION
This pull-request add a new authentication method based on a temporary token that it is valid only some amount of time. This method use the "WWW-Authenticate" and "Http-Authorization" headers. A new token must be created in some "start session endpoint", and in each session a 'Http-Authorization' header with: "Token xxx" must be send.

Valid time is set in settings.py with TOKEN_VALID_TIME

Tests and migrations are included.