### PR TITLE
log exceptions regardless of settings.DEBUG

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -229,15 +229,6 @@ class Resource(object):
         if isinstance(exception, (NotFound, ObjectDoesNotExist)):
             response_class = HttpResponseNotFound
 
-        if settings.DEBUG:
-            data = {
-                "error_message": unicode(exception),
-                "traceback": the_trace,
-            }
-            desired_format = self.determine_format(request)
-            serialized = self.serialize(request, data, desired_format)
-            return response_class(content=serialized, content_type=build_content_type(desired_format))
-
         # When DEBUG is False, send an error message to the admins (unless it's
         # a 404, in which case we check the setting).
         if not isinstance(exception, (NotFound, ObjectDoesNotExist)):
@@ -254,6 +245,15 @@ class Resource(object):
 
                 message = "%s\n\n%s" % (the_trace, request_repr)
                 mail_admins(subject, message, fail_silently=True)
+
+        if settings.DEBUG:
+            data = {
+                "error_message": unicode(exception),
+                "traceback": the_trace,
+            }
+            desired_format = self.determine_format(request)
+            serialized = self.serialize(request, data, desired_format)
+            return response_class(content=serialized, content_type=build_content_type(desired_format))
 
         # Prep the data going out.
         data = {


### PR DESCRIPTION

it's best if exceptions (via _handle_500) are logged regardless of settings.DEBUG. it's much easier to look at stack traces in the console or via file (if you have things configured to go to one) rather than always having to debug exceptions that have been returned to the calling client. 

it's not that big a deal when the calling client is a web browser (at least with jsonview,) but if you're calling with another device (iPad, android, ...) it's a pain to have to look there for the message. 