### PR TITLE
'filtering' is actually a dict

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -568,8 +568,8 @@ The inner ``Meta`` class allows for class-level configuration of how the
 ``filtering``
 -------------
 
-  Provides a list of fields that the ``Resource`` will accept client
-  filtering on. Default is ``{}``.
+  Specifies the fields that the ``Resource`` will accept client filtering on. 
+  Default is ``{}``.
 
   Keys should be the fieldnames as strings while values should be a list of
   accepted filter types.


### PR DESCRIPTION
Use of the word 'list' was just barely misleading enough; the default and key/value explanation should clarify.
