### PR TITLE
Don't throw ApiFieldError when callable attribute's queryset is empty.

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -688,14 +688,17 @@ class ToManyField(RelatedField):
 
         if isinstance(self.attribute, basestring):
             the_m2ms = getattr(bundle.obj, self.attribute)
+            
+            if not the_m2ms:
+                if not self.null:
+                    raise ApiFieldError("The model '%r' has an empty attribute '%s' and doesn't allow a null value." % (bundle.obj, self.attribute))
+
+                return []
+        
         elif callable(self.attribute):
             the_m2ms = self.attribute(bundle)
 
-        if not the_m2ms:
-            if not self.null:
-                raise ApiFieldError("The model '%r' has an empty attribute '%s' and doesn't allow a null value." % (bundle.obj, self.attribute))
-
-            return []
+        
 
         self.m2m_resources = []
         m2m_dehydrated = []


### PR DESCRIPTION
This is the simplest solution I found, it was taken from https://groups.google.com/group/django-tastypie/browse_thread/thread/e3e83c1db9b47a93

If there is a better way please advise, currently it seems that callable attributes are not usable without this fix.
Thanks.
