### PR TITLE
Fix Issue #765 : Successfully Import with Django 1.6

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,6 +69,7 @@ Contributors:
 * Jeremy Dunck (jdunck) for a patch adding an index to ``ApiKey``.
 * Wes Winham (winhamwr) for a documentation patch.
 * Andrew Austin (andrewaustin) for triaging, verifying and patching several tickets.
+* Erik Dykema (quietlyconfident) for a tiny patch fixing compatibility with Django 1.6.
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -1,5 +1,8 @@
 import warnings
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls.defaults import *
+except:
+    from django.conf.urls import *
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -3,7 +3,10 @@ import logging
 import warnings
 import django
 from django.conf import settings
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls.defaults import patterns,url
+except:
+    from django.conf.urls import patterns,url
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned, ValidationError
 from django.core.urlresolvers import NoReverseMatch, reverse, resolve, Resolver404, get_script_prefix
 from django.db import transaction


### PR DESCRIPTION
This patch fixes tastypie's failure, in Django 1.6, to import certain resources that have been moved around form prior versions of Django.  It resolves issue #765.

As far as I can tell, this patch complies with the contribution guidelines in that:
1. It is clear
2. It works across all supported versions of Python/Django
3. Follows the existing style
4. No comments needed
5. Causes existing tests to pass because tastypie otherwise cannot be imported by Django 1.6
6. Does not change a public API.
7. I am the original author, and contribute the patch under the BSD license.
8. Adds me to the Authors file.
