### PR TITLE
Update docs/resources.rst

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -285,12 +285,15 @@ A complex example::
             excludes = ['email', 'password', 'is_staff', 'is_superuser']
 
         def dehydrate(self, bundle):
-            # If they're requesting their own record, add in their email address.
-            if bundle.request.user.pk == bundle.obj.pk:
-                # Note that there isn't an ``email`` field on the ``Resource``.
-                # By this time, it doesn't matter, as the built data will no
-                # longer be checked against the fields on the ``Resource``.
-                bundle.data['email'] = bundle.obj.email
+            try:
+                # If they're requesting their own record, add in their email address.
+                if bundle.request.user.pk == bundle.obj.pk:
+                    # Note that there isn't an ``email`` field on the ``Resource``.
+                    # By this time, it doesn't matter, as the built data will no
+                    # longer be checked against the fields on the ``Resource``.
+                    bundle.data['email'] = bundle.obj.email
+            except AttributeError:
+                pass
 
             return bundle
 


### PR DESCRIPTION
bundle.request.user.pk == bundle.obj.pk condition check
leads to AttributeError while accessing by Anonymous user.
I think supressing AttributeError is mandatory
for all dehydrate methods.   