### PR TITLE
Updated docs' cookbook

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -224,8 +224,8 @@ resulting code will look something like::
             authentication = ApiKeyAuthentication()
             authorization = Authorization()
 
-        def obj_create(self, bundle, request=None, **kwargs):
-            return super(EnvironmentResource, self).obj_create(bundle, request, user=request.user)
+        def obj_create(self, bundle, **kwargs):
+            return super(EnvironmentResource, self).obj_create(bundle, user=bundle.request.user)
 
         def apply_authorization_limits(self, request, object_list):
             return object_list.filter(user=request.user)


### PR DESCRIPTION
Updated obj_create in one of the cookbook examples which was still using the pre-0.9.12 syntax which included a request argument. The doc now accesses the request through the bundle object. Related to: https://github.com/toastdriven/django-tastypie/issues/800
