### PR TITLE
Add support for X-HTTP-Method-Override

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -478,7 +478,15 @@ class Resource(object):
         if allowed is None:
             allowed = []
 
+        # Normally we'll just use request.method to determine the request
+        # method. However, since some bad clients can't support all HTTP
+        # methods, we allow overloading POST requests with a
+        # X-HTTP-Method-Override header. This allows POST requests to
+        # masquerade as different methods.
         request_method = request.method.lower()
+        if request_method == 'post' and 'HTTP_X_HTTP_METHOD_OVERRIDE' in request.META:
+            request_method = request.META['HTTP_X_HTTP_METHOD_OVERRIDE'].lower()
+
         allows = ','.join(map(str.upper, allowed))
 
         if request_method == "options":

--- a/tests/core/tests/__init__.py
+++ b/tests/core/tests/__init__.py
@@ -14,3 +14,4 @@ from core.tests.serializers import *
 from core.tests.throttle import *
 from core.tests.utils import *
 from core.tests.validation import *
+from core.tests.xhmo import *

--- a/tests/core/tests/xhmo.py
+++ b/tests/core/tests/xhmo.py
@@ -1,0 +1,26 @@
+"""
+Tests that the X-HTTP-Method-Override header works.
+"""
+
+from django.http import HttpRequest
+from django.test import TestCase
+from core.tests.resources import NoteResource
+
+class XHMOTests(TestCase):
+    def test_method_check_respects_xhmo(self):
+        """The X-HTTP-Method-Override header should override POST requests"""
+        resource = NoteResource()
+        request = HttpRequest()
+        request.method = 'POST'
+        request.META['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'DELETE'
+        method = resource.method_check(request, resource._meta.allowed_methods)
+        self.assertEqual(method.lower(), 'delete')
+
+    def test_method_check_ignores_hxmo_on_non_post_requests(self):
+        """X-HTTP-Method-Override should only be respected on POSTs"""
+        resource = NoteResource()
+        request = HttpRequest()
+        request.method = 'GET'
+        request.META['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'DELETE'
+        method = resource.method_check(request, resource._meta.allowed_methods)
+        self.assertEqual(method.lower(), 'get')


### PR DESCRIPTION
I've only allowed XHMO to masquerade requests from POST to other methods -- you can't use it to turn a GET into a DELETE, for example. If you'd rather have full masquerading let me know and I'll change it.
