### PR TITLE
Playing nice with Sentry by sending request exception signal.

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.conf.urls.defaults import patterns, url
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned, ValidationError
 from django.core.urlresolvers import NoReverseMatch, reverse, resolve, Resolver404, get_script_prefix
+from django.core.signals import got_request_exception
 from django.db import transaction
 from django.db.models.sql.constants import QUERY_TERMS
 from django.http import HttpResponse, HttpResponseNotFound, Http404
@@ -288,6 +289,9 @@ class Resource(object):
 
                 message = "%s\n\n%s" % (the_trace, request_repr)
                 mail_admins(subject, message, fail_silently=True)
+
+        # Send the signal so other apps are aware of the exception.
+        got_request_exception.send(self.__class__, request=request)
 
         # Prep the data going out.
         data = {


### PR DESCRIPTION
Currently tastypie keeps all information about an exception it encounters. This makes tastypie play nice with sentry and any other apps listening in for exceptions.
