### PR TITLE
More pervasive support for kwargs from urlpatterns.

### DIFF
--- a/tests/core/tests/api.py
+++ b/tests/core/tests/api.py
@@ -18,20 +18,6 @@ class UserResource(ModelResource):
         resource_name = 'users'
         queryset = User.objects.all()
 
-class ParameterizedNoteResource(ModelResource):
-    """
-    A resource that requires the kwarg `param` to be
-    passed by the URL pattern.
-    """
-    
-    #def obj_get_list(self, bundle, **kwargs):
-    #    param = kwargs['param']
-    #    return super(ParameterizedNoteResource, self).obj_get_list(self, bundle, **kwargs)
-
-    class Meta:
-        resource_name = 'notes'
-        queryset = Note.objects.all()
-
 
 class ApiTestCase(TestCase):
     urls = 'core.tests.api_urls'

--- a/tests/core/tests/api.py
+++ b/tests/core/tests/api.py
@@ -18,6 +18,20 @@ class UserResource(ModelResource):
         resource_name = 'users'
         queryset = User.objects.all()
 
+class ParameterizedNoteResource(ModelResource):
+    """
+    A resource that requires the kwarg `param` to be
+    passed by the URL pattern.
+    """
+    
+    #def obj_get_list(self, bundle, **kwargs):
+    #    param = kwargs['param']
+    #    return super(ParameterizedNoteResource, self).obj_get_list(self, bundle, **kwargs)
+
+    class Meta:
+        resource_name = 'notes'
+        queryset = Note.objects.all()
+
 
 class ApiTestCase(TestCase):
     urls = 'core.tests.api_urls'

--- a/tests/core/tests/field_urls.py
+++ b/tests/core/tests/field_urls.py
@@ -19,12 +19,30 @@ class CustomNoteResource(ModelResource):
         resource_name = 'notes'
         queryset = Note.objects.all()
 
+class ParameterizedNoteResource(ModelResource):
+    """
+    A resource that requires the kwarg `param` to be
+    passed by the URL pattern.
+    """
+    
+    #def obj_get_list(self, bundle, **kwargs):
+    #    param = kwargs['param']
+    #    return super(ParameterizedNoteResource, self).obj_get_list(self, bundle, **kwargs)
+
+    class Meta:
+        resource_name = 'parameterized_notes'
+        queryset = Note.objects.all()
+
 
 api = Api(api_name='v1')
 api.register(CustomNoteResource())
 api.register(UserResource())
 api.register(SubjectResource())
 
+api2 = Api(api_name='v2')
+api2.register(ParameterizedNoteResource())
+
 urlpatterns = patterns('',
     (r'^api/', include(api.urls)),
+    (r'^parameterized/(?P<param>[a-z]+)/api/', include(api2.urls)),
 )

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -27,6 +27,7 @@ from tastypie.validation import FormValidation
 from core.models import Note, NoteWithEditor, Subject, MediaBit, AutoNowNote, DateRecord, Counter
 from core.tests.mocks import MockRequest
 from core.utils import SimpleHandler
+from core.tests.field_urls import ParameterizedNoteResource
 
 
 class CustomSerializer(Serializer):
@@ -802,7 +803,6 @@ class NoteResource(ModelResource):
             return '/api/v1/notes/'
 
         return '/api/v1/notes/%s/' % bundle_or_obj.obj.id
-
 
 class NoQuerysetNoteResource(ModelResource):
     class Meta:
