### PR TITLE
Allow newer versions of dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django>=1.0.0
 mimeparse>=0.1.3
-python-dateutil==1.5
+python-dateutil>=2.1
 lxml
 PyYAML
 python-digest

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,11 @@ setup(
     zip_safe=False,
     requires=[
         'mimeparse',
-        'dateutil(>=1.5, < 2.0)',
+        'dateutil(>=1.5, !=2.0)',
     ],
     install_requires=[
         'mimeparse',
-        'python_dateutil >= 1.5, < 2.0',
+        'python_dateutil >= 1.5, != 2.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,4 @@ python-digest
 biplist
 pyyaml
 mimeparse>=0.1.3
-python-dateutil==1.5
+python-dateutil>=2.1


### PR DESCRIPTION
python-dateutil was changed to >=1.5,<2.0 because with 2.0 the author dropped support for Python 2.x and moved onto 3.x. With 2.1 he has brought back 2.x support via the six library. This change allows using any version of python-dateutil >=1.5, except for 2.0 which won't work on Python 2.x
