### PR TITLE
Changed Resource.patch_list to respect always_return data.

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1297,6 +1297,8 @@ class Resource(object):
         if len(deserialized["objects"]) and 'put' not in self._meta.detail_allowed_methods:
             raise ImmediateHttpResponse(response=http.HttpMethodNotAllowed())
 
+        bundles_seen = []
+
         for data in deserialized["objects"]:
             # If there's a resource_uri then this is either an
             # update-in-place or a create-via-PUT.
@@ -1323,6 +1325,7 @@ class Resource(object):
                 data = self.alter_deserialized_detail_data(request, data)
                 bundle = self.build_bundle(data=dict_strip_unicode_keys(data))
                 self.obj_create(bundle, request=request)
+            bundles_seen.append(bundle)
 
         if len(deserialized.get('deleted_objects', [])) and 'delete' not in self._meta.detail_allowed_methods:
             raise ImmediateHttpResponse(response=http.HttpMethodNotAllowed())
@@ -1331,7 +1334,13 @@ class Resource(object):
             obj = self.get_via_uri(uri, request=request)
             self.obj_delete(request=request, _obj=obj)
 
-        return http.HttpAccepted()
+        if not self._meta.always_return_data:
+            return http.HttpAccepted()
+        else:
+            to_be_serialized = {}
+            to_be_serialized['objects'] = [self.full_dehydrate(bundle) for bundle in bundles_seen]
+            to_be_serialized = self.alter_list_data_to_serialize(request, to_be_serialized)
+            return self.create_response(request, to_be_serialized, response_class=http.HttpAccepted)
 
     def patch_detail(self, request, **kwargs):
         """

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1829,6 +1829,20 @@ class ModelResourceTestCase(TestCase):
         updated_note = Note.objects.get(pk=2)
         self.assertEqual(updated_note.content, "This is note 2.")
 
+    def test_patch_list_return_data(self):
+        always_resource = AlwaysDataNoteResource()
+        request = HttpRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'PATCH'
+        request._read_started = False
+        
+        self.assertEqual(Note.objects.count(), 6)
+        request._raw_post_data = request._body = '{"objects": [{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back-again", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"}, {"resource_uri": "/api/v1/notes/2/", "content": "This is note 2."}], "deleted_objects": ["/api/v1/notes/1/"]}'
+
+        resp = always_resource.patch_list(request)
+        self.assertEqual(resp.status_code, 202)
+        self.assertTrue(resp.content.startswith('{"objects": ['))
+
     def test_patch_list_bad_resource_uri(self):
         resource = NoteResource()
         request = HttpRequest()


### PR DESCRIPTION
`patch_list` does not respect `Meta.always_return_data = True`, `patch_detail` has already been fixed by #447. It will also finally close #298.
