### PR TITLE
Moved X-HTTP-Method-Override into method_check in order to support custom methods

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -456,9 +456,6 @@ class Resource(object):
         """
         allowed_methods = getattr(self._meta, "%s_allowed_methods" % request_type, None)
 
-        if 'HTTP_X_HTTP_METHOD_OVERRIDE' in request.META:
-            request.method = request.META['HTTP_X_HTTP_METHOD_OVERRIDE']
-
         request_method = self.method_check(request, allowed=allowed_methods)
         method = getattr(self, "%s_%s" % (request_method, request_type), None)
 
@@ -524,6 +521,9 @@ class Resource(object):
         """
         if allowed is None:
             allowed = []
+
+        if 'HTTP_X_HTTP_METHOD_OVERRIDE' in request.META:
+            request.method = request.META['HTTP_X_HTTP_METHOD_OVERRIDE']
 
         request_method = request.method.lower()
         allows = ','.join(map(str.upper, allowed))


### PR DESCRIPTION
Some time ago support for X-HTTP-Method-Override was added (https://github.com/toastdriven/django-tastypie/pull/593). 

We're using AWS Load Balancer and they block our PATCH requests, so we tried to use this method.

The problem is that we have lots of custom methods, similar to the one noted in the docs: http://django-tastypie.readthedocs.org/en/latest/cookbook.html#adding-search-functionality

So I just moved the override method to `method_check`, now everything is working like a charm!

Rgds.
