### PR TITLE
Raise InvalidFilter on unlisted model field

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1737,10 +1737,15 @@ class ModelResource(Resource):
         else:
             query_terms = QUERY_TERMS.keys()
 
+        model_fields = map(lambda x:x.name, self._meta.queryset.model._meta.fields)
+
         for filter_expr, value in filters.items():
             filter_bits = filter_expr.split(LOOKUP_SEP)
             field_name = filter_bits.pop(0)
             filter_type = 'exact'
+
+            if field_name in model_fields and field_name not in self.fields:
+                raise InvalidFilterError("Invalid field in filtering %s" % field_name)
 
             if not field_name in self.fields:
                 # It's not a field we know about. Move along citizen.

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1489,6 +1489,9 @@ class ModelResourceTestCase(TestCase):
         # Make sure that fields that don't have attributes can't be filtered on.
         self.assertRaises(InvalidFilterError, resource_4.build_filters, filters={'notes__hello_world': 'News'})
 
+        # Filtering on a model field not listed within the Resource fields
+        self.assertRaises(InvalidFilterError, resource_4.build_filters, filters={'name': 'News'})
+
     def test_apply_sorting(self):
         resource = NoteResource()
 


### PR DESCRIPTION
When filtering on a model field unlisted within resource fields, an exception should be raised to warn the user. Otherwise he could think filtering is working while it actually isn't, potentially hitting some nasty silent bugs.

This has been commented on IRC with @issackelly.

Cheers,
Miguel
