### PR TITLE
Added automatic readonly ModelResource fields

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,6 +69,7 @@ Contributors:
 * Jeremy Dunck (jdunck) for a patch adding an index to ``ApiKey``.
 * Wes Winham (winhamwr) for a documentation patch.
 * Andrew Austin (andrewaustin) for triaging, verifying and patching several tickets.
+* Mark Larus (marblar) for a patch adding ``readonly`` to ModelResource
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -619,6 +619,18 @@ The inner ``Meta`` class allows for class-level configuration of how the
   Controls what introspected fields the ``Resource`` should *NOT* include.
   A blacklist of fields. Default is ``[]``.
 
+``readonly``
+-------------
+
+  Controls which automatically generated ``ModelResource`` fields should be
+  marked as readonly. Default is ``[]``
+
+``readwrite``
+--------------
+
+  Controls which automatically generated ``ModelResource`` fields should
+  *NOT* be marked as readonly. Default is ``[]``
+
 ``include_resource_uri``
 ------------------------
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1614,6 +1614,8 @@ class ModelResource(Resource):
         final_fields = {}
         fields = fields or []
         excludes = excludes or []
+        readonly = getattr(cls._meta,'readonly',[])
+        readwrite = getattr(cls._meta,'readwrite',[])
 
         if not cls._meta.object_class:
             return final_fields
@@ -1640,6 +1642,12 @@ class ModelResource(Resource):
                 'attribute': f.name,
                 'help_text': f.help_text,
             }
+
+            if readwrite and f.name not in readwrite:
+                kwargs['readonly']=True
+
+            if f.name in readonly:
+                kwargs['readonly']=True
 
             if f.null is True:
                 kwargs['null'] = True

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1064,6 +1064,18 @@ class CounterResource(ModelResource):
         new_shiny.obj.count = new_shiny.times_hydrated
         return new_shiny
 
+class MetaReadonlyNoteResource(ModelResource):
+    class Meta:
+        resource_name = 'readonly_note_meta'
+        queryset = Note.objects.all()
+        readonly = ['created','updated']
+
+class MetaReadwriteNoteResource(ModelResource):
+    class Meta:
+        resource_name = 'readwrite_note_meta'
+        queryset = Note.objects.all()
+        readwrite = ['title','content']
+
 
 class ModelResourceTestCase(TestCase):
     fixtures = ['note_testdata.json']
@@ -3079,6 +3091,19 @@ class ModelResourceTestCase(TestCase):
         finally:
             related_obj.save = _real_save
 
+    def test_readonly_meta_list(self):
+        mronr = MetaReadonlyNoteResource()
+        for attribute in ['created','updated']:
+            self.assertEqual(mronr.fields[attribute].readonly,True)
+        for attribute in ['title','slug','content','is_active']:
+            self.assertEqual(mronr.fields[attribute].readonly,False)
+        
+        mrwnr = MetaReadwriteNoteResource()
+        for attribute in ['title','content']:
+            self.assertEqual(mrwnr.fields[attribute].readonly,False)
+        for attribute in ['created','updated','slug','is_active']:
+            self.assertEqual(mrwnr.fields[attribute].readonly,True)
+        
 
     def test_collection_name(self):
         resource = AlternativeCollectionNameNoteResource()


### PR DESCRIPTION
Automatically generated ModelResource fields will be marked as readonly if their names are in the `Meta` class attribute `readonly` or if they don't appear in the non-empty `readwrite` list. Similar to the existing `excludes` and `fields` attributes.
