### PR TITLE
ApiKeyAuthentication Security Issue

### DIFF
--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -155,7 +155,7 @@ class ApiKeyAuthentication(Authentication):
     as suits your needs.
     """
     def _unauthorized(self):
-        return HttpUnauthorized()
+        return False
 
     def extract_credentials(self, request):
         if request.META.get('HTTP_AUTHORIZATION') and request.META['HTTP_AUTHORIZATION'].lower().startswith('apikey '):
@@ -196,8 +196,11 @@ class ApiKeyAuthentication(Authentication):
         if not self.check_active(user):
             return False
 
-        request.user = user
-        return self.get_key(user, api_key)
+        if self.get_key(user, api_key):
+            request.user = user
+            return True
+
+        return self._unauthorized()
 
     def get_key(self, user, api_key):
         """


### PR DESCRIPTION
ApiKeyAuthentication assigns user to request object basing only on
username checks what will change current user to any provided through
username value.

For example, if we would use MultiAuthentication in combination with ApiKeyAuthentcation + SessionAuthentication this will allready passes us as authenticated user if we specify only correct username.
