### PR TITLE
Fix paginator errors to include the bad input.

### DIFF
--- a/tastypie/paginator.py
+++ b/tastypie/paginator.py
@@ -67,10 +67,10 @@ class Paginator(object):
         try:
             limit = int(limit)
         except ValueError:
-            raise BadRequest("Invalid limit '%s' provided. Please provide a positive integer.")
+            raise BadRequest("Invalid limit '%s' provided. Please provide a positive integer." % limit)
 
         if limit < 0:
-            raise BadRequest("Invalid limit '%s' provided. Please provide an integer >= 0.")
+            raise BadRequest("Invalid limit '%s' provided. Please provide a positive integer >= 0." % limit)
 
         if self.max_limit and limit > self.max_limit:
             # If it's more than the max, we're only going to return the max.
@@ -96,10 +96,10 @@ class Paginator(object):
         try:
             offset = int(offset)
         except ValueError:
-            raise BadRequest("Invalid offset '%s' provided. Please provide an integer.")
+            raise BadRequest("Invalid offset '%s' provided. Please provide an integer." % offset)
 
         if offset < 0:
-            raise BadRequest("Invalid offset '%s' provided. Please provide an integer >= 0.")
+            raise BadRequest("Invalid offset '%s' provided. Please provide a positive integer >= 0." % offset)
 
         return offset
 

--- a/tests/core/tests/paginator.py
+++ b/tests/core/tests/paginator.py
@@ -114,10 +114,22 @@ class PaginatorTestCase(TestCase):
         self.assertEqual(paginator.get_limit(), 10)
 
         paginator.limit = -10
-        self.assertRaises(BadRequest, paginator.get_limit)
+        raised = False
+        try:
+            paginator.get_limit()
+        except BadRequest, e:
+            raised = e
+        self.assertTrue(raised)
+        self.assertEqual(str(raised), "Invalid limit '-10' provided. Please provide a positive integer >= 0.")
 
         paginator.limit = 'hAI!'
-        self.assertRaises(BadRequest, paginator.get_limit)
+        raised = False
+        try:
+            paginator.get_limit()
+        except BadRequest, e:
+            raised = e
+        self.assertTrue(raised)
+        self.assertEqual(str(raised), "Invalid limit 'hAI!' provided. Please provide a positive integer.")
 
         # Test the max_limit.
         paginator.limit = 1000
@@ -142,10 +154,22 @@ class PaginatorTestCase(TestCase):
         self.assertEqual(paginator.get_offset(), 10)
 
         paginator.offset= -10
-        self.assertRaises(BadRequest, paginator.get_offset)
+        raised = False
+        try:
+            paginator.get_offset()
+        except BadRequest, e:
+            raised = e
+        self.assertTrue(raised)
+        self.assertEqual(str(raised), "Invalid offset '-10' provided. Please provide a positive integer >= 0.")
 
         paginator.offset = 'hAI!'
-        self.assertRaises(BadRequest, paginator.get_offset)
+        raised = False
+        try:
+            paginator.get_offset()
+        except BadRequest, e:
+            raised = e
+        self.assertTrue(raised)
+        self.assertEqual(str(raised), "Invalid offset 'hAI!' provided. Please provide an integer.")
 
     def test_regression_nonqueryset(self):
         paginator = Paginator({}, ['foo', 'bar', 'baz'], limit=2, offset=0)


### PR DESCRIPTION
This changeset fixes a really minor problem where bad limits and offsets weren't correctly reported back in the Exception.
