### PR TITLE
[FEATURE] add support for ALL or ALL_WITH_RELATIONS as filtering or ordering

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -573,6 +573,11 @@ The inner ``Meta`` class allows for class-level configuration of how the
 
   Keys should be the fieldnames as strings while values should be a list of
   accepted filter types.
+  
+  Also may be set to ``tastypie.constants.ALL`` or 
+  ``tastypie.constants.ALL_WITH_RELATIONS`` to enable all filters on all fields 
+  or all filters with relations on all fields.
+  
 
 ``ordering``
 ------------
@@ -584,6 +589,8 @@ The inner ``Meta`` class allows for class-level configuration of how the
   by the ``order_by`` GET parameter, you can specify either the ``fieldname``
   (ascending order) or ``-fieldname`` (descending order).
 
+  Also may be set to ``tastypie.constants.ALL`` to enable ordering on all fields.
+  
 ``object_class``
 ----------------
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -707,8 +707,7 @@ class NoteResource(ModelResource):
             return '/api/v1/notes/'
 
         return '/api/v1/notes/%s/' % bundle_or_obj.obj.id
-
-
+        
 class LightlyCustomNoteResource(NoteResource):
     class Meta:
         resource_name = 'noteish'
@@ -884,6 +883,12 @@ class RelatedNoteResource(ModelResource):
         fields = ['title', 'slug', 'content', 'created', 'is_active']
 
 
+class FilterNote(RelatedNoteResource):
+    class Meta(RelatedNoteResource.Meta):
+        resource_name = 'filternotes'
+        filtering = ALL
+        ordering = ALL
+        
 class AnotherSubjectResource(ModelResource):
     notes = fields.ToManyField(DetailedNoteResource, 'notes')
 
@@ -1507,7 +1512,19 @@ class ModelResourceTestCase(TestCase):
 
         # Make sure that fields that don't have attributes can't be filtered on.
         self.assertRaises(InvalidFilterError, resource_4.build_filters, filters={'notes__hello_world': 'News'})
-
+        
+        resource_filter = FilterNote()
+        filters = {
+            'title__exact': "BLAM",
+            "content__exact": "VOOM",
+            "subjects__name": "Nome"
+        }
+        # All allowed but related
+        self.assertEqual(resource_filter.build_filters(filters=filters), {
+            'title__exact': "BLAM",
+            "content__exact": "VOOM"
+        })
+    
     def test_apply_sorting(self):
         resource = NoteResource()
 
@@ -1593,7 +1610,13 @@ class ModelResourceTestCase(TestCase):
         object_list = resource_2.obj_get_list()
         ordered_list = resource_2.apply_sorting(object_list, options={'order_by': ['-user__username', 'title']})
         self.assertEqual([obj.id for obj in ordered_list], [2, 1, 6, 4])
-
+        
+        resource_all = FilterNote()
+        object_list = resource_all.obj_get_list()
+        ordered = resource_all.apply_sorting(object_list, options={'order_by': 'title'})
+        # should allow since all set
+        self.assertEqual([obj.id for obj in ordered], [2, 1, 6, 3, 5, 4])
+        
     def test_get_list(self):
         resource = NoteResource()
         request = HttpRequest()


### PR DESCRIPTION
This allows for the meta options filtering and ordering to be set to `ALL` or `ALL_WITH_RELATIONS` to enable filtering or ordering across all fields or filtering across all fields with their relations instead of having to control these settings field by field.

Includes tests and docs.
