### PR TITLE
Added django.http.http404 to the list of exceptions returning 404.

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned, 
 from django.core.urlresolvers import NoReverseMatch, reverse, resolve, Resolver404, get_script_prefix
 from django.db import transaction
 from django.db.models.sql.constants import QUERY_TERMS, LOOKUP_SEP
-from django.http import HttpResponse, HttpResponseNotFound
+from django.http import HttpResponse, HttpResponseNotFound, Http404
 from django.utils.cache import patch_cache_control
 from tastypie.authentication import Authentication
 from tastypie.authorization import ReadOnlyAuthorization
@@ -227,7 +227,7 @@ class Resource(object):
         the_trace = '\n'.join(traceback.format_exception(*(sys.exc_info())))
         response_class = http.HttpApplicationError
 
-        if isinstance(exception, (NotFound, ObjectDoesNotExist)):
+        if isinstance(exception, (NotFound, ObjectDoesNotExist, Http404)):
             response_class = HttpResponseNotFound
 
         if settings.DEBUG:


### PR DESCRIPTION
In the cookbook there is an example of overriding Resource.dispatch using Django's get_object_or_404: 

http://django-tastypie.readthedocs.org/en/latest/cookbook.html#nested-resources

Django raises a http404 exception in this case, which isn't listed in Resource._handle_500 as one of the exceptions to return a 404 status for, so a 500 status is returned.

This change adds http404 to the exceptions checked for, so that using Django's get_object_or_404 will return a correct http status.

Thanks for the awesome software!
