### PR TITLE
Fixed CSVSerializer example's `to_csv` method to actually work.

### DIFF
--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -133,26 +133,6 @@ like::
             return data
 
 
-    class CSVSerializer(Serializer):
-        def to_csv(self, data, options=None):
-            options = options or {}
-            data = self.to_simple(data, options)
-            raw_data = StringIO.StringIO()
-            # Untested, so this might not work exactly right.
-            for item in data:
-                writer = csv.DictWriter(raw_data, item.keys(), extrasaction='ignore')
-                writer.write(item)
-            return raw_data
-
-        def from_csv(self, content):
-            raw_data = StringIO.StringIO(content)
-            data = []
-            # Untested, so this might not work exactly right.
-            for item in csv.DictReader(raw_data):
-                data.append(item)
-            return data
-
-
 ``Serializer`` Methods
 ======================
 

--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -113,10 +113,12 @@ like::
             data = self.to_simple(data, options)
             raw_data = StringIO.StringIO()
             if data['objects']:
-                writer = csv.DictWriter(raw_data, data['objects'][0].keys(),
+                fields = data['objects'][0].keys()
+                writer = csv.DictWriter(raw_data, fields,
                                         dialect="excel",
                                         extrasaction='ignore')
-                writer.writeheader()
+                header = dict(zip(fields, fields))
+                writer.writerow(header)  # In Python 2.7: `writer.writeheader()`
                 for item in data['objects']:
                     writer.writerow(item)
 


### PR DESCRIPTION
I tried using the example as provided in the current docs, and found that the `to_csv` method didn't work. I've fixed this, based on my own working version. I have to tested the `from_csv` method, but I did check it against the docs, and it appears correct.

The improved example also demonstrates better subclassing of parent Serializer, so the subclass doesn't need to know which formats are already implemented on the parent class.
