### PR TITLE
Removing the Manager dependency in ToManyField.dehydrate()

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -721,9 +721,8 @@ class ToManyField(RelatedField):
         self.m2m_resources = []
         m2m_dehydrated = []
 
-        # TODO: Also model-specific and leaky. Relies on there being a
-        #       ``Manager`` there.
-        for m2m in the_m2ms.all():
+        m2m_objs = the_m2ms if isinstance(the_m2ms, (list, tuple)) else list(the_m2ms.all())
+        for m2m in m2m_objs:
             m2m_resource = self.get_related_resource(m2m)
             m2m_bundle = Bundle(obj=m2m, request=bundle.request)
             self.m2m_resources.append(m2m_resource)


### PR DESCRIPTION
In [fields.py:726](/toastdriven/django-tastypie/blob/master/tastypie/fields.py#L726) `ToManyField.dehydrate()` assumes `the_m2m` to be a Manager. At that point, it only needs a list of objects to dehydrate. Thus, IMHO, it's better and more general to be able to handle a list or tuple of objects.

This way, we can manipulate the list of objects to return in the model layer, in case we need it.


E.g.:
```python
## models.py
import random
from django.db import models

UserProfile(models.Model):
    nickname = models.CharField(max_length=100, blank=True, null=True)

Visits(models.Model):
    visitor = models.ForeignKey(UserProfile, related_name="visitor")

    @property
    def guesses(self):
        potential_visitors = list(UserProfile.object.all()[:9])
        potential_visitors.append(self.visitor)
        random.shuffle(potential_visitors)
        return potential_visitors

## resources.py
from tastypie import fields
from tastypie.resources import ModelResource

class UserProfileResource(ModelResource):
    class Meta(BaseMeta):
        queryset = UserProfile.objects.all()

class VisitResource(ModelResource):
    visitor = fields.ForeignKey(FriendResource, 'visitor', full=True)
    guesses = fields.ToManyField(FriendResource, 'guesses', \
                                 readonly=True, full=True, null=True)

    class Meta(BaseMeta):
        queryset = Visit.objects.all()[:10]
```