### PR TITLE
Changed date formatting to return non-localized dates

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -7,7 +7,7 @@ from django.utils import simplejson
 from django.utils.encoding import force_unicode
 from tastypie.bundle import Bundle
 from tastypie.exceptions import UnsupportedFormat
-from tastypie.utils import format_datetime, format_date, format_time, make_naive
+from tastypie.utils import format_datetime, format_date, format_time
 try:
     import lxml
     from lxml.etree import parse as parse_xml
@@ -120,7 +120,6 @@ class Serializer(object):
 
         Default is ``iso-8601``, which looks like "2010-12-16T03:02:14".
         """
-        data = make_naive(data)
         if self.datetime_formatting == 'rfc-2822':
             return format_datetime(data)
 

--- a/tastypie/utils/formatting.py
+++ b/tastypie/utils/formatting.py
@@ -2,6 +2,7 @@ import email
 import datetime
 import time
 from django.utils import dateformat
+from django.utils.feedgenerator import rfc2822_date
 from tastypie.utils.timezone import make_aware, make_naive, aware_datetime
 
 # Try to use dateutil for maximum date-parsing niceness. Fall back to
@@ -16,7 +17,7 @@ def format_datetime(dt):
     """
     RFC 2822 datetime formatter
     """
-    return dateformat.format(make_naive(dt), 'r')
+    return rfc2822_date(make_naive(dt))
 
 def format_date(d):
     """

--- a/tastypie/utils/formatting.py
+++ b/tastypie/utils/formatting.py
@@ -3,7 +3,7 @@ import datetime
 import time
 from django.utils import dateformat
 from django.utils.feedgenerator import rfc2822_date
-from tastypie.utils.timezone import make_aware, make_naive, aware_datetime
+from tastypie.utils.timezone import make_aware, aware_datetime
 
 # Try to use dateutil for maximum date-parsing niceness. Fall back to
 # hard-coded RFC2822 parsing if that's not possible.
@@ -17,7 +17,7 @@ def format_datetime(dt):
     """
     RFC 2822 datetime formatter
     """
-    return rfc2822_date(make_naive(dt))
+    return rfc2822_date(dt)
 
 def format_date(d):
     """


### PR DESCRIPTION
Hello!

I have made some changes in the date formatting.

The formatting is currently handled by the old django function that has an unsolved bug which is
described here: https://code.djangoproject.com/ticket/9762. The problem is that the function returns
localized date and that has unwanted consequences. For example it is impossible to automatically parse dates on the client-side if you are using languages other than English. 

I replaced the old function with the `rfc2822_date` function from the django's feedgenerator library.
This function works properly and also takes care of the time zones so the old `make_naive` function was removed as it is no longer needed.
