### PR TITLE
Fixed detail_uri_name is not used when generating resource_uri 

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2073,8 +2073,8 @@ class ModelResource(Resource):
         if isinstance(bundle_or_obj, Bundle):
             kwargs[self._meta.detail_uri_name] = getattr(bundle_or_obj.obj, self._meta.detail_uri_name)
         else:
-            kwargs[self._meta.detail_uri_name] = getattr(bundle_or_obj, self._meta.detail_uri_name)
-
+            kwargs[self._meta.detail_uri_name] = bundle_or_obj.id if self._meta.detail_uri_name is 'pk' else getattr(bundle_or_obj, self._meta.detail_uri_name) 
+            
         return kwargs
 
 


### PR DESCRIPTION
The returning resource_uri is still using pk, and this patch fix this problem. 
