### PR TITLE
Use `path_info` instead of `path`

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -672,7 +672,7 @@ class RelatedField(ApiField):
         """
         should_dehydrate_full_resource = False
         if self.full:
-            is_details_view = resolve(bundle.request.path).url_name == "api_dispatch_detail"
+            is_details_view = resolve(bundle.request.path_info).url_name == "api_dispatch_detail"
             if is_details_view:
                 if (not callable(self.full_detail) and self.full_detail) or (callable(self.full_detail) and self.full_detail(bundle)):
                     should_dehydrate_full_resource = True


### PR DESCRIPTION
`RelatedField.should_full_dehydrate` uses `bundle.request.path`. Here, `.path` might be changed to `.path_info`, which is required under some web server configs, for example when _Django_ is deployed under a subpath (e.g. `/myproject` instead of `/`; [see the Django docs](https://docs.djangoproject.com/en/dev/ref/request-response/#django.http.HttpRequest.path_info)).

_NB. `path_info` should be equal to `path` in more common configurations._
