### PR TITLE
Username based throttling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,6 +67,7 @@ Contributors:
 * Jason Brownbridge (jbrownbridge) for patching multiple ``offset/limit`` params appearing in pagination URIs.
 * Mitar for compatability patches with django-tastypie-mongoengine
 * Jeremy Dunck (jdunck) for a patch adding an index to ``ApiKey``.
+* Christopher Hartfield (chrishartfield) for patch to allow user-based (not just IP address based) throttelling
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -582,7 +582,7 @@ class Resource(object):
         identifier = self._meta.authentication.get_identifier(request)
 
         # Check to see if they should be throttled.
-        if self._meta.throttle.should_be_throttled(identifier):
+        if self._meta.throttle.should_be_throttled(identifier, request):
             # Throttle limit exceeded.
             raise ImmediateHttpResponse(response=http.HttpTooManyRequests())
 

--- a/tastypie/throttle.py
+++ b/tastypie/throttle.py
@@ -44,7 +44,7 @@ class BaseThrottle(object):
         safe_string = ''.join(bits)
         return "%s_accesses" % safe_string
     
-    def should_be_throttled(self, identifier, **kwargs):
+    def should_be_throttled(self, identifier, request, **kwargs):
         """
         Returns whether or not the user has exceeded their throttle limit.
         


### PR DESCRIPTION
Tastypie should allow the ability to throttle users based upon more then just their IP address (the identifier).  By passing in "request" to the function "should_be_throttled" and the function "accessed" in throttle.py developers would have the option to throttle based upon username, custom http headers, etc.