### PR TITLE
Support for X-HTTP-Method-Override

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -435,6 +435,8 @@ class Resource(object):
         throttling, method lookup) surrounding most CRUD interactions.
         """
         allowed_methods = getattr(self._meta, "%s_allowed_methods" % request_type, None)
+        if 'HTTP_X_HTTP_METHOD_OVERRIDE' in request.META:
+            request.method = request.META['HTTP_X_HTTP_METHOD_OVERRIDE']
         request_method = self.method_check(request, allowed=allowed_methods)
         method = getattr(self, "%s_%s" % (request_method, request_type), None)
 


### PR DESCRIPTION
This header allows to do one type of requests as another. Useful when Tastypie is in use with a server/proxy that doesn't support some kind of HTTP request.

For example Heroku doesn't allow at the moment PATCH requests, this way we can do a PATCH as a POST request.

This was once submitted but closed, see GH-351. This patch merges with current django-tastypie upstream.

Cheers,
Miguel
