### PR TITLE
Fix filter_value_to_python

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,6 +67,7 @@ Contributors:
 * Jason Brownbridge (jbrownbridge) for patching multiple ``offset/limit`` params appearing in pagination URIs.
 * Mitar for compatability patches with django-tastypie-mongoengine
 * Jeremy Dunck (jdunck) for a patch adding an index to ``ApiKey``.
+* Miguel Carranza (MiguelCarranza) for patching 'filter_value_to_python' to support __in filters in kwargs.
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1728,7 +1728,10 @@ class ModelResource(Resource):
                 value = []
 
                 for part in filters.getlist(filter_expr):
-                    value.extend(part.split(','))
+                    if hasattr(part, 'split'):
+                        value.extend(part.split(','))
+                    else:
+                        value.extend(part)
             elif hasattr(value, 'split'):
                 value = value.split(',')
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1729,7 +1729,7 @@ class ModelResource(Resource):
 
                 for part in filters.getlist(filter_expr):
                     value.extend(part.split(','))
-            else:
+            elif hasattr(value, 'split'):
                 value = value.split(',')
 
         return value

--- a/tests/basic/api/resources.py
+++ b/tests/basic/api/resources.py
@@ -6,6 +6,11 @@ from tastypie.authentication import SessionAuthentication
 from tastypie.authorization import Authorization
 from basic.models import Note, AnnotatedNote, SlugBasedNote
 
+from django.conf.urls.defaults import *
+from tastypie.utils import trailing_slash
+from tastypie.constants import ALL, ALL_WITH_RELATIONS
+
+
 
 class UserResource(ModelResource):
     class Meta:
@@ -45,7 +50,19 @@ class NoteResource(ModelResource):
         resource_name = 'notes'
         queryset = Note.objects.all()
         authorization = Authorization()
+        filtering = {"id": ALL}
 
+    def override_urls(self):
+        return [url(r"^(?P<resource_name>%s)/(?P<pk>\w[\w/-]*)/filterin%s$" % 
+                (self._meta.resource_name, trailing_slash()), 
+                self.wrap_view('get_filterin'), name="api_get_filterin"),]
+
+
+    def get_filterin(self, request, **kwargs):
+        note_resource = NoteResource()
+        # ids can actually be generated in a different way 
+        ids = ["1", "2"]
+        return note_resource.get_list(request, id__in=ids)
 
 class BustedResource(ModelResource):
     class Meta:
@@ -61,7 +78,7 @@ class SlugBasedNoteResource(ModelResource):
         queryset = SlugBasedNote.objects.all()
         resource_name = 'slugbased'
         detail_uri_name = 'slug'
-
+  
 
 class SessionUserResource(ModelResource):
     class Meta:

--- a/tests/basic/tests/http.py
+++ b/tests/basic/tests/http.py
@@ -115,3 +115,10 @@ class HTTPTestCase(TestServerTestCase):
 
         self.assertEqual(cache_control, set(["s-maxage=3600", "max-age=3600", "private"]))
         self.assertTrue('"johndoe"' in response.read())
+
+    def test_filter_in(self):
+        connection = self.get_connection()
+        connection.request('GET', '/api/v1/notes/1/filterin/', headers={'Accept': 'application/json'})
+        response = connection.getresponse()
+        connection.close()
+        self.assertEqual(response.status, 200)


### PR DESCRIPTION
Currently, it is not possible to use __in filters when a list is provided to Resource.get_list through kwargs.

The following code produces an error ("int() argument must be a string or a number, not 'list'")


```python
def get_concepts(self, request, **kwargs):
    concept_resource = ConceptResource()
    # ids actually generated in a different way 
    ids = ["1", "2", "3", "4"]
    return concept_resource.get_list(request, id__in=ids)
```

Basically, this pull request allows to use a list like 'ids' in kwargs, so that we could filter by, for instance, a set of primary keys.