### PR TITLE
Return HTTP 406 when Accept is unsatisfiable

### DIFF
--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -3,7 +3,7 @@ from django.conf.urls.defaults import *
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseBadRequest
-from tastypie.exceptions import NotRegistered, BadRequest
+from tastypie.exceptions import NotRegistered, BadRequest, ImmediateHttpResponse
 from tastypie.serializers import Serializer
 from tastypie.utils import trailing_slash, is_valid_jsonp_callback_value
 from tastypie.utils.mime import determine_format, build_content_type
@@ -74,6 +74,8 @@ class Api(object):
         def wrapper(request, *args, **kwargs):
             try:
                 return getattr(self, view)(request, *args, **kwargs)
+            except ImmediateHttpResponse, e:
+                return e.response
             except BadRequest:
                 return HttpResponseBadRequest()
         return wrapper

--- a/tests/basic/tests/views.py
+++ b/tests/basic/tests/views.py
@@ -33,6 +33,35 @@ class ViewsTestCase(TestCase):
         self.assertEqual(len(deserialized['objects']), 2)
         self.assertEqual([obj['title'] for obj in deserialized['objects']], [u'Another Post', u'First Post!'])
 
+    def _check_path_conneg(self, path):
+        # Helper so we can have specific tests for different views without a loop which would hide details
+        # from failure messages
+        resp = self.client.get(path)
+        self.assertEqual(resp.status_code, 200, msg="Requests without Accept should use the default format")
+        self.assertEqual(resp['content-type'], 'application/json')
+
+        resp = self.client.get(path, HTTP_ACCEPT='application/json')
+        self.assertEqual(resp.status_code, 200, msg='Requests which Accept a supported format should return 200')
+        self.assertEqual(resp['content-type'], 'application/json')
+
+        resp = self.client.get(path, HTTP_ACCEPT='text/bogus')
+        self.assertEqual(resp.status_code, 406, msg="Requests which Accept only unsupported formats should return 406")
+
+        resp = self.client.get(path, HTTP_ACCEPT='text/bogus;q=1.0,application/xml;q=0.1')
+        self.assertEqual(resp.status_code, 200, msg="Content negotiation should fail down to a supported format")
+
+        resp = self.client.get("%s?format=json" % path, HTTP_ACCEPT='application/foobar')
+        self.assertEqual(resp.status_code, 200, msg="Explicit format selection should overrule the Accept header")
+
+    def test_top_level_content_negotiation(self):
+        self._check_path_conneg('/api/v1/')
+
+    def test_resource_list_content_negotiation(self):
+        self._check_path_conneg('/api/v1/notes/')
+
+    def test_resource_detail_content_negotiation(self):
+        self._check_path_conneg('/api/v1/notes/1/')
+
     def test_get_test_client_error(self):
         # The test server should re-raise exceptions to make debugging easier.
         self.assertRaises(Exception, self.client.get, '/api/v2/busted/', data={'format': 'json'})

--- a/tests/core/tests/utils.py
+++ b/tests/core/tests/utils.py
@@ -1,7 +1,7 @@
 from django.http import HttpRequest
 from django.test import TestCase
 
-from tastypie.exceptions import BadRequest
+from tastypie.exceptions import BadRequest, ImmediateHttpResponse
 from tastypie.serializers import Serializer
 from tastypie.utils.mime import determine_format, build_content_type
 
@@ -54,6 +54,9 @@ class MimeTestCase(TestCase):
 
         # Again, disabled by default.
         request.META = {'HTTP_ACCEPT': 'text/javascript'}
+        self.assertRaises(ImmediateHttpResponse, determine_format, request, serializer)
+
+        request.META = {'HTTP_ACCEPT': 'text/javascript,application/json'}
         self.assertEqual(determine_format(request, serializer), 'application/json')
 
         # Again, explicitly enabled.


### PR DESCRIPTION
When the request includes a specific Accept list and the serializer does not
support any of the requested formats, it's appropriate to return an HTTP 406
Not Acceptable response.

As part of this patch, Api.wrap_view now handles ImmediateHttpResponse 
exceptions as expected for consistency with behaviour in Resource methods.
