### PR TITLE
Raise ApiFieldError on invalid datetimes

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -364,11 +364,15 @@ class DateTimeField(ApiField):
         value = super(DateTimeField, self).hydrate(bundle)
 
         if value and not hasattr(value, 'year'):
-            try:
-                # Try to rip a date/datetime out of it.
-                value = make_aware(parse(value))
-            except ValueError:
-                pass
+            if isinstance(value, basestring):
+                try:
+                    # Try to rip a date/datetime out of it.
+                    value = make_aware(parse(value))
+                except ValueError:
+                    raise ApiFieldError("Datetime provided to '%s' field doesn't appear to be a valid datetime string: '%s'" % (self.instance_name, value))
+
+            else:
+                raise ApiFieldError("Datetime provided to '%s' field must be a string: %s" % (self.instance_name, value))
 
         return value
 

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -568,6 +568,16 @@ class DateTimeFieldTestCase(TestCase):
         field_4.instance_name = 'datetime'
         self.assertEqual(field_4.hydrate(bundle_4), None)
 
+        bundle_5 = Bundle(data={'datetime': 'foo'})
+        field_5 = DateTimeField()
+        field_5.instance_name = 'datetime'
+        self.assertRaises(ApiFieldError, field_5.hydrate, bundle_5)
+
+        bundle_6 = Bundle(data={'datetime': ['a', 'list', 'used', 'to', 'crash']})
+        field_6 = DateTimeField()
+        field_6.instance_name = 'datetime'
+        self.assertRaises(ApiFieldError, field_6.hydrate, bundle_6)
+
 
 class UserResource(ModelResource):
     class Meta:


### PR DESCRIPTION
Currently, invalid datetimes are allowed to pass through `DateTimeField.hydrate()` without any indication on errors.

When strings like `'foo'` are hydrated in a DateTimeField, the string value is returned without any errors raised, even though it is not a valid datetime.

If someone (accidentally or maliciously) passes in a list, an AttributeError from deep within `dateutil.parser.parse()` is raised.

This change makes sure that what comes out of `hydrate()` for a `DateTimeField` is indeed a `datetime.datetime` object, otherwise an error is raised.
