### PR TITLE
Properly check if model instance's pk is set

### DIFF
--- a/tastypie/validation.py
+++ b/tastypie/validation.py
@@ -51,7 +51,7 @@ class FormValidation(Validation):
 
         kwargs = {'data': {}}
 
-        if hasattr(bundle.obj, 'pk'):
+        if hasattr(bundle.obj, 'pk') and bundle.obj.pk:
             if issubclass(self.form_class, ModelForm):
                 kwargs['instance'] = bundle.obj
 


### PR DESCRIPTION
FormValidation is improperly checking whether we are editing an instance of creating one.
It's checking for presence of pk, but it should check if pk is True, as per  https://docs.djangoproject.com/en/dev/ref/models/instances/?from=olddocs#how-django-knows-to-update-vs-insert
