### PR TITLE
Modifying Error Handling of ModelResource.obj_get()

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1778,7 +1778,7 @@ class ModelResource(Resource):
 
             return object_list[0]
         except ValueError:
-            raise NotFound("Invalid resource lookup data provided (mismatched type).")
+            raise BadRequest("Invalid resource lookup data provided (mismatched type).")
 
     def obj_create(self, bundle, request=None, **kwargs):
         """


### PR DESCRIPTION
Currently, if `obj_get` raises a ValueError when trying to lookup the object,
tastypie will return a 404 not found error along with an error message saying
that the object type was wrong.

This behavior is undesirable, as the 404 status code doesn't accurately explain
what happened to make the request fail.

Instead, I propose raising a BadRequest exception (like the other ModelResource
methods do), which returns an HTTP 400 (BAD REQUEST) signaling to the user that
the request was malformed.

There are no tests attached to this change because I couldn't find any tests
that already exercise this part of the codebase. I'd be happy to add something
to this patch if necessary to get it accepted.
