### PR TITLE
Add a custom name in objects collections

### DIFF
--- a/tastypie/paginator.py
+++ b/tastypie/paginator.py
@@ -15,7 +15,7 @@ class Paginator(object):
     ``total_count`` of resources seen and convenience links to the
     ``previous``/``next`` pages of data as available.
     """
-    def __init__(self, request_data, objects, resource_uri=None, limit=None, offset=0):
+    def __init__(self, request_data, objects, resource_uri=None, limit=None, offset=0, collection_name='objects'):
         """
         Instantiates the ``Paginator`` and allows for some configuration.
         
@@ -38,6 +38,7 @@ class Paginator(object):
         self.limit = limit
         self.offset = offset
         self.resource_uri = resource_uri
+        self.collection_name = collection_name
     
     def get_limit(self):
         """
@@ -165,6 +166,6 @@ class Paginator(object):
             meta['next'] = self.get_next(limit, offset, count)
 
         return {
-            'objects': objects,
+            self.collection_name: objects,
             'meta': meta,
         }

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -77,6 +77,7 @@ class ResourceOptions(object):
     include_resource_uri = True
     include_absolute_url = False
     always_return_data = False
+    collection_name = 'objects'
 
     def __new__(cls, meta=None):
         overrides = {}
@@ -1029,7 +1030,7 @@ class Resource(object):
         objects = self.obj_get_list(request=request, **self.remove_api_resource_names(kwargs))
         sorted_objects = self.apply_sorting(objects, options=request.GET)
 
-        paginator = self._meta.paginator_class(request.GET, sorted_objects, resource_uri=self.get_resource_list_uri(), limit=self._meta.limit)
+        paginator = self._meta.paginator_class(request.GET, sorted_objects, resource_uri=self.get_resource_list_uri(), limit=self._meta.limit, collection_name=self._meta.collection_name)
         to_be_serialized = paginator.page()
 
         # Dehydrate the bundles in preparation for serialization.

--- a/tests/core/tests/paginator.py
+++ b/tests/core/tests/paginator.py
@@ -156,3 +156,13 @@ class PaginatorTestCase(TestCase):
         self.assertEqual(meta['previous'], '/api/v1/notes/?slug__startswith=%E2%98%83&offset=0&limit=2&format=json')
         self.assertEqual(meta['next'], u'/api/v1/notes/?slug__startswith=%E2%98%83&offset=4&limit=2&format=json')
         self.assertEqual(meta['total_count'], 6)
+
+    def test_custom_collection_name(self):
+        paginator = Paginator({}, self.data_set, resource_uri='/api/v1/notes/', limit=20, offset=0, collection_name='notes')
+        meta = paginator.page()['meta']
+        self.assertEqual(meta['limit'], 20)
+        self.assertEqual(meta['offset'], 0)
+        self.assertEqual(meta['previous'], None)
+        self.assertEqual(meta['next'], None)
+        self.assertEqual(meta['total_count'], 6)
+        self.assertEqual(len(paginator.page()['notes']), 6)


### PR DESCRIPTION
This just add an option to change the name 'objects' in the paginator. 
Sorry no docs, I will try to have time this evening.
