### PR TITLE
Security fix: use yaml.safe_load instead of yaml.load to prevent arbitrary python injection.

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -389,7 +389,7 @@ class Serializer(object):
         if yaml is None:
             raise ImproperlyConfigured("Usage of the YAML aspects requires yaml.")
 
-        return yaml.load(content, Loader=TastypieLoader)
+        return yaml.safe_load(content, Loader=TastypieLoader)
 
     def to_plist(self, data, options=None):
         """


### PR DESCRIPTION
As per https://groups.google.com/forum/?fromgroups#!topic/django-tastypie/i2aNGDHTUBI:

Everyone, 

   Several days ago, David B brought to my attention a security flaw 
in Tastypie's included `Serializer`. This flaw goes all the way back 
to early versions of Tastypie & affects _EVERYONE_. I recommend that 
you patch this immediately. 

Who It Affects: 
_ALL_ users of Tastypie likely have this bug present. You should 
update as soon as possible. 

The Flaw: 
Tastypie's included `Serializer` class included YAML serialization, 
which is not problem. However, the `Serializer` was using 
`yaml.load`, which can load _arbitary_ Python code in addition to 
the basic types. This was never the intended use, as I was unaware 
YAML (or perhaps just PyYAML) could do this. 

The Fix: 
The solution is simply to use `yaml.safe_load`, which only handles 
the simple types Tastypie is expecting anyway. 

How To Secure Yourself: 
- If you're on a git checkout, the fix was committed a couple days ago 
  when I was first made aware of it (https://github.com/toastdriven/ 
  django-tastypie/commit/e8af315211b07c8f48f32a063233cc3f76dd5bc2). 
  Please run a `git pull` & ensure you have that SHA. 
- If you're on a recent release, you can try applying the following 
  patch: https://gist.github.com/1330846. This should apply cleanly on 
  v0.9.9 (and may work on older releases). 
- If the patch doesn't work (or you can't apply the patch, say in 
  automated production deployments), you ccan create your own custom 
  `Serializer` in your codebase like so: 
# 

```
from tastypie import serializers 

class MySerializer(serializers.Serializer): 
    def from_yaml(self, content): 
        if yaml is None: 
            raise ImproperlyConfigured("Usage of the YAML aspects 
```

requires yaml.") 

```
        return yaml.safe_load(content) 

# Then in your resources... 
class MyResource(ModelResource): 
    # The usual fields & whatnot here... 

    class Meta: 
        serializer = MySerializer() 
```
# 

   As usual, I'd appreciate that any security flaws be pointed out to 
me first (not filing an issue or mailing the list). Sending me a 
message through GitHub is the best option to do so. If you have any 
concerns or questions, I'd be happy to address that in this thread. 

Daniel
