### PR TITLE
Avoid to call full_hydrate when bundle.obj contains detail_uri_name in obj_update

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1885,7 +1885,7 @@ class ModelResource(Resource):
         """
         A ORM-specific implementation of ``obj_update``.
         """
-        if not bundle.obj or not bundle.obj.pk:
+        if not bundle.obj or not getattr(bundle.obj,self._meta.detail_uri_name):
             # Attempt to hydrate data from kwargs before doing a lookup for the object.
             # This step is needed so certain values (like datetime) will pass model validation.
             try:


### PR DESCRIPTION
In obj_update, if bundle.obj contains self._meta.detail_uri_name, it's not necessary to create empty object and do full_hydrate.
