### PR TITLE
reverse sort the URLs from `Api`

### DIFF
--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -98,7 +98,7 @@ class Api(object):
             url(r"^(?P<api_name>%s)%s$" % (self.api_name, trailing_slash()), self.wrap_view('top_level'), name="api_%s_top_level" % self.api_name),
         ]
 
-        for name in sorted(self._registry.keys()):
+        for name in sorted(self._registry.keys(), reverse=True):
             self._registry[name].api_name = self.api_name
             pattern_list.append((r"^(?P<api_name>%s)/" % self.api_name, include(self._registry[name].urls)))
 
@@ -124,7 +124,7 @@ class Api(object):
         if api_name is None:
             api_name = self.api_name
 
-        for name in sorted(self._registry.keys()):
+        for name in sorted(self._registry.keys(), reverse=True):
             available_resources[name] = {
                 'list_endpoint': self._build_reverse_url("api_dispatch_list", kwargs={
                     'api_name': api_name,


### PR DESCRIPTION
This allows prepended URLs which are longer (/foo/bar/<id>/) to take precedence
over shorter ones (/foo/<id>/).

I didn't see any test cases for this behavior, but I can add them if they're wanted.
