### PR TITLE
Package is actually called `python-dateutil`, replace underscore with hyphen.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,11 @@ setup(
     zip_safe=False,
     requires=[
         'mimeparse',
-        'python_dateutil(>=1.5, < 2.0)',
+        'python-dateutil(>=1.5, < 2.0)',
     ],
     install_requires=[
         'mimeparse',
-        'python_dateutil >= 1.5, < 2.0',
+        'python-dateutil >= 1.5, < 2.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Even though `pip`, `easy_install` and PyPI also recognize the underscore, not every other possible tool in the chain does that (in my case, `localshop`, a local caching PyPI, failed to recognize the package).
