### PR TITLE
Fix #739 - pass request to obj_get in GenericResource.get_via_uri

### DIFF
--- a/tastypie/contrib/contenttypes/resources.py
+++ b/tastypie/contrib/contenttypes/resources.py
@@ -37,6 +37,6 @@ class GenericResource(ModelResource):
 
         parent_resource = resource_class(api_name=self._meta.api_name)
         kwargs = parent_resource.remove_api_resource_names(kwargs)
-        return parent_resource.obj_get(**kwargs)
+        return parent_resource.obj_get(request=request, **kwargs)
 
 

--- a/tests/content_gfk/api/resources.py
+++ b/tests/content_gfk/api/resources.py
@@ -10,7 +10,13 @@ class DefinitionResource(ModelResource):
         resource_name = 'definitions'
         queryset = Definition.objects.all()
 
+
 class NoteResource(ModelResource):
+
+    def apply_authorization_limits(self, request, object_list):
+        if request is None:
+            return object_list.none()
+        return object_list
 
     class Meta:
         resource_name = 'notes'
@@ -22,6 +28,7 @@ class QuoteResource(ModelResource):
     class Meta:
         resource_name = 'quotes'
         queryset = Quote.objects.all()
+
 
 class RatingResource(ModelResource):
     content_object = GenericForeignKeyField({

--- a/tests/content_gfk/tests/fields.py
+++ b/tests/content_gfk/tests/fields.py
@@ -3,6 +3,7 @@ from __future__ import with_statement
 from django.test import TestCase
 from tastypie.contrib.contenttypes.fields import GenericForeignKeyField
 from tastypie.bundle import Bundle
+from core.tests.mocks import MockRequest
 from content_gfk.models import Note, Quote, Rating, Definition
 from content_gfk.api.resources import NoteResource, DefinitionResource, \
     QuoteResource, RatingResource
@@ -56,10 +57,15 @@ class ContentTypeFieldTestCase(TestCase):
             Quote: QuoteResource
         }, 'nofield')
 
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'GET'
+
         self.assertEqual(
             gfk_field.resource_from_uri(
                 gfk_field.to_class(),
-                '/api/v1/notes/%s/' % note_2.pk
+                '/api/v1/notes/%s/' % note_2.pk,
+                request
             ).obj,
             note_2
         )

--- a/tests/content_gfk/tests/resources.py
+++ b/tests/content_gfk/tests/resources.py
@@ -2,19 +2,34 @@ from django.test import TestCase
 from tastypie.exceptions import NotFound
 from tastypie.contrib.contenttypes.resources import GenericResource
 
+from core.tests.mocks import MockRequest
 from content_gfk.api.resources import NoteResource, DefinitionResource
+from content_gfk.models import Note
 
 
 class GenericResourceTestCase(TestCase):
     def setUp(self):
         self.resource = GenericResource([NoteResource, DefinitionResource])
 
-
     def test_bad_uri(self):
         bad_uri = '/bad_uri/'
         self.assertRaises(NotFound, self.resource.get_via_uri, bad_uri)
 
-
     def test_resource_not_registered(self):
         bad_uri = '/api/v1/quotes/1/'
         self.assertRaises(NotFound, self.resource.get_via_uri, bad_uri)
+
+    def test_resource_passes_request(self):
+        note = Note.objects.create(
+            title='All aboard the rest train',
+            content='Sometimes it is just better to lorem ipsum'
+        )
+
+        uri = '/api/v1/notes/1/'
+
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'GET'
+
+        result = self.resource.get_via_uri(uri, request=request)
+        self.assertEqual(result, note)


### PR DESCRIPTION
Added tests and a small change to GenericResource.
