### PR TITLE
Update documentation showing use of can_update

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -230,6 +230,34 @@ resulting code will look something like::
         def apply_authorization_limits(self, request, object_list):
             return object_list.filter(user=request.user)
 
+Using read-only resources as foreign keys
+-----------------------------------------
+
+One might want to allow users to use a resource as a foreign key without
+allowing those users to modify that resource.  For instance,  we want an
+``ArticleResource`` which has ``allowed_methods = ['get']`` so users can only
+read an article.  We also want a ``CommentResource`` users can modify, which
+has an ``ArticleResource`` as a foreign key.  If we try just using
+``fields.ForeignKey(ArticleResource, 'article')``, creating/modifying a comment
+will fail, as we are not authorized to modify the article.
+
+To work around this, we can create a read-only subclass of ``ArticleResource``
+which has ``can_update`` always return ``False``.  For example::
+
+    # myapp/api/resources.py
+    class SafeArticleResource(ArticleResource):
+        class Meta:
+            queryset = Article.objects.all()
+            allowed_methods = ['get']
+            authorization = Authorization()
+            resource_name = 'article'
+        def can_update(self):
+            return False
+
+    class CommentResource(ModelResource):
+        article = fields.ForeignKey(SafeArticleResource, 'article')
+        ...
+
 camelCase JSON Serialization
 ----------------------------
 


### PR DESCRIPTION
Adds a simple example problem to the cookbook:
given an ArticleResource which should be read-only (i.e. only
allow "GET") and a CommentResource which has an ArticleResource
as a foreign key, how to let users set the ArticleResource foreign
key without running into authorization problems.

Fixes #480.
