### PR TITLE
[Bugfix] Fixed Paginator.max_limit (default=1000) to respect settings.API_MAX_LIMIT_PER_PAGE

### DIFF
--- a/tests/core/tests/paginator.py
+++ b/tests/core/tests/paginator.py
@@ -160,6 +160,19 @@ class PaginatorTestCase(TestCase):
         paginator = Paginator({}, self.data_set, limit=20, offset=0, max_limit=10)
         self.assertEqual(paginator.get_limit(), 10)
 
+        # Test the global max limit
+        paginator = Paginator({}, self.data_set, limit=20, offset=0)
+        settings.API_MAX_LIMIT_PER_PAGE = 10000
+        paginator.limit = 20000
+        self.assertEqual(paginator.get_limit(), 10000)
+
+        # Test that if a limit is passed into the Paginator instance,
+        #   it will defer to that
+        paginator = Paginator({}, self.data_set, limit=20, offset=0, max_limit=10)
+        paginator.limit = 20000
+        self.assertEqual(paginator.get_limit(), 10)
+
+
     def test_offset(self):
         paginator = Paginator({}, self.data_set, limit=20, offset=0)
 


### PR DESCRIPTION
Changing the setting `API_LIMIT_PER_PAGE` will still be limited by the arbitrary number on the initialization of `Paginator`, currently @ 1000.

By setting the default value to `None`, and checking to see if a value is set on instantiation, the `Paginator.max_limit` property will default, if available, to the setting `API_MAX_LIMIT_PER_PAGE`.  If that's not available, it will set max_limit to 1000.

This will give priority to the property set on the `Resource`, but will still allow a global `max_limit` for those who wish to set it.

In reference to commit 0379aa3

Address issues #572 #218
