### PR TITLE
See issue 597

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -335,7 +335,7 @@ class Serializer(object):
         """
         options = options or {}
         data = self.to_simple(data, options)
-        return simplejson.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True, ensure_ascii=False)
+        return simplejson.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True, ensure_ascii=True)
 
     def from_json(self, content):
         """


### PR DESCRIPTION
https://github.com/toastdriven/django-tastypie/issues/597

During the calculations of request parameters in `patch` (tastypie/test.py), 'content_length' is
being calculated based on the length of an ascii version of `patch_data`. When the json that was
being passed to WSGI was being made, simplejson was returning a JSON that contained a unicode
string.  The unicode JSON, having more bytes per character, was not being fully read into
_raw_post_data because `content_length` didn't account for the extra bytes in unicode. This caused
non-valid JSON to be sent to json.loads on the other side of the request. This patch forces the
created JSON to always be ascii.
