### PR TITLE
Add BigIntegerField to the Django model types supported for IntegerField...

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1589,7 +1589,7 @@ class ModelResource(Resource):
             result = fields.FloatField
         elif internal_type in ('DecimalField',):
             result = fields.DecimalField
-        elif internal_type in ('IntegerField', 'PositiveIntegerField', 'PositiveSmallIntegerField', 'SmallIntegerField', 'AutoField'):
+        elif internal_type in ('IntegerField', 'PositiveIntegerField', 'PositiveSmallIntegerField', 'SmallIntegerField', 'AutoField', 'BigIntegerField'):
             result = fields.IntegerField
         elif internal_type in ('FileField', 'ImageField'):
             result = fields.FileField


### PR DESCRIPTION
Regarding issue:
https://github.com/toastdriven/django-tastypie/issues/760

The Django model BigIntegerField is missing from the list of fields for IntegerField in Resource.api_field_from_django_field() so it defaults to a CharField.
