### PR TITLE
docs for a south + create_api_key signal error

### DIFF
--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -69,4 +69,18 @@ You can do this over an entire collection as well::
     curl -H 'Accept: application/json' 'http://localhost:8000/api/v1/entry/?limit=0' | \
     curl -H 'Content-Type: application/json' -X PUT --data @- "http://localhost:8000/api/v1/entry/"
 
+"Why is my syncdb with superuser failing with a DatabaseError?"
+=====================================================================
+
+More completely, this specific DatabaseError::
+
+    django.db.utils.DatabaseError: no such table: tastypie_apikey
+
+This is a side effect of the (disabled by default) ``create_api_key`` signal
+as described in the :ref:`authentication_authorization` section of the
+documentation when used in conjunction with South.
+
+To work around this issue,  you can disable the ``create_api_key`` signal
+until you have completed running syncdb --migrate for the first time.
+
 .. _Requests: http://python-requests.org


### PR DESCRIPTION
Document the error possible when attempting to syncdb a database
with the create_api_key signal installed in conjunction with South.
