### PR TITLE
Make sure TestApiClient doesn't send unicode (proposed fix for #531)

### DIFF
--- a/tastypie/test.py
+++ b/tastypie/test.py
@@ -160,7 +160,7 @@ class TestApiClient(object):
         kwargs['content_type'] = content_type
 
         if data is not None:
-            kwargs['data'] = self.serializer.serialize(data, format=content_type)
+            kwargs['data'] = str(self.serializer.serialize(data, format=content_type))
 
         if authentication is not None:
             kwargs['HTTP_AUTHORIZATION'] = authentication


### PR DESCRIPTION
FakePayload doesn't seem to handle unicode

Fixes #531