### PR TITLE
Fix tests.core.tests.authentication.OAuthAuthenticationTestCase

### DIFF
--- a/tests/core/tests/authentication.py
+++ b/tests/core/tests/authentication.py
@@ -239,16 +239,12 @@ class OAuthAuthenticationTestCase(TestCase):
         }
         user = User.objects.create_user('daniel', 'test@example.com', 'password')
         request.META['Authorization'] = 'OAuth ' + ','.join([key+'='+value for key, value in request.REQUEST.items()])
-        resource, _ = Resource.objects.get_or_create(url='test', defaults={
-            'name': 'Test Resource'
-        })
         consumer, _ = Consumer.objects.get_or_create(key='123', defaults={
             'name': 'Test',
             'description': 'Testing...'
         })
         token, _ = Token.objects.get_or_create(key='foo', token_type=Token.ACCESS, defaults={
             'consumer': consumer,
-            'resource': resource,
             'secret': '',
             'user': user,
         })


### PR DESCRIPTION
Fixed tests.core.tests.authentication.OAuthAuthenticationTestCase because it was failing with one error.

```
======================================================================
ERROR: test_is_authenticated (core.tests.authentication.OAuthAuthenticationTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/mgbelisle/code/django-tastypie/tests/core/tests/authentication.py", line 253, in test_is_authenticated
    'user': user,
  File "/Users/mgbelisle/.pythonbrew/pythons/Python-2.7/lib/python2.7/site-packages/django/db/models/manager.py", line 134, in get_or_create
    return self.get_query_set().get_or_create(**kwargs)
  File "/Users/mgbelisle/.pythonbrew/pythons/Python-2.7/lib/python2.7/site-packages/django/db/models/query.py", line 447, in get_or_create
    obj = self.model(**params)
  File "/Users/mgbelisle/.pythonbrew/pythons/Python-2.7/lib/python2.7/site-packages/django/db/models/base.py", line 367, in __init__
    raise TypeError("'%s' is an invalid keyword argument for this function" % kwargs.keys()[0])
TypeError: 'resource' is an invalid keyword argument for this function

----------------------------------------------------------------------
```
