### PR TITLE
ensure_ascii change

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -338,9 +338,9 @@ class Serializer(object):
         data = self.to_simple(data, options)
 
         if django.get_version() >= '1.5':
-            return json.json.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True, ensure_ascii=False)
+            return json.json.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True, ensure_ascii=True)
         else:
-            return simplejson.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True, ensure_ascii=False)
+            return simplejson.dumps(data, cls=json.DjangoJSONEncoder, sort_keys=True, ensure_ascii=True)
 
     def from_json(self, content):
         """


### PR DESCRIPTION
I have found that having ensure_ascii set to False often throws an error while running tests.