### PR TITLE
get_multiple now calls alter_detail_data_to_serialize for consistency.

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1468,6 +1468,7 @@ class Resource(object):
                 obj = self.obj_get(request, **{self._meta.detail_uri_name: identifier})
                 bundle = self.build_bundle(obj=obj, request=request)
                 bundle = self.full_dehydrate(bundle)
+                bundle = self.alter_detail_data_to_serialize(request, bundle)
                 objects.append(bundle)
             except ObjectDoesNotExist:
                 not_found.append(identifier)


### PR DESCRIPTION
Fixes issue #452.  It seems that `get_multiple` should call `alter_detail_data_to_serialize` to be consistent with `get_detail.`  Both are used for requesting detail objects.
