### PR TITLE
Adhere to ISO8601 strict. Millisecond precision only on datetime.

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -124,7 +124,12 @@ class Serializer(object):
         if self.datetime_formatting == 'rfc-2822':
             return format_datetime(data)
 
-        return data.isoformat()
+        r = data.isoformat()
+        if data.microsecond:
+            r = r[:23] + r[26:]
+        if r.endswith('+00:00'):
+            r = r[:-6] + 'Z'
+        return r
 
     def format_date(self, data):
         """


### PR DESCRIPTION
Javascript Date and most js date libraries only adhere to ISO8601 strict, which means either second precision or millisecond precision only. However, `datetime.isoformat()` will return microsecond precision if available. This fix is taken from `django.core.serializers.json.DjangoJSONEncoder` -  https://github.com/django/django/blob/master/django/core/serializers/json.py
