### PR TITLE
Fix callable attributes in ToOneField with tests

### DIFF
--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -656,6 +656,13 @@ class ToOneFieldTestCase(TestCase):
         self.assertEqual(user_bundle.data['username'], u'johndoe')
         self.assertEqual(user_bundle.data['email'], u'john@doe.com')
 
+    def test_dehydrate_with_callable(self):
+        note = Note.objects.get(pk=1)
+        bundle = Bundle(obj=note)
+
+        field_1 = ToOneField(UserResource, lambda bundle: User.objects.get(pk=1))
+        self.assertEqual(field_1.dehydrate(bundle), '/api/v1/users/1/')
+
     def test_hydrate(self):
         note = Note()
         bundle = Bundle(obj=note)


### PR DESCRIPTION
This fixes the issue outlined in #355
