### PR TITLE
Add support for cookie based authentication

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,6 +60,7 @@ Contributors:
 * Julien Bouquillon (revolunet) for authentication and authorization docs fixes.
 * Andrey Voronov (eyvoro) for fixing a typo in the AUTHORS file.
 * D.B. Tsai (dbtsai) for a fix relating to ``detail_uri_kwargs``.
+* Mahendra M (mahendra) for adding cookie based authentication support
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/docs/authentication_authorization.rst
+++ b/docs/authentication_authorization.rst
@@ -123,6 +123,14 @@ should be included in ``INSTALLED_APPS``.
 
 .. _`this post`: http://www.nerdydork.com/basic-authentication-on-mod_wsgi.html
 
+``CookieAuthentication``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This authentication scheme uses cookies to check a user's credentials.
+This scheme is useful in web pages, which make use of REST APIs to
+access/modify data. In such cases, the browser can use the session cookie
+for authentication.
+
 ``OAuthAuthentication``
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -414,8 +414,14 @@ class CookieAuthentication(object):
     This is beneficial when the APIs are being used within browsers
     """
 
+    def _unauthorized(self):
+        return HttpUnauthorized()
+
     def is_authenticated(self, request, **kwargs):
-        return request.user.is_authenticated()
+        if not request.user.is_authenticated():
+            return self._unauthorized()
+
+        return True
 
     def get_identifier(self, request):
         """


### PR DESCRIPTION
If a client is already authenticated using django's auth framework, we can rely on it to do the auth.

This is useful where a JS web UI is developed over the tastypie REST APIs.
