### PR TITLE
Change OAuthAuthentication to use storage method to get user

### DIFF
--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -428,10 +428,11 @@ class OAuthAuthentication(Authentication):
                 return oauth_provider.utils.send_oauth_error(e)
 
             if consumer and token:
-                if not self.check_active(token.user):
+                user = store.get_user_for_access_token(request, oauth_request, token)
+                if not self.check_active(user):
                     return False
 
-                request.user = token.user
+                request.user = user
                 return True
 
             return oauth_provider.utils.send_oauth_error(oauth2.Error(_('You are not allowed to access this resource.')))


### PR DESCRIPTION
`oauth_provider.store` has a method `get_user_for_access_token` that retrieves the user object for an access token. the default implementation just returns `token.user`, but i have my own implementation which does a few other things.

this patch changes OAuthAuthentication to use this method instead of accessing `token.user` directly.