### PR TITLE
Problem with ForeignKey form validation.

### DIFF
--- a/tastypie/validation.py
+++ b/tastypie/validation.py
@@ -56,8 +56,10 @@ class FormValidation(Validation):
                 kwargs['instance'] = bundle.obj
 
             kwargs['data'] = model_to_dict(bundle.obj)
+        
+        data.update(kwargs['data'])
+        kwargs['data'] = data
 
-        kwargs['data'].update(data)
         return kwargs
 
     def is_valid(self, bundle, request=None):


### PR DESCRIPTION
If you try to validate form with ForeignKey like this:

``` python

class CitationResource(BaseResource):
    book = fields.ForeignKey('api.resource.books.BookResource', 'book')
    part = fields.CharField(attribute='part', default=None)

    class Meta:
        fields = ['book', 'part']
        queryset = Citation.objects.all()
        validation = FormValidation(form_class=CitationForm)

class CitationForm(forms.ModelForm):
    class Meta:
        model = Citation

```

We have error in book field, because self.data['book'] == '/api/book/1', not Book object. 
This path solve this problem.

PS. Sorry for my english ;(
