### PR TITLE
Patch get_multiple to do only one query for ModelResource

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -65,6 +65,7 @@ Contributors:
 * Vladimir Volodin (vvolodin) for patching ToManyField callable attributes.
 * Mike Urbanski (mcu) for patching ``Paginator.get_limit``.
 * Jason Brownbridge (jbrownbridge) for patching multiple ``offset/limit`` params appearing in pagination URIs.
+* Brice Gelineau for patching ``get_multiple``
 
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1544,7 +1544,8 @@ Should return a HttpResponse (200 OK).
 Returns a serialized list of resources based on the identifiers
 from the URL.
 
-Calls ``obj_get`` to fetch only the objects requested. This method
+Try to call obj_get_multiple to fetch all objects in one go. Fallbacks to
+``obj_get`` if the previous method is not implemented. This method
 only responds to HTTP GET.
 
 Should return a HttpResponse (200 OK).

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -422,6 +422,10 @@ class ResourceTestCase(TestCase):
         basic = BasicResource()
         self.assertRaises(NotImplementedError, basic.obj_get, pk=1)
 
+    def test_obj_get_multiple(self):
+        basic = BasicResource()
+        self.assertRaises(NotImplementedError, basic.obj_get_multiple, [1])
+
     def test_obj_create(self):
         basic = BasicResource()
         bundle = Bundle()
@@ -2164,6 +2168,28 @@ class ModelResourceTestCase(TestCase):
         self.assertEqual(related_obj.author.username, u'johndoe')
         self.assertEqual(related_obj.title, u'First Post!')
         self.assertEqual(list(related_obj.subjects.values_list('id', flat=True)), [1, 2])
+
+    def test_obj_get_multiple(self):
+        notes = NoteResource().obj_get_multiple(identifiers=[1, 2])
+        self.assertEqual(len(notes), 2)
+        self.assertEqual(notes[0].is_active, True)
+        self.assertEqual(notes[0].title, u'First Post!')
+        self.assertEqual(notes[1].is_active, True)
+        self.assertEqual(notes[1].title, u'Another Post')
+
+        customs = VeryCustomNoteResource().obj_get_multiple(identifiers=[1, 2])
+        self.assertEqual(len(customs), 2)
+        self.assertEqual(customs[0].is_active, True)
+        self.assertEqual(customs[0].title, u'First Post!')
+        self.assertEqual(customs[0].author.username, u'johndoe')
+        self.assertEqual(customs[1].is_active, True)
+        self.assertEqual(customs[1].title, u'Another Post')
+        self.assertEqual(customs[1].author.username, u'johndoe')
+
+        relateds = RelatedNoteResource().obj_get_multiple(identifiers=[1])
+        self.assertEqual(len(relateds), 1)
+        self.assertEqual(relateds[0].content, u'This is my very first post using my shiny new API. Pretty sweet, huh?')
+        self.assertEqual(list(relateds[0].subjects.values_list('id', flat=True)), [1, 2])
 
     def test_uri_fields(self):
         with_abs_url = WithAbsoluteURLNoteResource()


### PR DESCRIPTION
The get_multiple function does one query per object. When dealing with multiple objects, that's a huge performance hit.
The patch updates the method to call a dedicated function and fallbacks on fetching all resources independantly if needed.
