### PR TITLE
Make default serialization formats use a Django setting

### DIFF
--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -12,21 +12,12 @@ As a result, Tastypie ships with a serializer that tries to meet the basic
 needs of most use cases, and the flexibility to go outside of that when you
 need to.
 
-The default ``Serializer`` supports the following formats:
-
-* json
-* jsonp (Disabled by default)
-* xml
-* yaml
-* html
-* plist (see http://explorapp.com/biplist/)
-
 Usage
 =====
 
 Using this class is simple. It is the default option on all ``Resource``
-classes unless otherwise specified. The following code is a no-op, but
-demonstrate how you could use your own serializer::
+classes unless otherwise specified. The following code is identical to the
+defaults but demonstrate how you could use your own serializer::
 
     from django.contrib.auth.models import User
     from tastypie.resources import ModelResource
@@ -41,9 +32,26 @@ demonstrate how you could use your own serializer::
             # Add it here.
             serializer = Serializer()
 
-Not everyone wants to install or support all the serialization options. To
-that end, you can limit the ones available by passing a ``formats=`` kwarg.
-For example, to provide only JSON & binary plist serialization::
+Configuring Allowed Formats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The default ``Serializer`` supports the following formats:
+
+* json
+* jsonp (Disabled by default)
+* xml
+* yaml
+* html
+* plist (see http://explorapp.com/biplist/)
+
+Not everyone wants to install or support all the serialization options. If you
+would list to customize the list of supported formats for your entire site
+the :ref:`TASTYPIE_DEFAULT_FORMATS setting <settings.TASTYPIE_DEFAULT_FORMATS>`
+allows you to set the default format list site-wide.
+
+If you wish to change the format list for a specific resource, you can pass the
+list of supported formats using the ``formats=`` kwarg. For example, to provide
+only JSON & binary plist serialization::
 
     from django.contrib.auth.models import User
     from tastypie.resources import ModelResource

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -98,3 +98,19 @@ An example::
     TASTYPIE_DATETIME_FORMATTING = 'rfc-2822'
 
 Defaults to ``iso-8601``.
+
+.. _settings.TASTYPIE_DEFAULT_FORMATS:
+
+``TASTYPIE_DEFAULT_FORMATS``
+================================
+
+**Optional**
+
+This setting allows you to globally configure the list of allowed serialization
+formats for your entire site.
+
+An example::
+
+    TASTYPIE_DEFAULT_FORMATS = ['json', 'xml']
+
+Defaults to ``['json', 'xml', 'yaml', 'html', 'plist']``.

--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -71,28 +71,37 @@ class Serializer(object):
     various format methods (i.e. ``to_json``), by changing the
     ``formats/content_types`` options or by altering the other hook methods.
     """
+
     formats = ['json', 'xml', 'yaml', 'html', 'plist']
-    content_types = {
-        'json': 'application/json',
-        'jsonp': 'text/javascript',
-        'xml': 'application/xml',
-        'yaml': 'text/yaml',
-        'html': 'text/html',
-        'plist': 'application/x-plist',
-    }
+
+    content_types = {'json': 'application/json',
+                     'jsonp': 'text/javascript',
+                     'xml': 'application/xml',
+                     'yaml': 'text/yaml',
+                     'html': 'text/html',
+                     'plist': 'application/x-plist'}
 
     def __init__(self, formats=None, content_types=None, datetime_formatting=None):
-        self.supported_formats = []
-        self.datetime_formatting = getattr(settings, 'TASTYPIE_DATETIME_FORMATTING', 'iso-8601')
+        if datetime_formatting is not None:
+            self.datetime_formatting = datetime_formatting
+        else:
+            self.datetime_formatting = getattr(settings, 'TASTYPIE_DATETIME_FORMATTING', 'iso-8601')
 
-        if formats is not None:
-            self.formats = formats
+        self.supported_formats = []
 
         if content_types is not None:
             self.content_types = content_types
 
-        if datetime_formatting is not None:
-            self.datetime_formatting = datetime_formatting
+        if formats is not None:
+            self.formats = formats
+
+        if self.formats is Serializer.formats and hasattr(settings, 'TASTYPIE_DEFAULT_FORMATS'):
+            # We want TASTYPIE_DEFAULT_FORMATS to override unmodified defaults but not intentational changes
+            # on Serializer subclasses:
+            self.formats = settings.TASTYPIE_DEFAULT_FORMATS
+
+        if not isinstance(self.formats, (list, tuple)):
+            raise ImproperlyConfigured('Formats should be a list or tuple, not %r' % self.formats)
 
         for format in self.formats:
             try:

--- a/tests/core/tests/serializers.py
+++ b/tests/core/tests/serializers.py
@@ -67,6 +67,34 @@ class SerializerTestCase(TestCase):
 
         self.assertRaises(ImproperlyConfigured, Serializer, formats=['json', 'xml'], content_types={'json': 'text/json'})
 
+    def test_default_formats_setting(self):
+        # When we drop support for Django 1.3 this boilerplate can be replaced with
+        # a simple django.test.utils.override_settings decorator:
+
+        old_formats = getattr(settings, 'TASTYPIE_DEFAULT_FORMATS', None)
+
+        try:
+            # Confirm that the setting will override the default values:
+            settings.TASTYPIE_DEFAULT_FORMATS = ('json', 'xml')
+            s = Serializer()
+            self.assertItemsEqual(s.formats, ['json', 'xml'])
+            self.assertItemsEqual(s.supported_formats, ['application/json', 'application/xml'])
+            self.assertDictEqual(s.content_types, {'xml': 'application/xml', 'yaml': 'text/yaml', 'json': 'application/json', 'jsonp': 'text/javascript', 'html': 'text/html', 'plist': 'application/x-plist'})
+
+            # Confirm that subclasses which set their own formats list won't be overriden:
+            class JSONSerializer(Serializer):
+                formats = ['json']
+
+            js = JSONSerializer()
+            self.assertItemsEqual(js.formats, ['json'])
+            self.assertItemsEqual(js.supported_formats, ['application/json'])
+
+        finally:
+            if old_formats is None:
+                del settings.TASTYPIE_DEFAULT_FORMATS
+            else:
+                settings.TASTYPIE_DEFAULT_FORMATS = old_formats
+
     def get_sample1(self):
         return {
             'name': 'Daniel',


### PR DESCRIPTION
While it's possible to configure or subclass Serializer to accomplish the same
goal (or will be when #817 lands) that requires repetitive code changes for a
simple site policy like 'We only support JSON and XML', which can now be as
simple as adding a setting:

```
TASTYPIE_DEFAULT_FORMATS = ['json', 'xml']
```

Changes:
- Serializer: **init** will apply TASTYPIE_DEFAULT_FORMATS when
  self.formats is the default Serializer.formats
- Serializer: restructured **init** to improve locality for format-
  related settings
- Restructured serializers documentation so format-related info is
  in one place & added a link to the new setting doc for
  TASTYPIE_DEFAULT_FORMATS
