### PR TITLE
"'set' object has no attribute 'keys'"

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1725,7 +1725,8 @@ class ModelResource(Resource):
 
         if hasattr(self._meta, 'queryset'):
             # Get the possible query terms from the current QuerySet.
-            query_terms = self._meta.queryset.query.query_terms.keys()
+            if hasattr(self._meta.queryset.query.query_terms, 'keys'):
+                query_terms = self._meta.queryset.query.query_terms.keys()
         else:
             query_terms = QUERY_TERMS.keys()
 


### PR DESCRIPTION
When calling an 'overview' action, you'd get an error that the function
'keys' isn't available. This will add an additional check so we'll be
able to fetch the data we need.

Error log:

{"error_message": "'set' object has no attribute 'keys'", "traceback": "Traceback (most recent call last):\n\n  File \"/Library/Python/2.7/site-packages/django_tastypie-0.9.12_alpha-py2.7.egg/tastypie/resources.py\", line 196, in wrapper\n    response = callback(request, _args, *_kwargs)\n\n  File \"/Library/Python/2.7/site-packages/django_tastypie-0.9.12_alpha-py2.7.egg/tastypie/resources.py\", line 417, in dispatch_list\n    return self.dispatch('list', request, *_kwargs)\n\n  File \"/Library/Python/2.7/site-packages/django_tastypie-0.9.12_alpha-py2.7.egg/tastypie/resources.py\", line 446, in dispatch\n    response = method(request, *_kwargs)\n\n  File \"/Library/Python/2.7/site-packages/django_tastypie-0.9.12_alpha-py2.7.egg/tastypie/resources.py\", line 1099, in get_list\n    objects = self.obj_get_list(request=request, **self.remove_api_resource_names(kwargs))\n\n  File \"/Library/Python/2.7/site-packages/django_tastypie-0.9.12_alpha-py2.7.egg/tastypie/resources.py\", line 1842, in obj_get_list\n    applicable_filters = self.build_filters(filters=filters)\n\n  File \"/Library/Python/2.7/site-packages/django_tastypie-0.9.12_alpha-py2.7.egg/tastypie/resources.py\", line 1728, in build_filters\n    query_terms = self._meta.queryset.query.query_terms.keys()\n\nAttributeError: 'set' object has no attribute 'keys'\n"}
