### PR TITLE
See pull request https://github.com/toastdriven/django-tastypie/pull/646...

### DIFF
--- a/tastypie/test.py
+++ b/tastypie/test.py
@@ -161,6 +161,9 @@ class TestApiClient(object):
 
         if data is not None:
             kwargs['data'] = self.serializer.serialize(data, format=content_type)
+            if content_type == "application/json":
+                kwargs['data'] = str(kwargs['data'])
+
 
         if authentication is not None:
             kwargs['HTTP_AUTHORIZATION'] = authentication


### PR DESCRIPTION
.... Instead of modifying core tastypie stuff, this patch coerces the serialized JSON to an ASCII string in the test client.
