### PR TITLE
Cookbook: Use csrf_exempt when determining format via URL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,6 +67,7 @@ Contributors:
 * Jason Brownbridge (jbrownbridge) for patching multiple ``offset/limit`` params appearing in pagination URIs.
 * Mitar for compatability patches with django-tastypie-mongoengine
 * Jeremy Dunck (jdunck) for a patch adding an index to ``ApiKey``.
+* Wes Winham (winhamwr) for a documentation patch.
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -323,6 +323,10 @@ of ``/api/v1/users/?format=json``. The following snippet allows that kind
 of syntax additional to the default URL scheme::
 
     # myapp/api/resources.py
+
+    # Piggy-back on internal csrf_exempt existence handling
+    from tastypie.resources import csrf_exempt
+
     class UserResource(ModelResource):
         class Meta:
             queryset = User.objects.all()
@@ -350,6 +354,7 @@ of syntax additional to the default URL scheme::
             return super(UserResource, self).determine_format(request)
 
         def wrap_view(self, view):
+            @csrf_exempt
             def wrapper(request, *args, **kwargs):
                 request.format = kwargs.pop('format', None)
                 wrapped_view = super(UserResource, self).wrap_view(view)


### PR DESCRIPTION
Without this, anyone who follows this example will get CSRF errors if they're using the default Django CSRF protection and they're not already sending the CSRF token. This brings the behavior in line with the default `wrap_view`.

It took me quite a while to figure out why my wrapped views following the current example weren't behaving, but I'm very glad that cookbook existed.
