### PR TITLE
allow per-Resource setting of the Cache-Control header for AJAX

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -190,14 +190,6 @@ class Resource(object):
             try:
                 callback = getattr(self, view)
                 response = callback(request, *args, **kwargs)
-
-
-                if request.is_ajax():
-                    # IE excessively caches XMLHttpRequests, so we're disabling
-                    # the browser cache here.
-                    # See http://www.enhanceie.com/ie/bugs.asp for details.
-                    patch_cache_control(response, no_cache=True)
-
                 return response
             except (BadRequest, fields.ApiFieldError), e:
                 return http.HttpBadRequest(e.args[0])
@@ -976,7 +968,13 @@ class Resource(object):
         """
         desired_format = self.determine_format(request)
         serialized = self.serialize(request, data, desired_format)
-        return response_class(content=serialized, content_type=build_content_type(desired_format), **response_kwargs)
+        response = response_class(content=serialized, content_type=build_content_type(desired_format), **response_kwargs)
+        if request.is_ajax():
+            # IE excessively caches XMLHttpRequests, so we're disabling
+            # the browser cache here.
+            # See http://www.enhanceie.com/ie/bugs.asp for details.
+            patch_cache_control(response, no_cache=True)
+        return response
 
     def is_valid(self, bundle, request=None):
         """


### PR DESCRIPTION
This patch moves the `patch_cache_control()` call for AJAX from `wrap_view()` to `Resource.create_response()`.  This allows sub-Resources to replace the default `Cache-Control: no-cache`
setting for AJAX requests by overriding `create_response()`. It can be helpful to enable browser caching on a per-Resource basis.

The `core.tests.resources.ModelResourceTestCase.test_browser_cache()` test case already covers this nicely.
