### PR TITLE
django.conf.urls.defaults is now deprecated. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,10 @@ A basic example looks like::
 
     # urls.py
     # =======
-    from django.conf.urls.defaults import *
+    try:
+        from django.conf.urls import *
+    except ImportError:  # Django<=1.4
+        from django.conf.urls.defaults import *
     from tastypie.api import Api
     from myapp.api import EntryResource
 

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -132,7 +132,10 @@ Another alternative approach is to override the ``dispatch`` method::
             return super(EntryResource, self).dispatch(request_type, request, **kwargs)
 
     # urls.py
-    from django.conf.urls.defaults import *
+    try:
+        from django.conf.urls import *
+    except ImportError:  # Django<=1.4
+        from django.conf.urls.defaults import *
     from myapp.api import EntryResource
 
     entry_resource = EntryResource()
@@ -151,7 +154,10 @@ approach uses Haystack_, though you could hook it up to any search technology.
 We leave the CRUD methods of the resource alone, choosing to add a new endpoint
 at ``/api/v1/notes/search/``::
 
-    from django.conf.urls.defaults import *
+    try:
+        from django.conf.urls import *
+    except ImportError:  # Django<=1.4
+        from django.conf.urls.defaults import *
     from django.core.paginator import Paginator, InvalidPage
     from django.http import Http404
     from haystack.query import SearchQuerySet

--- a/docs/interacting.rst
+++ b/docs/interacting.rst
@@ -45,7 +45,10 @@ We'll assume that we're interacting with the following Tastypie code::
 
 
     # urls.py
-    from django.conf.urls.defaults import *
+    try:
+        from django.conf.urls import *
+    except ImportError:  # Django<=1.4
+        from django.conf.urls.defaults import *
     from tastypie.api import Api
     from myapp.api.resources import EntryResource, UserResource
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -142,7 +142,10 @@ do this, we simply instantiate the resource in our URLconf and hook up its
 ``urls``::
 
     # urls.py
-    from django.conf.urls.defaults import *
+    try:
+        from django.conf.urls import *
+    except ImportError:  # Django<=1.4
+        from django.conf.urls.defaults import *
     from myapp.api import EntryResource
 
     entry_resource = EntryResource()
@@ -264,7 +267,10 @@ We'll go back to our URLconf (``urls.py``) and change it to match the
 following::
 
     # urls.py
-    from django.conf.urls.defaults import *
+    try:
+        from django.conf.urls import *
+    except ImportError:  # Django<=1.4
+        from django.conf.urls.defaults import *
     from tastypie.api import Api
     from myapp.api import EntryResource, UserResource
 

--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -1,5 +1,10 @@
 import warnings
-from django.conf.urls.defaults import *
+
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
+    
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseBadRequest

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -3,7 +3,10 @@ import logging
 import warnings
 import django
 from django.conf import settings
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import patterns, url
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned, ValidationError
 from django.core.urlresolvers import NoReverseMatch, reverse, resolve, Resolver404, get_script_prefix
 from django.db import transaction

--- a/tests/alphanumeric/api/urls.py
+++ b/tests/alphanumeric/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from alphanumeric.api.resources import ProductResource
 

--- a/tests/alphanumeric/urls.py
+++ b/tests/alphanumeric/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
     (r'^api/', include('alphanumeric.api.urls')),

--- a/tests/authorization/urls.py
+++ b/tests/authorization/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import patterns, url, include
+try:
+    from django.conf.urls import patterns, url, include
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import patterns, url, include
 
 from tastypie.api import Api
 from .api.resources import ArticleResource, AuthorProfileResource, SiteResource, UserResource

--- a/tests/basic/api/urls.py
+++ b/tests/basic/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from basic.api.resources import NoteResource, UserResource, BustedResource, CachedUserResource, PublicCachedUserResource, PrivateCachedUserResource, SlugBasedNoteResource, SessionUserResource
 

--- a/tests/basic/urls.py
+++ b/tests/basic/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
     (r'^api/', include('basic.api.urls')),

--- a/tests/complex/api/urls.py
+++ b/tests/complex/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from complex.api.resources import PostResource, ProfileResource, CommentResource, UserResource, GroupResource
 

--- a/tests/complex/urls.py
+++ b/tests/complex/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
     (r'^api/', include('complex.api.urls')),

--- a/tests/content_gfk/api/urls.py
+++ b/tests/content_gfk/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from content_gfk.api.resources import NoteResource, QuoteResource, \
     RatingResource, DefinitionResource

--- a/tests/content_gfk/urls.py
+++ b/tests/content_gfk/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
     (r'^api/', include('content_gfk.api.urls')),

--- a/tests/core/tests/api_urls.py
+++ b/tests/core/tests/api_urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from core.tests.api import Api, NoteResource, UserResource
 
 

--- a/tests/core/tests/field_urls.py
+++ b/tests/core/tests/field_urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from tastypie import fields
 from tastypie.resources import ModelResource
 from core.models import Note, Subject

--- a/tests/core/tests/manual_urls.py
+++ b/tests/core/tests/manual_urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from core.tests.resources import NoteResource
 
 

--- a/tests/gis/api/urls.py
+++ b/tests/gis/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from gis.api.resources import GeoNoteResource, UserResource
 

--- a/tests/gis/urls.py
+++ b/tests/gis/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
     (r'^api/', include('gis.api.urls')),

--- a/tests/namespaced/api/urls.py
+++ b/tests/namespaced/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import NamespacedApi
 from namespaced.api.resources import NamespacedNoteResource, NamespacedUserResource
 

--- a/tests/related_resource/api/urls.py
+++ b/tests/related_resource/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from related_resource.api.resources import NoteResource, UserResource, \
         CategoryResource, TagResource, TaggableTagResource, TaggableResource, \

--- a/tests/slashless/api/urls.py
+++ b/tests/slashless/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from slashless.api.resources import NoteResource, UserResource
 

--- a/tests/validation/api/urls.py
+++ b/tests/validation/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django<=1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from validation.api.resources import NoteResource, UserResource, AnnotatedNoteResource
 


### PR DESCRIPTION
django.conf.urls.defaults is now deprecated. Use django.conf.urls instead.