### PR TITLE
Regression in the paginator module

### DIFF
--- a/tastypie/paginator.py
+++ b/tastypie/paginator.py
@@ -115,8 +115,9 @@ class Paginator(object):
         """
         Slices the result set to the specified ``limit`` & ``offset``.
         """
+        # If it's zero, return everything.
         if limit == 0:
-            raise BadRequest("Invalid limit '%s' provided. Please provide a positive, non-zero, integer." % limit)
+            return self.objects[offset:]
 
         return self.objects[offset:offset + limit]
 


### PR DESCRIPTION
As stated in the documentation, we can set the API_LIMIT_PER_PAGE in order to do not use any pagination by default. (See: http://django-tastypie.readthedocs.org/en/latest/settings.html#api-limit-per-page)

This commit https://github.com/toastdriven/django-tastypie/commit/f407a58d15f2290dd79c73df4d23354b2201a3da broke this feature. 

Here's a regression patch.
