### PR TITLE
Allow negative primary keys

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -284,8 +284,8 @@ class Resource(object):
         return [
             url(r"^(?P<resource_name>%s)%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('dispatch_list'), name="api_dispatch_list"),
             url(r"^(?P<resource_name>%s)/schema%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('get_schema'), name="api_get_schema"),
-            url(r"^(?P<resource_name>%s)/set/(?P<pk_list>\w[\w/;-]*)/$" % self._meta.resource_name, self.wrap_view('get_multiple'), name="api_get_multiple"),
-            url(r"^(?P<resource_name>%s)/(?P<pk>\w[\w/-]*)%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
+            url(r"^(?P<resource_name>%s)/set/(?P<pk_list>-?\w[\w/;-]*)/$" % self._meta.resource_name, self.wrap_view('get_multiple'), name="api_get_multiple"),
+            url(r"^(?P<resource_name>%s)/(?P<pk>-?\w[\w/-]*)%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
         ]
 
     def override_urls(self):

--- a/tests/basic/fixtures/initial_data.json
+++ b/tests/basic/fixtures/initial_data.json
@@ -1,6 +1,15 @@
 [
     {
         "fields": {
+            "username": "johndoes",
+            "email": "john@does.com",
+            "password": "this_is_not_a_valid_password_string"
+        },
+        "model": "auth.user",
+        "pk": -1
+    },
+    {
+        "fields": {
             "username": "johndoe",
             "email": "john@doe.com",
             "password": "this_is_not_a_valid_password_string"

--- a/tests/basic/tests/views.py
+++ b/tests/basic/tests/views.py
@@ -68,6 +68,23 @@ class ViewsTestCase(TestCase):
         self.assertEqual(obj['is_active'], True)
         self.assertEqual(obj['user'], '/api/v1/users/1/')
 
+    def test_negative_pk(self):
+        # Test single result
+        resp = self.client.get('/api/v1/users/-1/')
+        self.assertEqual(resp.status_code, 200)
+        obj = json.loads(resp.content)
+        self.assertEqual(obj['username'], 'johndoes')
+        self.assertEqual(obj['resource_uri'], '/api/v1/users/-1/')
+
+        # Test set of results
+        resp = self.client.get('/api/v1/users/set/-1;1/')
+        self.assertEqual(resp.status_code, 200)
+        obj = json.loads(resp.content)['objects']
+        self.assertEqual(len(obj), 2)
+        self.assertTrue(obj[0]['id'] in ("-1", "1"))
+        self.assertTrue(obj[1]['id'] in ("-1", "1"))
+
+
     def test_api_field_error(self):
         # When a field error is encountered, we should be presenting the message
         # back to the user.


### PR DESCRIPTION
Hi toastdriven (and others),

This commit allows primary keys to be negative (which Django _does_ allow). I've added a small unit-test and provided them with (hopefully) useful comments.

Kind regards,
Martijn