### PR TITLE
Add cookbook example for pretty-printing JSON serializer.

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -294,6 +294,26 @@ values in camelCase instead::
 
         return underscored_data
 
+Pretty-printed JSON Serialization
+---------------------------------
+
+By default, Tastypie outputs JSON with no indentation or newlines (equivalent to calling
+:py:func:`json.dumps` with *indent* set to ``None``). You can override this
+behavior in a custom serializer::
+
+    from django.core.serializers import json
+    from django.utils import simplejson
+    from tastypie.serializers import Serializer
+
+    class PrettyJSONSerializer(Serializer):
+        json_indent = 2
+
+        def to_json(self, data, options=None):
+            options = options or {}
+            data = self.to_simple(data, options)
+            return simplejson.dumps(data, cls=json.DjangoJSONEncoder,
+                    sort_keys=True, ensure_ascii=False, indent=self.json_indent)
+
 Determining format via URL
 --------------------------
 


### PR DESCRIPTION
Documentation-only change as suggested in #479.
