### PR TITLE
Adding tests for obj_update with identifiers

### DIFF
--- a/tests/core/fixtures/note_testdata.json
+++ b/tests/core/fixtures/note_testdata.json
@@ -30,6 +30,15 @@
 
     {
         "fields": {
+            "date": "2012-09-07",
+            "username": "MARAUJOP"
+        },
+        "model": "core.daterecord",
+        "pk": 1
+    },
+
+    {
+        "fields": {
             "author": 1,
             "title": "First Post!",
             "slug": "first-post",

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -4,6 +4,11 @@ from django.db import models
 from tastypie.utils import now, aware_datetime
 
 
+class DateRecord(models.Model):
+    date = models.DateField()
+    username = models.CharField(max_length=20)
+
+
 class Note(models.Model):
     author = models.ForeignKey(User, related_name='notes', blank=True, null=True)
     title = models.CharField(max_length=100)

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -25,7 +25,7 @@ from tastypie.serializers import Serializer
 from tastypie.throttle import CacheThrottle
 from tastypie.utils import aware_datetime, make_naive, now
 from tastypie.validation import Validation, FormValidation
-from core.models import Note, NoteWithEditor, Subject, MediaBit, AutoNowNote
+from core.models import Note, NoteWithEditor, Subject, MediaBit, AutoNowNote, DateRecord
 from core.tests.mocks import MockRequest
 from core.utils import SimpleHandler
 
@@ -669,6 +669,15 @@ class ResourceTestCase(TestCase):
 # ====================
 # Model-based tests...
 # ====================
+
+class DateRecordResource(ModelResource):
+    class Meta:
+        queryset = DateRecord.objects.all()
+        always_return_data = True
+
+    def hydrate_username(self, bundle):
+        bundle.data['username'] = bundle.data['username'].upper()
+        return bundle
 
 
 class NoteResource(ModelResource):
@@ -1768,6 +1777,30 @@ class ModelResourceTestCase(TestCase):
         self.assertEqual(Note.objects.count(), 7)
         new_note = Note.objects.get(slug='cat-is-back')
         self.assertEqual(new_note.author, None)
+
+    def test_put_detail_with_identifiers(self):
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'PUT'
+        request.raw_post_data = '{"is_active": true, "username": "whatever"}'
+        date_record_resource = DateRecordResource()
+        resp = date_record_resource.put_detail(request, username="maraujop")
+
+        self.assertEqual(resp.status_code, 202)
+        data = json.loads(resp.content)
+        self.assertEqual(data['username'], "MARAUJOP")
+
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'PUT'
+        request.raw_post_data = '{"time": "whatever", "username": "different"}'
+        date_record_resource = DateRecordResource()
+        resp = date_record_resource.put_detail(request, date="2012-09-07")
+
+        self.assertEqual(resp.status_code, 202)
+        data = json.loads(resp.content)
+        self.assertEqual(data['date'], "2012-09-07T00:00:00")
+        self.assertEqual(data['username'], "DIFFERENT")
 
     def test_post_list(self):
         self.assertEqual(Note.objects.count(), 6)


### PR DESCRIPTION
Adding tests for exercising `obj_update` when grabbing an object using its uri identifiers.

<a href="https://github.com/toastdriven/django-tastypie/blob/5397dec04fe83092a56ba14a843731f2aa08184d/tastypie/resources.py#L1918-1929">These lines</a> cover this special case and there is no test case for them currently. If you comment out those lines and run the whole Tastypie's test suite, it will pass.

This tests will help refactoring `obj_update` to avoid side effects that prevent calling `full_hydrate` several times without performance hit. Related to #390

Cheers,
Miguel
