### PR TITLE
add SECRET_KEY to tests/settings.py as it is required from Django 1.4

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 CACHE_BACKEND = 'locmem://'
+SECRET_KEY = 'verysecret'
 
 # to make sure timezones are handled correctly in Django>=1.4
 USE_TZ = True


### PR DESCRIPTION
- SECRET_KEY is required since Django 1.4, see
  https://docs.djangoproject.com/en/dev/releases/1.4/#secret-key-setting-is-required
