### PR TITLE
Filter using objects, not just strings.

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1678,18 +1678,18 @@ class ModelResource(Resource):
 
         return [self.fields[field_name].attribute]
 
-    def filter_value_to_python(self, value, field_name, filters, filter_expr,
-            filter_type):
+    def filter_value_to_python(self, value, field_name, filters=None,
+            filter_expr=None, filter_type=None):
         """
         Turn the string ``value`` into a python object.
         """
         # Simple values
         if value in ['true', 'True', True]:
-            value = True
+            return True
         elif value in ['false', 'False', False]:
-            value = False
+            return False
         elif value in ('nil', 'none', 'None', None):
-            value = None
+            return None
 
         # Split on ',' if not empty string and either an in or range filter.
         if filter_type in ('in', 'range') and len(value):
@@ -1700,6 +1700,18 @@ class ModelResource(Resource):
                     value.extend(part.split(','))
             else:
                 value = value.split(',')
+
+            to_python = self.filter_value_to_python
+            # We just use None to ensure the to_python call is just a
+            # string -> python object conversion.
+            return [to_python(v, field_name, None, None, None) for v in value]
+
+        # Attempt to use the associated Field object to convert the value to a
+        # python object.
+        try:
+            value = self.fields[field_name].convert(value)
+        except:
+            pass
 
         return value
 


### PR DESCRIPTION
Previously, we were sending qs.filter() only string values (excepting the simple values True, False and None).

This fixes #385 for me.  #385 is an issue with string-value based date filtering, not necessarily with tastypie.  Previously we would pass filter() something that looked like {'key__gte': '2012-06-25T22:21:30'}.  At least for me, in Django 1.3.0, a filter() using an ISO8601 date string just doesn't work -- it needs to look like '2012-06-25 22:21:30' for it to work.  I'm guessing this is because of django.conf.global_settings.DATETIME_INPUT_FORMATS, which doesn't support ISO8601.

So maybe we should be filtering with a datetime object and not just a string?  I use the associated Field object's convert() method to turn the string into a python object.
