### PR TITLE
Fix typo in git/grep command

### DIFF
--- a/BACKWARDS-INCOMPATIBLE.txt
+++ b/BACKWARDS-INCOMPATIBLE.txt
@@ -16,4 +16,4 @@ v0.9.12
 
 
 Backward-incompatible commits were not recorded prior to the release of v0.9.11
-but may be found using ``git grep --oneline ...v0.9.11 | grep "BACKWARD-"``.
+but may be found using ``git log --oneline ...v0.9.11 | grep "BACKWARD-"``.


### PR DESCRIPTION
I think git log was the intended command, not git grep.