### PR TITLE
Fix for exception raised when using DummyCache

### DIFF
--- a/tastypie/throttle.py
+++ b/tastypie/throttle.py
@@ -83,7 +83,7 @@ class CacheThrottle(BaseThrottle):
         
         # Weed out anything older than the timeframe.
         minimum_time = int(time.time()) - int(self.timeframe)
-        times_accessed = [access for access in cache.get(key) if access >= minimum_time]
+        times_accessed = [access for access in cache.get(key,[]) if access >= minimum_time]
         cache.set(key, times_accessed, self.expiration)
         
         if len(times_accessed) >= int(self.throttle_at):


### PR DESCRIPTION
Note that even though this should not happen since cache.add(key,[]) should make sure there's something in the cache for key, the DummyCache doesn't store any keys therefore cache.get(key) returns None which throws an exception
