### PR TITLE
Escape \u2028 and \u2029 in JSONP.

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -352,9 +352,16 @@ class Serializer(object):
         """
         Given some Python data, produces JSON output wrapped in the provided
         callback.
+
+        Due to a difference between JSON and Javascript, two
+        newline characters, \u2028 and \u2029, need to be escaped.
+        See http://timelessrepo.com/json-isnt-a-javascript-subset for
+        details.
         """
         options = options or {}
-        return '%s(%s)' % (options['callback'], self.to_json(data, options))
+        json = self.to_json(data, options)
+        json = json.replace(u'\u2028', u'\\u2028').replace(u'\u2029', u'\\u2029')
+        return u'%s(%s)' % (options['callback'], json)
 
     def to_xml(self, data, options=None):
         """

--- a/tests/core/tests/serializers.py
+++ b/tests/core/tests/serializers.py
@@ -256,6 +256,21 @@ class SerializerTestCase(TestCase):
 
         sample_1 = self.get_sample1()
         options = {'callback': 'myCallback'}
+        serialized = serializer.to_jsonp(sample_1, options=options)
+        serialized_json = serializer.to_json(sample_1)
+        self.assertEqual('myCallback(%s)' % serialized_json,
+                         serialized)
+
+    def test_invalid_jsonp_characters(self):
+        """
+        The newline characters \u2028 and \u2029 need to be escaped
+        in JSONP.
+        """
+        serializer = Serializer()
+
+        jsonp = serializer.to_jsonp({'foo': u'Hello \u2028\u2029world!'},
+                                    {'callback': 'callback'})
+        self.assertEqual(jsonp, u'callback({"foo": "Hello \\u2028\\u2029world!"})')
 
     def test_to_plist(self):
         if not biplist:


### PR DESCRIPTION
This is for #682, but I'd like to get a review on this, since the problem is really non-obvious. 

I tested this in a browser, with it failing before and not after. 
