### PR TITLE
Add test for #327

### DIFF
--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -192,6 +192,11 @@ class CharFieldTestCase(TestCase):
         field_2 = CharField(default=20)
         self.assertEqual(field_2.dehydrate(bundle), u'20')
 
+    def test_utf8_bytestring(self):
+        unicode_str = u'abcd' + unichr(233)
+        field_1 = CharField()
+        self.assertEqual(field_1.convert(unicode_str.encode('utf-8')), unicode_str)
+
 
 class FileFieldTestCase(TestCase):
     fixtures = ['note_testdata.json']


### PR DESCRIPTION
MySQLdb returns unicode strings from a column with utf8_bin collation as bytestrings. This causes a `UnicodeDecodeError` when the string is passed to `unicode()`. The problem presents in tastypie when converting `field.CharField` values. This test covers that case by creating a bytestring with unicode characters and passing it to `CharField.convert()`.

This relates to issue #327 and pull request #768
