### PR TITLE
PATCH docs examples

### DIFF
--- a/docs/interacting.rst
+++ b/docs/interacting.rst
@@ -668,7 +668,7 @@ We should get back::
 
 The Accepted response means the server has accepted the request, but gives no details on the result. In order to see any created resources, we would need to do a get ``GET`` on the list endpoint. 
 
-This request is atomic, in that all operations succeed or fail. The request body can contain an ``objects`` list to containing the list of objects to be created or updated. If the object has a ``resource_uri`` field and there exists a model corresponding to that ``resource_uri``, it will be partially updated, otherwise it will be created.  The request body can also contain a ``deleted_objects`` list, which is a list resource_uris to be deleted.
+For detailed information on the format of a bulk request, see :ref:`patch-list`.
 
 
 You Did It!

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1380,6 +1380,9 @@ Calls ``obj_delete``.
 If the resource is deleted, return ``HttpNoContent`` (204 No Content).
 If the resource did not exist, return ``HttpNotFound`` (404 Not Found).
 
+
+.. _patch-list:
+
 ``patch_list``
 --------------
 


### PR DESCRIPTION
This pull request attempts to address #375. 

It adds an example of sending a PATCH request to both the detail and list endpoints, and a note on the PUT detail example about full representations. 
