### PR TITLE
Fixes attribute error on patch_list

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1293,7 +1293,6 @@ class Resource(object):
                     # so this is a create-by-PUT equivalent.
                     data = self.alter_deserialized_detail_data(request, data)
                     bundle = self.build_bundle(data=dict_strip_unicode_keys(data))
-                    bundle.obj.pk = obj.pk
                     self.obj_create(bundle, request=request)
             else:
                 # There's no resource URI, so this is a create call just

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1809,7 +1809,7 @@ class ModelResourceTestCase(TestCase):
         request._read_started = False
 
         self.assertEqual(Note.objects.count(), 6)
-        request._raw_post_data = request._body = '{"objects": [{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back-again", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"}], "deleted_objects": ["/api/v1/notes/1/"]}'
+        request._raw_post_data = request._body = '{"objects": [{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back-again", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"}, {"resource_uri": "/api/v1/notes/2/", "content": "This is note 2."}], "deleted_objects": ["/api/v1/notes/1/"]}'
 
         resp = resource.patch_list(request)
         self.assertEqual(resp.status_code, 202)
@@ -1818,6 +1818,25 @@ class ModelResourceTestCase(TestCase):
         self.assertEqual(Note.objects.filter(is_active=True).count(), 4)
         new_note = Note.objects.get(slug='cat-is-back-again')
         self.assertEqual(new_note.content, "The cat is back. The dog coughed him up out back.")
+        updated_note = Note.objects.get(pk=2)
+        self.assertEqual(updated_note.content, "This is note 2.")
+
+    def test_patch_list_bad_resource_uri(self):
+        resource = NoteResource()
+        request = HttpRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'PATCH'
+        request._read_started = False
+
+        self.assertEqual(Note.objects.count(), 6)
+        request._raw_post_data = request._body = '{"objects": [{"resource_uri": "/api/v1/notes/99999/", "content": "This is an invalid resource_uri", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "invalid-uri", "title": "Invalid URI", "updated": "2010-04-03 20:05:00"}]}'
+
+        resp = resource.patch_list(request)
+        self.assertEqual(resp.status_code, 202)
+        self.assertEqual(resp.content, '')
+        self.assertEqual(Note.objects.count(), 7)
+        new_note = Note.objects.get(slug='invalid-uri')
+        self.assertEqual(new_note.content, "This is an invalid resource_uri")
 
     def test_patch_detail(self):
         self.assertEqual(Note.objects.count(), 6)


### PR DESCRIPTION
Also adds tests for a couple untested PATCH scenarios:
- Updating an existing resource
- Fallback creation of a resource with a non-existent `resource_uri` (which triggered the attribute error)
