### PR TITLE
Fixes issue #449

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     package_data={
         'tastypie': ['templates/tastypie/*'],
     },
+    zip_safe=False,
     requires=[
         'mimeparse',
         'python_dateutil(>=1.5, < 2.0)',


### PR DESCRIPTION
Since django-tastypie contains a South `migrations` directory,
it must not be packaged as a file egg.
