### PR TITLE
BUGFIX: instance creation conflict when loading fixtures due to incorrect signal code

### DIFF
--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -55,5 +55,5 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
         """
         A signal for hooking up automatic ``ApiKey`` creation.
         """
-        if kwargs.get('created') is True:
+        if kwargs.get('created') is True and kwargs.get('raw') is False:
             ApiKey.objects.create(user=kwargs.get('instance'))


### PR DESCRIPTION
When connecting to a "post_save" signal, it is always good to check the "raw" argument. Failure to do so would cause crash in the process of loading fixtures, when a model is set to be creating new instance using that signal (e.g., profile auto creation).

To reproduce the bug, make sure there are API keys in the database already, perform "dumpdata" using Django command to a json file, wipe the database, syncdb, and then "loaddata" from previous saved json file.

For example:
```
$ (venv) python manage.py dumpdata --indent 4 > data.json
$ < wipe your database >
$ (venv) python manage.py syncdb
$ (venv) python manage.py loaddata data.json
```

Error is:
```
IntegrityError: Could not load tastypie.ApiKey(pk=1): column user_id is not unique
```

This commit fixed the loaddata bug.