### PR TITLE
Doc: Include import statement for trailing_slash

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -97,6 +97,8 @@ You can also do "nested resources" (resources within another related resource)
 by lightly overriding the ``prepend_urls`` method & adding on a new method to
 handle the children::
 
+    from tastypie.utils import trailing_slash
+
     class ParentResource(ModelResource):
         children = fields.ToManyField(ChildResource, 'children')
 


### PR DESCRIPTION
I didn't add imports for other things because the user probably
has figured out how to import ModelResource, etc., by the time
he gets to the cookbook. But `trailing_slash` was not used elsewhere,
so I though it would be useful to show where it comes from.