### PR TITLE
CleanedDataFormValidation change to actually change data

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1866,8 +1866,10 @@ class ModelResource(Resource):
 
         for key, value in kwargs.items():
             setattr(bundle.obj, key, value)
-        bundle = self.full_hydrate(bundle)
+        # first - check whether bundle is valid, 
+        # because validation might change bundle
         self.is_valid(bundle,request)
+        bundle = self.full_hydrate(bundle)
 
         if bundle.errors:
             self.error_response(bundle.errors, request)

--- a/tastypie/validation.py
+++ b/tastypie/validation.py
@@ -101,7 +101,7 @@ class CleanedDataFormValidation(FormValidation):
         if form.is_valid():
             # We're different here & relying on having a reference to the same
             # bundle the rest of the process is using.
-            bundle.data = form.cleaned_data
+            bundle.data.update(form.cleaned_data)
             return {}
 
         # The data is invalid. Let's collect all the error messages & return


### PR DESCRIPTION
Docs state, that if you want to alter data that came and validated via form - you should use CleanedDataFormValidation.
As far as I understand it is not working correctly, at least during object creation. in obj_create is_valid is called after full_hydrate, so that the obj is already there and new field values from form validation do not make it there.
I suggest calling is_valid prior to calling full_hydrate to fix it. I also suggest using update for bundle.data, instead of assigning cleaned_data to it, so that it would not lose any of values, not present in form
