### PR TITLE
avoid double query on the_m2ms, 715 & 726

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -712,7 +712,7 @@ class ToManyField(RelatedField):
         elif callable(self.attribute):
             the_m2ms = self.attribute(bundle)
 
-        if not the_m2ms:
+        if the_m2ms is None:
             if not self.null:
                 raise ApiFieldError("The model '%r' has an empty attribute '%s' and doesn't allow a null value." % (previous_obj, attr))
 


### PR DESCRIPTION

the_m2ms is queried twice, once in an if and again in the for m2m in the_m2ms. if the_m2ms is None prevents the extra query, but may or may not be valid depending on what all values the_m2ms could hold.