### PR TITLE
Return value if Bundle was passed in to build_related_resource

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -582,7 +582,10 @@ class RelatedField(ApiField):
             'related_name': related_name,
         }
 
-        if isinstance(value, basestring):
+        if isinstance(value, Bundle):
+            # We got Bundle already so return it.
+            return value
+        elif isinstance(value, basestring):
             # We got a URI. Load the object and assign it.
             return self.resource_from_uri(self.fk_resource, value, **kwargs)
         elif hasattr(value, 'items'):


### PR DESCRIPTION
This occurs when you have PATCH request and a ToOne fields that gets filled in
with a Bundle object already.
