### PR TITLE
New cookbook example for using resources in views with a valid resource_uri.

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -45,7 +45,8 @@ Using Your ``Resource`` In Regular Views
 In addition to using your resource classes to power the API, you can also use
 them to write other parts of your application, such as your views. For
 instance, if you wanted to encode user information in the page for some
-Javascript's use, you could do the following::
+Javascript's use, you could do the following. In this case, ``user_json`` will
+not include a valid ``resource_uri``::
 
     # views.py
     from django.shortcuts import render_to_response
@@ -63,6 +64,27 @@ Javascript's use, you could do the following::
             # Other things here.
             "user_json": ur.serialize(None, ur.full_dehydrate(ur_bundle), 'application/json'),
         })
+
+To include a valid ``resource_uri``, the resource must be associated
+with an ``tastypie.Api`` instance, as below::
+
+    # urls.py
+    from tastypie.api import Api
+    from myapp.api.resources import UserResource
+
+
+    my_api = Api(api_name='v0')
+    my_api.register(UserResource())
+
+::
+
+    # views.py
+    from myapp.urls import my_api
+
+
+    def user_detail(request, username):
+        ur = my_api.canonical_resource_for('user')
+        # continue as above...
 
 
 Using Non-PK Data For Your URLs


### PR DESCRIPTION
The cookbook example for using resources in views will generate an object with no valid ``resource_uri`` because it is not associated with ``tastypie.Api`` instance. This docs update shows how you can get a valid ``resource_uri`` field on an resource in views.