### PR TITLE
Crate.io API link is dead

### DIFF
--- a/docs/who_uses.rst
+++ b/docs/who_uses.rst
@@ -50,15 +50,6 @@ To power their mobile (iPhone/Android/Playbook) applications.
 * http://www.politifact.com/mobile/
 
 
-Crate
------
-
-Crate is a PyPI mirror/replacement. It's using Tastypie to provide a convenient
-REST API.
-
-* https://crate.io/api/v1/
-
-
 LocalWiki
 ---------
 


### PR DESCRIPTION
I simply removed it from the docs since it is a dead link. Hopefully it comes back.
