### PR TITLE
Fix some docs formatting

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -646,13 +646,13 @@ The inner ``Meta`` class allows for class-level configuration of how the
   with a body containing all the data in a serialized form.
 
 ``collection_name``
-------------~~~~~~~
+-------------------
 
   Specifies the collection of objects returned in the ``GET`` list will be
   named. Default is ``objects``.
 
 ``detail_uri_name``
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
   Specifies the name for the regex group that matches on detail views. Defaults
   to ``pk``.


### PR DESCRIPTION
there was a ~ where there should have been -
