### PR TITLE
Fix primary key check.

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -698,7 +698,7 @@ class ToManyField(RelatedField):
         self.m2m_bundles = []
 
     def dehydrate(self, bundle):
-        if not bundle.obj or not bundle.obj.pk:
+        if not bundle.obj or bundle.obj.pk is None:
             if not self.null:
                 raise ApiFieldError("The model '%r' does not have a primary key and can not be used in a ToMany context." % bundle.obj)
 


### PR DESCRIPTION
An empty primary key is None and a valid primary key can evaluate to False. Thus, the primary key should be check with 'pk is None' and not 'not pk'.