### PR TITLE
Re-patching: 'filtering' is actually a dict

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -69,6 +69,7 @@ Contributors:
 * Jeremy Dunck (jdunck) for a patch adding an index to ``ApiKey``.
 * Wes Winham (winhamwr) for a documentation patch.
 * Andrew Austin (andrewaustin) for triaging, verifying and patching several tickets.
+* Sam Thompson(georgedorn) for fixing some docs and tests.
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -585,8 +585,8 @@ The inner ``Meta`` class allows for class-level configuration of how the
 ``filtering``
 -------------
 
-  Provides a list of fields that the ``Resource`` will accept client
-  filtering on. Default is ``{}``.
+  Specifies the fields that the ``Resource`` will accept client filtering on.
+  Default is ``{}``.
 
   Keys should be the fieldnames as strings while values should be a list of
   accepted filter types.


### PR DESCRIPTION
Revisiting a minor doc tweak, this time without trailing whitespace.