### PR TITLE
Error creating required foreign key objects on obj_create

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1810,12 +1810,10 @@ class ModelResource(Resource):
         if bundle.errors:
             self.error_response(bundle.errors, request)
 
-        bundle.obj.save()
-
         # Save FKs just in case.
         self.save_related(bundle)
 
-        # After saving related object, we may need to update the parent again.
+        # Save parent
         bundle.obj.save()
 
         # Now pick up the M2M bits.
@@ -1959,6 +1957,8 @@ class ModelResource(Resource):
             # Because sometimes it's ``None`` & that's OK.
             if related_obj:
                 if field_object.related_name:
+                    if not bundle.obj.pk:
+                        bundle.obj.save()
                     setattr(related_obj, field_object.related_name, bundle.obj)
 
                 related_obj.save()

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -30,6 +30,8 @@ class Note(models.Model):
     def my_property(self):
         return 'my_property'
 
+class NoteWithEditor(Note):
+    editor = models.ForeignKey(User, related_name='notes_edited')
 
 class Subject(models.Model):
     notes = models.ManyToManyField(Note, related_name='subjects')


### PR DESCRIPTION
See the associated test for an example of how to trigger the error. I made a small change to get all the tests to pass, but I don't think it's the right one. 

It seems like reverse relations (`ToManyField`s with `related_name`) should be handled in `save_m2m` when you are sure the bundle object has a `pk`, instead of in `save_related` when the bundle object might not have been saved yet.
