### PR TITLE
Correct override_urls check in Api (closes #692)

### DIFF
--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -79,8 +79,7 @@ class Api(object):
         """
         Deprecated. Will be removed by v1.0.0. Please use ``prepend_urls`` instead.
         """
-        warnings.warn("'override_urls' is a deprecated method & will be removed by v1.0.0. Please use ``prepend_urls`` instead.")
-        return self.prepend_urls()
+        return []
 
     def prepend_urls(self):
         """
@@ -104,9 +103,10 @@ class Api(object):
 
         urlpatterns = self.prepend_urls()
 
-        if self.override_urls():
+        overridden_urls = self.override_urls()
+        if overridden_urls:
             warnings.warn("'override_urls' is a deprecated method & will be removed by v1.0.0. Please rename your method to ``prepend_urls``.")
-            urlpatterns += self.override_urls()
+            urlpatterns += overridden_urls
 
         urlpatterns += patterns('',
             *pattern_list

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -337,9 +337,10 @@ class Resource(object):
         """
         urls = self.prepend_urls()
 
-        if self.override_urls():
+        overridden_urls = self.override_urls()
+        if overridden_urls:
             warnings.warn("'override_urls' is a deprecated method & will be removed by v1.0.0. Please rename your method to ``prepend_urls``.")
-            urls += self.override_urls()
+            urls += overridden_urls
 
         urls += self.base_urls()
         urlpatterns = patterns('',


### PR DESCRIPTION
This applies the same change which #516 made to Resource to only issue the
deprecation warning when override_urls() actually returns something.

This also changes the logic in both locations to avoid calling override_urls()
more than once
