### PR TITLE
ValueError handled in deserialize method

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -367,8 +367,11 @@ class Resource(object):
 
         Mostly a hook, this uses the ``Serializer`` from ``Resource._meta``.
         """
-        deserialized = self._meta.serializer.deserialize(data, format=request.META.get('CONTENT_TYPE', 'application/json'))
-        return deserialized
+        try:
+            deserialized = self._meta.serializer.deserialize(data, format=request.META.get('CONTENT_TYPE', 'application/json'))
+            return deserialized
+        except ValueError, e:
+            raise BadRequest("Invalid data sent: %s" % e)
 
     def alter_list_data_to_serialize(self, request, data):
         """

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -672,9 +672,15 @@ class ResourceTestCase(TestCase):
         request.method = 'POST'
         request.raw_post_data = '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"'
 
-        with self.assertRaises(BadRequest) as er:
-            deserialized = resource.deserialize(request, request.raw_post_data)
+        result = False
 
+        try:
+            deserialized = resource.deserialize(request, request.raw_post_data)
+        except BadRequest:
+            result = True
+
+        self.assertTrue(result)
+            
 
 # ====================
 # Model-based tests...

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -665,6 +665,16 @@ class ResourceTestCase(TestCase):
         output = mangled.alter_list_data_to_serialize(request, data)
         self.assertEqual(output, {'testobjects': [{'abc': 123, 'hello': 'world'}]})
 
+    def test_invalid_json_deserialization(self):
+        resource = BasicResource()
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'POST'
+        request.raw_post_data = '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"'
+
+        with self.assertRaises(BadRequest) as er:
+            deserialized = resource.deserialize(request, request.raw_post_data)
+
 
 # ====================
 # Model-based tests...


### PR DESCRIPTION
When I do POST with bad JSON, I receive 500. Wouldn't it be nicer to handle it in deserialize@resources.py, so I'd get for eg.:

400 BAD REQUEST:
Invalid data sent: Expecting , delimiter: line 1 column 180 (char 180)