@@ -1897,6 +1897,15 @@ class ModelResourceTestCase(TestCase):
         resp = resource.get_list(request)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content, '{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null, "total_count": 5}, "objects": [{"content": "This is my very first post using my shiny new API. Pretty sweet, huh?", "created": "2010-03-30T20:05:00", "id": 1, "is_active": true, "resource_uri": "/api/v1/notes/1/", "slug": "first-post", "title": "First Post!", "updated": "2010-03-30T20:05:00"}, {"content": "The dog ate my cat today. He looks seriously uncomfortable.", "created": "2010-03-31T20:05:00", "id": 2, "is_active": true, "resource_uri": "/api/v1/notes/2/", "slug": "another-post", "title": "Another Post", "updated": "2010-03-31T20:05:00"}, {"content": "My neighborhood\'s been kinda weird lately, especially after the lava flow took out the corner store. Granny can hardly outrun the magma with her walker.", "created": "2010-04-01T20:05:00", "id": 4, "is_active": true, "resource_uri": "/api/v1/notes/4/", "slug": "recent-volcanic-activity", "title": "Recent Volcanic Activity.", "updated": "2010-04-01T20:05:00"}, {"content": "Man, the second eruption came on fast. Granny didn\'t have a chance. On the upshot, I was able to save her walker and I got a cool shawl out of the deal!", "created": "2010-04-02T10:05:00", "id": 6, "is_active": true, "resource_uri": "/api/v1/notes/6/", "slug": "grannys-gone", "title": "Granny\'s Gone", "updated": "2010-04-02T10:05:00"}, {"content": "Whee!", "created": "2010-07-21T11:23:00", "id": 7, "is_active": true, "resource_uri": "/api/v1/notes/7/", "slug": "another-fresh-note", "title": "Another fresh note.", "updated": "%s"}]}' % make_naive(new_note.updated).isoformat())
+
+        # Ensure that pagination works for resources that expect kwargs from the urlpattern
+        resource = ParameterizedNoteResource()
+        request = HttpRequest()
+        request.GET = {'format': 'json', 'offset': 0, 'limit': 2}
+
+        resp = resource.get_list(request, param='fizzle')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, '{"meta": {"limit": 2, "next": "/parameterized/fizzle/api/v1/parameterized_notes/?format=json&limit=2&offset=2", "offset": 0, "previous": null, "total_count": 4}, "objects": [{"content": "This is my very first post using my shiny new API. Pretty sweet, huh?", "created": "2010-03-30T20:05:00", "id": 1, "is_active": true, "resource_uri": "/api/v1/notes/1/", "slug": "first-post", "title": "First Post!", "updated": "2010-03-30T20:05:00"}, {"content": "The dog ate my cat today. He looks seriously uncomfortable.", "created": "2010-03-31T20:05:00", "id": 2, "is_active": true, "resource_uri": "/api/v1/notes/2/", "slug": "another-post", "title": "Another Post", "updated": "2010-03-31T20:05:00"}]}')
 
         # Regression - Ensure that the limit on the Resource gets used if
         # no other limit is requested.


### PR DESCRIPTION
Hello!

This is actually bug report/feature request with a failing test case. I know how to fix it, essentially, but would like feedback.

The issue: I am working on a project (1) that has a URL structure like this:

```python
urlpatterns = patterns('',
   (r'^a/(?P<domain>[a-z]+)/api/', include(api.urls)),
)
```

Each resource depends on the `domain` parameter extensively, which is passed to the resource views as a kwarg (and could be added to the bundle, etc.)

However, these kwargs are not passed to `get_resource_uri` on [this line in `get_list`](https://github.com/toastdriven/django-tastypie/blob/master/tastypie/resources.py#L1262) and in fact `resource_uri_kwargs` is not written to incorporate them, so the [`reverse` lookup on this line](https://github.com/toastdriven/django-tastypie/blob/master/tastypie/resources.py#L304) always fails. This manifests as missing `next` and `prev`.

This cannot be fixed by adding it to the bundle because the bundle is not passed to `get_resource_uri` in the case of a list endpoint, and it cannot be in the current design. (2)

This can be fixed by passing the `kwargs` everywhere reliably and modifying `resource_uri_kwargs` to include them.

Note that as far as I can tell this _cannot_ be done by overrides except overriding `get_list` because that is where the problematic invocation of `get_resource_uri` lies. But `get_list` has a lot of functionality and is not an appropriate override point. I don't think this should require any overrides.

I am happy to go ahead and make the necessary changes; please comment.

Thanks,

Kenn

(1) The project is open source and available [on github](https://github.com/dimagi/commcare-hq) but very large, so I have presented a simplified example.

(2) This merging of two independent functions based on whether `bundle_or_obj` is `None` seems to needlessly complicate things. It seems that [in the past `get_resource_uri` and `get_resource_list_uri` were separate](https://github.com/toastdriven/django-tastypie/blob/v0.9.11/tastypie/resources.py#L601). This makes sense and would make it simple to pass the bundle to `get_resource_list_uri`.
