### PR TITLE
Fix invalid post data

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1255,7 +1255,8 @@ class Resource(object):
         try:
             deserialized = self.deserialize(request, request.raw_post_data, format=request.META.get('CONTENT_TYPE', 'application/json'))
             deserialized = self.alter_deserialized_detail_data(request, deserialized)
-        except (ValueError, UnsupportedFormat):
+            deserialized.items()
+        except (ValueError, UnsupportedFormat, AttributeError):
             raise BadRequest("Invalid data sent.")
 
         bundle = self.build_bundle(data=dict_strip_unicode_keys(deserialized), request=request)

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1252,8 +1252,12 @@ class Resource(object):
         If ``Meta.always_return_data = True``, there will be a populated body
         of serialized data.
         """
-        deserialized = self.deserialize(request, request.raw_post_data, format=request.META.get('CONTENT_TYPE', 'application/json'))
-        deserialized = self.alter_deserialized_detail_data(request, deserialized)
+        try:
+            deserialized = self.deserialize(request, request.raw_post_data, format=request.META.get('CONTENT_TYPE', 'application/json'))
+            deserialized = self.alter_deserialized_detail_data(request, deserialized)
+        except ValueError:
+            raise BadRequest("Invalid data sent.")
+
         bundle = self.build_bundle(data=dict_strip_unicode_keys(deserialized), request=request)
         updated_bundle = self.obj_create(bundle, request=request, **self.remove_api_resource_names(kwargs))
         location = self.get_resource_uri(updated_bundle)

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -19,7 +19,7 @@ from tastypie.exceptions import NotFound, BadRequest, InvalidFilterError, Hydrat
 from tastypie import fields
 from tastypie import http
 from tastypie.paginator import Paginator
-from tastypie.serializers import Serializer
+from tastypie.serializers import Serializer, UnsupportedFormat
 from tastypie.throttle import BaseThrottle
 from tastypie.utils import is_valid_jsonp_callback_value, dict_strip_unicode_keys, trailing_slash
 from tastypie.utils.mime import determine_format, build_content_type
@@ -1255,7 +1255,7 @@ class Resource(object):
         try:
             deserialized = self.deserialize(request, request.raw_post_data, format=request.META.get('CONTENT_TYPE', 'application/json'))
             deserialized = self.alter_deserialized_detail_data(request, deserialized)
-        except ValueError:
+        except (ValueError, UnsupportedFormat):
             raise BadRequest("Invalid data sent.")
 
         bundle = self.build_bundle(data=dict_strip_unicode_keys(deserialized), request=request)

--- a/tests/basic/tests/http.py
+++ b/tests/basic/tests/http.py
@@ -39,6 +39,17 @@ class HTTPTestCase(TestServerTestCase):
         self.assertEqual(response.status, 200)
         self.assertEqual(response.read(), '{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null, "total_count": 2}, "objects": [{"content": "This is my very first post using my shiny new API. Pretty sweet, huh?", "created": "2010-03-30T20:05:00", "id": 1, "is_active": true, "resource_uri": "/api/v1/notes/1/", "slug": "first-post", "title": "First Post!", "updated": "2010-03-30T20:05:00", "user": "/api/v1/users/1/"}, {"content": "The dog ate my cat today. He looks seriously uncomfortable.", "created": "2010-03-31T20:05:00", "id": 2, "is_active": true, "resource_uri": "/api/v1/notes/2/", "slug": "another-post", "title": "Another Post", "updated": "2010-03-31T20:05:00", "user": "/api/v1/users/1/"}]}')
 
+    def test_invalid_post_object(self):
+        """
+        Ensure that a HTTP BadRequest, status code 400, is returned if we send invalid JSON.
+        """
+        connection = self.get_connection()
+        post_data = '{"content": "A new post.""is_active": true, "title": "New Title", "slug": "new-title", "user": "/api/v1/users/1/"}'
+        connection.request('POST', '/api/v1/notes/', body=post_data, headers={'Accept': 'application/json', 'Content-type': 'application/json'})
+        response = connection.getresponse()
+        self.assertEqual(response.status, 400)
+
+
     def test_post_object(self):
         connection = self.get_connection()
         post_data = '{"content": "A new post.", "is_active": true, "title": "New Title", "slug": "new-title", "user": "/api/v1/users/1/"}'

--- a/tests/basic/tests/http.py
+++ b/tests/basic/tests/http.py
@@ -39,6 +39,17 @@ class HTTPTestCase(TestServerTestCase):
         self.assertEqual(response.status, 200)
         self.assertEqual(response.read(), '{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null, "total_count": 2}, "objects": [{"content": "This is my very first post using my shiny new API. Pretty sweet, huh?", "created": "2010-03-30T20:05:00", "id": 1, "is_active": true, "resource_uri": "/api/v1/notes/1/", "slug": "first-post", "title": "First Post!", "updated": "2010-03-30T20:05:00", "user": "/api/v1/users/1/"}, {"content": "The dog ate my cat today. He looks seriously uncomfortable.", "created": "2010-03-31T20:05:00", "id": 2, "is_active": true, "resource_uri": "/api/v1/notes/2/", "slug": "another-post", "title": "Another Post", "updated": "2010-03-31T20:05:00", "user": "/api/v1/users/1/"}]}')
 
+    def test_post_object_bad_type(self):
+        """
+        Ensure that a HTTP BadRequest, status code 400, is returned if we send invalid JSON.
+        """
+        connection = self.get_connection()
+        post_data = '"fee, fie, foo, fum"'
+        connection.request('POST', '/api/v1/notes/', body=post_data, headers={})
+        response = connection.getresponse()
+        self.assertEqual(response.status, 400)
+
+
     def test_invalid_post_object(self):
         """
         Ensure that a HTTP BadRequest, status code 400, is returned if we send invalid JSON.

--- a/tests/basic/tests/http.py
+++ b/tests/basic/tests/http.py
@@ -39,6 +39,17 @@ class HTTPTestCase(TestServerTestCase):
         self.assertEqual(response.status, 200)
         self.assertEqual(response.read(), '{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null, "total_count": 2}, "objects": [{"content": "This is my very first post using my shiny new API. Pretty sweet, huh?", "created": "2010-03-30T20:05:00", "id": 1, "is_active": true, "resource_uri": "/api/v1/notes/1/", "slug": "first-post", "title": "First Post!", "updated": "2010-03-30T20:05:00", "user": "/api/v1/users/1/"}, {"content": "The dog ate my cat today. He looks seriously uncomfortable.", "created": "2010-03-31T20:05:00", "id": 2, "is_active": true, "resource_uri": "/api/v1/notes/2/", "slug": "another-post", "title": "Another Post", "updated": "2010-03-31T20:05:00", "user": "/api/v1/users/1/"}]}')
 
+    def test_random_string_posted(self):
+        """
+        If we are sent a random string, we should not collapse and die, even though we expect JSON.
+        """
+        connection = self.get_connection()
+        post_data = '"fee, fie, foo, fum"'
+        connection.request('POST', '/api/v1/notes/', body=post_data, headers={'Accept': 'application/json', 'Content-type': 'application/json'})
+        response = connection.getresponse()
+        self.assertEqual(response.status, 400)
+
+
     def test_post_object_bad_type(self):
         """
         Ensure that a HTTP BadRequest, status code 400, is returned if we send invalid JSON.


### PR DESCRIPTION
If invalid JSON, or data which is not deserialisable is submitted, TasyPit will return a 500.

Instead return a 400 to the requester.