### PR TITLE
set 'Vary: Accept' on the response for caching

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -8,7 +8,7 @@ from django.core.urlresolvers import NoReverseMatch, reverse, resolve, Resolver4
 from django.db import transaction
 from django.db.models.sql.constants import QUERY_TERMS, LOOKUP_SEP
 from django.http import HttpResponse, HttpResponseNotFound
-from django.utils.cache import patch_cache_control
+from django.utils.cache import patch_cache_control, patch_vary_headers
 from tastypie.authentication import Authentication
 from tastypie.authorization import ReadOnlyAuthorization
 from tastypie.bundle import Bundle
@@ -192,6 +192,10 @@ class Resource(object):
                 callback = getattr(self, view)
                 response = callback(request, *args, **kwargs)
 
+                # our response (content-type) can vary based on the Accept
+                # header so we need to tell caches that so that they won't
+                # return the wrong (cached) version
+                patch_vary_headers(response, ('Accept',))
 
                 if request.is_ajax():
                     # IE excessively caches XMLHttpRequests, so we're disabling


### PR DESCRIPTION
since the "Content-Type" returned can change based on the "Accept" header "Vary: Accept" needs to be set on the response to prevent caches from (wrongly) returning an unexpected cached version.

not an issue when using format=XXX since that changes the path.

this also affects django's page_cache if/when it's used to do request/response-level caching of resources. doing this can result in HUGE performance gains, if your use-case can accept the behavior. currently i have to override wrap_view to "decorate" Resource.wrap_view with cache_page to do this (going to look to see if i can come up with a cleaner way to go about this.)
