### PR TITLE
Enable Q object in apply_filters now with test

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1211,6 +1211,10 @@ This needs to be implemented at the user level.
 ``ModelResource`` includes a full working version specific to Django's
 ``Models``.
 
+As the parameter ``applicable_filters`` ``ModelResource``.``apply_filters``
+accepts either a dictionary that will be passed as kwargs to the
+``filter`` method of the provided ``QuerySet`` or a ``Q``-object.
+
 ``obj_get_list``
 ----------------
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -7,6 +7,7 @@ from django.conf.urls.defaults import patterns, url
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned, ValidationError
 from django.core.urlresolvers import NoReverseMatch, reverse, resolve, Resolver404, get_script_prefix
 from django.db import transaction
+from django.db.models import Q
 from django.db.models.sql.constants import QUERY_TERMS
 from django.http import HttpResponse, HttpResponseNotFound, Http404
 from django.utils.cache import patch_cache_control, patch_vary_headers
@@ -1847,6 +1848,8 @@ class ModelResource(Resource):
         The default simply applies the ``applicable_filters`` as ``**kwargs``,
         but should make it possible to do more advanced things.
         """
+        if isinstance(applicable_filters, Q):
+           return self.get_object_list(request).filter(applicable_filters)
         return self.get_object_list(request).filter(**applicable_filters)
 
     def get_object_list(self, request):

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -14,6 +14,7 @@ from django.http import HttpRequest, QueryDict, Http404
 from django.test import TestCase
 from django.utils import dateformat
 from django.utils import simplejson as json
+from django.db.models import Q
 from tastypie.authentication import BasicAuthentication
 from tastypie.authorization import Authorization
 from tastypie.bundle import Bundle
@@ -2117,6 +2118,24 @@ class ModelResourceTestCase(TestCase):
             'created__lte': datetime.date(2010, 6, 30),
         }
         notes = nr.apply_filters(mock_request, filters)
+        self.assertEqual(len(notes), 2)
+        self.assertEqual(notes[0].title, u'First Post!')
+        self.assertEqual(notes[1].title, u'Another Post')
+
+    def test_apply_filters_using_q(self):
+        nr = NoteResource()
+        mock_request = MockRequest()
+
+        q = Q(title=u"Granny's Gone")
+        notes = nr.apply_filters(mock_request, q)
+        self.assertEqual(len(notes), 1)
+        self.assertEqual(notes[0].title, u"Granny's Gone")
+
+        q = Q(
+            title__icontains=u"post",
+            created__lte=datetime.date(2010, 6, 30)
+        )
+        notes = nr.apply_filters(mock_request, q)
         self.assertEqual(len(notes), 2)
         self.assertEqual(notes[0].title, u'First Post!')
         self.assertEqual(notes[1].title, u'Another Post')


### PR DESCRIPTION
This adds a test and some documentation to @guocb's pull request 'Enable Q object in apply_filters'

https://github.com/toastdriven/django-tastypie/pull/677

I cherry-picked the commit from the original pull request.
