### PR TITLE
Django dev JSONEncoder is now based on json

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -1,5 +1,6 @@
 import datetime
 from StringIO import StringIO
+import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers import json
@@ -335,7 +336,11 @@ class Serializer(object):
         """
         options = options or {}
         data = self.to_simple(data, options)
-        return simplejson.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True, ensure_ascii=False)
+
+        if django.get_version() >= '1.5':
+            return json.json.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True, ensure_ascii=False)
+        else:
+            return simplejson.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True, ensure_ascii=False)
 
     def from_json(self, content):
         """


### PR DESCRIPTION
Djando dev breaks Tastypie serialization. Tastypie uses Django `json.JSONEncoder`, which was based on simplejson in previous versions, but it's now based on json, which doesn't accept a keyword argument
`namedtuple_as_object` anymore.

This raises this runtime error:

```
__init__() got an unexpected keyword argument 'namedtuple_as_object'
```

So in Django 1.5 we need to pass `JSONEncoder` to json, instead of simplejson.

See my comments on the commit in Django that introduced this change:
https://github.com/django/django/commit/cec6bd5a59547dc97fe98975c570fc27a1e970be#django-core-serializers-json-py-P46

I'm not sure if this should be fixed in Django or Tastypie, meanwhile we can have Tastypie working with latest Django dev version with this patch.

Cheers,
Miguel
