### PR TITLE
Fix headings in `docs/resources.rst`

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -633,7 +633,7 @@ The inner ``Meta`` class allows for class-level configuration of how the
   ``False``.
 
 ``always_return_data``
-------------------------
+----------------------
 
   Specifies all HTTP methods (except ``DELETE``) should return a serialized form
   of the data. Default is ``False``.
@@ -646,13 +646,13 @@ The inner ``Meta`` class allows for class-level configuration of how the
   with a body containing all the data in a serialized form.
 
 ``collection_name``
-------------~~~~~~~
+-------------------
 
   Specifies the collection of objects returned in the ``GET`` list will be
   named. Default is ``objects``.
 
 ``detail_uri_name``
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
   Specifies the name for the regex group that matches on detail views. Defaults
   to ``pk``.


### PR DESCRIPTION
I've noticed that some headings were not properly marked up while reading the documentation
so I fixed them for you.