### PR TITLE
Do not return datetime and time data with greater precision than supported by DB backend

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -355,7 +355,7 @@ class DateTimeField(ApiField):
         if isinstance(value, datetime.datetime):
             if DATABASE_IS_MYSQL:
                 # MySQL does not store fractions of seconds; create a new datetime with microseconds set to 0
-                return datetime.datetime(year=value.year, month=value.month, day=value.day, hour=value.hour, minute=value.minute, second=value.second)
+                return datetime.datetime(year=value.year, month=value.month, day=value.day, hour=value.hour, minute=value.minute, second=value.second, tzinfo=value.tzinfo)
 
         return value
 
@@ -799,7 +799,7 @@ class TimeField(ApiField):
         if isinstance(value, datetime.time):
             if DATABASE_IS_MYSQL:
                 # MySQL does not store fractions of seconds; create a new datetime with microseconds set to 0
-                return datetime.time(hour=value.hour, minute=value.minute, second=value.second)
+                return datetime.time(hour=value.hour, minute=value.minute, second=value.second, tzinfo=value.tzinfo)
         return value
 
     def to_time(self, s):


### PR DESCRIPTION
When using MySQL, datetime and time fields are not stored with sub-second precision. When POST/PUTing to tastypie with always_return_data, tastypie currently returns datetime and time values with the internal python precision, which in the case of MySQL is not the same.
