### PR TITLE
Added warning to docs regarding mod_wsgi and Authorization HTTP header with ApiKeyAuthentication.

### DIFF
--- a/docs/authentication_authorization.rst
+++ b/docs/authentication_authorization.rst
@@ -106,6 +106,15 @@ objects. Hooking it up looks like::
 
     models.signals.post_save.connect(create_api_key, sender=User)
 
+.. warning::
+
+  If you're using Apache & ``mod_wsgi``, you will need to enable
+  ``WSGIPassAuthorization On``, otherwise ``mod_wsgi`` strips out the
+  ``Authorization`` header. See `this post`_ for details (even though it
+  only mentions Basic auth).
+
+.. _`this post`: http://www.nerdydork.com/basic-authentication-on-mod_wsgi.html
+
 ``DigestAuthentication``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Added a short warning for Authorizarion header and ApiKeyAuthentication in a similar style to the existing basic/digest HTTP auth warnings when using Apache and mod_wsgi.
