### PR TITLE
Using create_response to create the responses in Resource._handle_500 

### DIFF
--- a/tastypie/http.py
+++ b/tastypie/http.py
@@ -8,11 +8,7 @@ class HttpCreated(HttpResponse):
     status_code = 201
 
     def __init__(self, *args, **kwargs):
-        location = ''
-
-        if 'location' in kwargs:
-            location = kwargs['location']
-            del(kwargs['location'])
+        location = kwargs.pop('location', '')
 
         super(HttpCreated, self).__init__(*args, **kwargs)
         self['Location'] = location

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -246,9 +246,7 @@ class Resource(object):
                 "error_message": unicode(exception),
                 "traceback": the_trace,
             }
-            desired_format = self.determine_format(request)
-            serialized = self.serialize(request, data, desired_format)
-            return response_class(content=serialized, content_type=build_content_type(desired_format))
+            return self.create_response(request, data, response_class=response_class)
 
         # When DEBUG is False, send an error message to the admins (unless it's
         # a 404, in which case we check the setting).
@@ -273,9 +271,7 @@ class Resource(object):
         data = {
             "error_message": getattr(settings, 'TASTYPIE_CANNED_ERROR', "Sorry, this request could not be processed. Please try again later."),
         }
-        desired_format = self.determine_format(request)
-        serialized = self.serialize(request, data, desired_format)
-        return response_class(content=serialized, content_type=build_content_type(desired_format))
+        return self.create_response(request, data, response_class=response_class)
 
     def _build_reverse_url(self, name, args=None, kwargs=None):
         """

--- a/tastypie/utils/mime.py
+++ b/tastypie/utils/mime.py
@@ -4,13 +4,13 @@ import mimeparse
 def determine_format(request, serializer, default_format='application/json'):
     """
     Tries to "smartly" determine which output format is desired.
-    
+
     First attempts to find a ``format`` override from the request and supplies
     that if found.
-    
+
     If no request format was demanded, it falls back to ``mimeparse`` and the
     ``Accepts`` header, allowing specification that way.
-    
+
     If still no format is found, returns the ``default_format`` (which defaults
     to ``application/json`` if not provided).
     """
@@ -18,11 +18,11 @@ def determine_format(request, serializer, default_format='application/json'):
     if request.GET.get('format'):
         if request.GET['format'] in serializer.formats:
             return serializer.get_mime_for_format(request.GET['format'])
-    
+
     # If callback parameter is present, use JSONP.
-    if request.GET.has_key('callback'):
+    if 'callback' in request.GET:
         return serializer.get_mime_for_format('jsonp')
-    
+
     # Try to fallback on the Accepts header.
     if request.META.get('HTTP_ACCEPT', '*/*') != '*/*':
         formats = list(serializer.supported_formats) or []
@@ -31,10 +31,10 @@ def determine_format(request, serializer, default_format='application/json'):
         # more information.
         formats.reverse()
         best_format = mimeparse.best_match(formats, request.META['HTTP_ACCEPT'])
-        
+
         if best_format:
             return best_format
-    
+
     # No valid 'Accept' header/formats. Sane default.
     return default_format
 
@@ -45,5 +45,5 @@ def build_content_type(format, encoding='utf-8'):
     """
     if 'charset' in format:
         return format
-    
+
     return "%s; charset=%s" % (format, encoding)


### PR DESCRIPTION
This one of the changes needed to be able to customize response format to smth like {"status": response_status_code, "errors": [{"code": error_code, "message": error_message, "traceback": traceback_if_allowed},], "data": {...}}