### PR TITLE
tastypie.contrib.gis is missing in the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ setup(
         'tastypie.management',
         'tastypie.management.commands',
         'tastypie.migrations',
+        'tastypie.contrib',
+        'tastypie.contrib.gis',
     ],
     package_data={
         'tastypie': ['templates/tastypie/*'],


### PR DESCRIPTION
Current installation of the tastypie doesn't includes `contrib.gis` package, but it deserve to be included.
