### PR TITLE
Fixed all deprecation warnings as of Django 1.5

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -301,8 +301,8 @@ By default, Tastypie outputs JSON with no indentation or newlines (equivalent to
 :py:func:`json.dumps` with *indent* set to ``None``). You can override this
 behavior in a custom serializer::
 
+    import json as simplejson
     from django.core.serializers import json
-    from django.utils import simplejson
     from tastypie.serializers import Serializer
 
     class PrettyJSONSerializer(Serializer):

--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -1,5 +1,8 @@
 import warnings
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseBadRequest

--- a/tastypie/contrib/gis/resources.py
+++ b/tastypie/contrib/gis/resources.py
@@ -4,7 +4,10 @@
 from urllib import unquote
 
 from django.contrib.gis.db.models import GeometryField
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError: # < Python 2.6
+    from django.utils import simplejson
 from django.contrib.gis.geos import GEOSGeometry
 
 from tastypie.fields import ApiField, CharField

--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -4,7 +4,10 @@ import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers import json
-from django.utils import simplejson
+try:
+    import json as simplejson
+except ImportError: # < Python 2.6
+    from django.utils import simplejson
 from django.utils.encoding import force_unicode
 from tastypie.bundle import Bundle
 from tastypie.exceptions import UnsupportedFormat

--- a/tests/alphanumeric/api/urls.py
+++ b/tests/alphanumeric/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from alphanumeric.api.resources import ProductResource
 

--- a/tests/alphanumeric/tests/http.py
+++ b/tests/alphanumeric/tests/http.py
@@ -1,5 +1,8 @@
 import httplib
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError: # < Python 2.6
+    from django.utils import simplejson as json
 from testcases import TestServerTestCase
 
 

--- a/tests/alphanumeric/tests/views.py
+++ b/tests/alphanumeric/tests/views.py
@@ -1,9 +1,20 @@
+import django
 from django.http import HttpRequest
 from django.test import TestCase
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError: # < Python 2.6
+    from django.utils import simplejson as json
 
 
 class ViewsTestCase(TestCase):
+    def setUp(self):
+        if django.VERSION >= (1, 4):
+            self.body_attr = "body"
+        else:
+            self.body_attr = "raw_post_data"
+        super(ViewsTestCase, self).setUp()
+
     def test_gets(self):
         resp = self.client.get('/api/v1/', data={'format': 'json'})
         self.assertEqual(resp.status_code, 200)
@@ -77,7 +88,7 @@ class ViewsTestCase(TestCase):
     def test_posts(self):
         request = HttpRequest()
         post_data = '{"name": "Ball", "artnr": "12345"}'
-        request._raw_post_data = post_data
+        setattr(request, "_" + self.body_attr, post_data)
         
         resp = self.client.post('/api/v1/products/', data=post_data, content_type='application/json')
         self.assertEqual(resp.status_code, 201)
@@ -93,7 +104,7 @@ class ViewsTestCase(TestCase):
         # With appended characters
         request = HttpRequest()
         post_data = '{"name": "Ball 2", "artnr": "12345ABC"}'
-        request._raw_post_data = post_data
+        setattr(request, "_" + self.body_attr, post_data)
         
         resp = self.client.post('/api/v1/products/', data=post_data, content_type='application/json')
         self.assertEqual(resp.status_code, 201)
@@ -109,7 +120,7 @@ class ViewsTestCase(TestCase):
         # With prepended characters
         request = HttpRequest()
         post_data = '{"name": "Ball 3", "artnr": "WK12345"}'
-        request._raw_post_data = post_data
+        setattr(request, "_" + self.body_attr, post_data)
         
         resp = self.client.post('/api/v1/products/', data=post_data, content_type='application/json')
         self.assertEqual(resp.status_code, 201)
@@ -125,7 +136,7 @@ class ViewsTestCase(TestCase):
         # Now Primary Keys with Slashes
         request = HttpRequest()
         post_data = '{"name": "Bigwheel", "artnr": "76123/03"}'
-        request._raw_post_data = post_data
+        setattr(request, "_" + self.body_attr, post_data)
         
         resp = self.client.post('/api/v1/products/', data=post_data, content_type='application/json')
         self.assertEqual(resp.status_code, 201)
@@ -140,7 +151,7 @@ class ViewsTestCase(TestCase):
         
         request = HttpRequest()
         post_data = '{"name": "Trampolin", "artnr": "WS65150/02"}'
-        request._raw_post_data = post_data
+        setattr(request, "_" + self.body_attr, post_data)
         
         resp = self.client.post('/api/v1/products/', data=post_data, content_type='application/json')
         self.assertEqual(resp.status_code, 201)

--- a/tests/alphanumeric/urls.py
+++ b/tests/alphanumeric/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
     (r'^api/', include('alphanumeric.api.urls')),

--- a/tests/authorization/urls.py
+++ b/tests/authorization/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import patterns, url, include
+try:
+    from django.conf.urls import patterns, url, include
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import patterns, url, include
 
 from tastypie.api import Api
 from .api.resources import ArticleResource, AuthorProfileResource, SiteResource, UserResource

--- a/tests/basic/api/urls.py
+++ b/tests/basic/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from basic.api.resources import NoteResource, UserResource, BustedResource, CachedUserResource, PublicCachedUserResource, PrivateCachedUserResource, SlugBasedNoteResource, SessionUserResource
 

--- a/tests/basic/tests/http.py
+++ b/tests/basic/tests/http.py
@@ -1,6 +1,9 @@
 import httplib
 from testcases import TestServerTestCase
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError: # < Python 2.6
+    from django.utils import simplejson as json
 
 
 class HTTPTestCase(TestServerTestCase):

--- a/tests/basic/tests/views.py
+++ b/tests/basic/tests/views.py
@@ -1,10 +1,21 @@
+import django
 from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.test import TestCase, Client
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError: # < Python 2.6
+    from django.utils import simplejson as json
 
 
 class ViewsTestCase(TestCase):
+    def setUp(self):
+        if django.VERSION >= (1, 4):
+            self.body_attr = "body"
+        else:
+            self.body_attr = "raw_post_data"
+        super(ViewsTestCase, self).setUp()
+
     def test_gets(self):
         resp = self.client.get('/api/v1/', data={'format': 'json'})
         self.assertEqual(resp.status_code, 200)
@@ -40,7 +51,7 @@ class ViewsTestCase(TestCase):
     def test_posts(self):
         request = HttpRequest()
         post_data = '{"content": "A new post.", "is_active": true, "title": "New Title", "slug": "new-title", "user": "/api/v1/users/1/"}'
-        request._raw_post_data = post_data
+        setattr(request, "_" + self.body_attr, post_data)
 
         resp = self.client.post('/api/v1/notes/', data=post_data, content_type='application/json')
         self.assertEqual(resp.status_code, 201)
@@ -57,7 +68,7 @@ class ViewsTestCase(TestCase):
     def test_puts(self):
         request = HttpRequest()
         post_data = '{"content": "Another new post.", "is_active": true, "title": "Another New Title", "slug": "new-title", "user": "/api/v1/users/1/"}'
-        request._raw_post_data = post_data
+        setattr(request, "_" + self.body_attr, post_data)
 
         resp = self.client.put('/api/v1/notes/1/', data=post_data, content_type='application/json')
         self.assertEqual(resp.status_code, 204)
@@ -75,7 +86,7 @@ class ViewsTestCase(TestCase):
         # back to the user.
         request = HttpRequest()
         post_data = '{"content": "More internet memes.", "is_active": true, "title": "IT\'S OVER 9000!", "slug": "its-over", "user": "/api/v1/users/9001/"}'
-        request._raw_post_data = post_data
+        setattr(request, "_" + self.body_attr, post_data)
 
         resp = self.client.post('/api/v1/notes/', data=post_data, content_type='application/json')
         self.assertEqual(resp.status_code, 400)

--- a/tests/basic/urls.py
+++ b/tests/basic/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
     (r'^api/', include('basic.api.urls')),

--- a/tests/complex/api/urls.py
+++ b/tests/complex/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from complex.api.resources import PostResource, ProfileResource, CommentResource, UserResource, GroupResource
 

--- a/tests/complex/urls.py
+++ b/tests/complex/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
     (r'^api/', include('complex.api.urls')),

--- a/tests/content_gfk/api/urls.py
+++ b/tests/content_gfk/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from content_gfk.api.resources import NoteResource, QuoteResource, \
     RatingResource, DefinitionResource

--- a/tests/content_gfk/urls.py
+++ b/tests/content_gfk/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
     (r'^api/', include('content_gfk.api.urls')),

--- a/tests/core/tests/api_urls.py
+++ b/tests/core/tests/api_urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from core.tests.api import Api, NoteResource, UserResource
 
 

--- a/tests/core/tests/field_urls.py
+++ b/tests/core/tests/field_urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from tastypie import fields
 from tastypie.resources import ModelResource
 from core.models import Note, Subject

--- a/tests/core/tests/manual_urls.py
+++ b/tests/core/tests/manual_urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from core.tests.resources import NoteResource
 
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -12,7 +12,10 @@ from django.core.urlresolvers import reverse
 from django import forms
 from django.http import HttpRequest, QueryDict, Http404
 from django.test import TestCase
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError: # < Python 2.6
+    from django.utils import simplejson as json
 from tastypie.authentication import BasicAuthentication
 from tastypie.authorization import Authorization
 from tastypie.bundle import Bundle
@@ -1212,6 +1215,11 @@ class ModelResourceTestCase(TestCase):
         )
         self.note_1.subjects.add(self.subject_1)
         self.note_1.subjects.add(self.subject_2)
+        
+        if django.VERSION >= (1, 4):
+            self.body_attr = "body"
+        else:
+            self.body_attr = "raw_post_data"
 
     def test_init(self):
         # Very minimal & stock.
@@ -1931,7 +1939,7 @@ class ModelResourceTestCase(TestCase):
         request.method = 'PUT'
 
         self.assertEqual(Note.objects.count(), 6)
-        request.raw_post_data = '{"objects": [{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back-again", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"}]}'
+        setattr(request, self.body_attr, '{"objects": [{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back-again", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"}]}')
 
         resp = resource.put_list(request)
         self.assertEqual(resp.status_code, 204)
@@ -1952,7 +1960,7 @@ class ModelResourceTestCase(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
-        request.raw_post_data = '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"}'
+        setattr(request, self.body_attr, '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"}')
 
         resp = resource.put_detail(request, pk=10)
         self.assertEqual(resp.status_code, 201)
@@ -1960,7 +1968,7 @@ class ModelResourceTestCase(TestCase):
         new_note = Note.objects.get(slug='cat-is-back')
         self.assertEqual(new_note.content, "The cat is back. The dog coughed him up out back.")
 
-        request.raw_post_data = '{"content": "The cat is gone again. I think it was the rabbits that ate him this time.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Gone", "updated": "2010-04-03 20:05:00"}'
+        setattr(request, self.body_attr, '{"content": "The cat is gone again. I think it was the rabbits that ate him this time.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Gone", "updated": "2010-04-03 20:05:00"}')
 
         resp = resource.put_detail(request, pk=10)
         self.assertEqual(resp.status_code, 204)
@@ -1989,7 +1997,7 @@ class ModelResourceTestCase(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
-        request.raw_post_data = '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00", "author": null}'
+        setattr(request, self.body_attr, '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00", "author": null}')
 
         resp = nullable_resource.put_detail(request, pk=10)
         self.assertEqual(resp.status_code, 204)
@@ -2001,7 +2009,7 @@ class ModelResourceTestCase(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
-        request.raw_post_data = '{"date": "2012-09-07", "username": "WAT", "message": "hello"}'
+        setattr(request, self.body_attr, '{"date": "2012-09-07", "username": "WAT", "message": "hello"}')
 
         date_record_resource = DateRecordResource()
         resp = date_record_resource.put_detail(request, username="maraujop")
@@ -2013,7 +2021,7 @@ class ModelResourceTestCase(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
-        request.raw_post_data = '{"date": "WAT", "username": "maraujop", "message": "hello"}'
+        setattr(request, self.body_attr, '{"date": "WAT", "username": "maraujop", "message": "hello"}')
 
         date_record_resource = DateRecordResource()
         resp = date_record_resource.put_detail(request, date="2012-09-07")
@@ -2025,7 +2033,7 @@ class ModelResourceTestCase(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
-        request.raw_post_data = '{"date": "2012-09-07", "username": "maraujop", "message": "WAT"}'
+        setattr(request, self.body_attr, '{"date": "2012-09-07", "username": "maraujop", "message": "WAT"}')
         date_record_resource = DateRecordResource()
         resp = date_record_resource.put_detail(request, message="HELLO")
 
@@ -2039,7 +2047,7 @@ class ModelResourceTestCase(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'POST'
-        request.raw_post_data = '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"}'
+        setattr(request, self.body_attr, '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"}')
 
         resp = resource.post_list(request)
         self.assertEqual(resp.status_code, 201)

--- a/tests/gis/api/urls.py
+++ b/tests/gis/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from gis.api.resources import GeoNoteResource, UserResource
 

--- a/tests/gis/tests/http.py
+++ b/tests/gis/tests/http.py
@@ -1,7 +1,10 @@
 import httplib
 from urllib import quote
 from testcases import TestServerTestCase
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError: # < Python 2.6
+    from django.utils import simplejson as json
 
 
 class HTTPTestCase(TestServerTestCase):

--- a/tests/gis/tests/views.py
+++ b/tests/gis/tests/views.py
@@ -1,6 +1,9 @@
 from django.http import HttpRequest
 from django.test import TestCase
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError: # < Python 2.6
+    from django.utils import simplejson as json
 
 
 class ViewsTestCase(TestCase):
@@ -35,7 +38,7 @@ class ViewsTestCase(TestCase):
     def test_posts(self):
         request = HttpRequest()
         post_data = '{"content": "A new post.", "is_active": true, "title": "New Title", "slug": "new-title", "user": "/api/v1/users/1/"}'
-        request._raw_post_data = post_data
+        request._body = request._raw_post_data = post_data
 
         resp = self.client.post('/api/v1/geonotes/', data=post_data, content_type='application/json')
         self.assertEqual(resp.status_code, 201)
@@ -52,7 +55,7 @@ class ViewsTestCase(TestCase):
     def test_puts(self):
         request = HttpRequest()
         post_data = '{"content": "Another new post.", "is_active": true, "title": "Another New Title", "slug": "new-title", "user": "/api/v1/users/1/", "lines": null, "points": null, "polys": null}'
-        request._raw_post_data = post_data
+        request._body = request._raw_post_data = post_data
 
         resp = self.client.put('/api/v1/geonotes/1/', data=post_data, content_type='application/json')
         self.assertEqual(resp.status_code, 204)
@@ -70,7 +73,7 @@ class ViewsTestCase(TestCase):
         # back to the user.
         request = HttpRequest()
         post_data = '{"content": "More internet memes.", "is_active": true, "title": "IT\'S OVER 9000!", "slug": "its-over", "user": "/api/v1/users/9001/"}'
-        request._raw_post_data = post_data
+        request._body = request._raw_post_data = post_data
 
         resp = self.client.post('/api/v1/geonotes/', data=post_data, content_type='application/json')
         self.assertEqual(resp.status_code, 400)

--- a/tests/gis/urls.py
+++ b/tests/gis/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
     (r'^api/', include('gis.api.urls')),

--- a/tests/namespaced/api/urls.py
+++ b/tests/namespaced/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import NamespacedApi
 from namespaced.api.resources import NamespacedNoteResource, NamespacedUserResource
 

--- a/tests/namespaced/tests.py
+++ b/tests/namespaced/tests.py
@@ -2,7 +2,10 @@ from django.conf import settings
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.http import HttpRequest
 from django.test import TestCase
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError: # < Python 2.6
+    from django.utils import simplejson as json
 
 
 class NamespacedViewsTestCase(TestCase):

--- a/tests/related_resource/api/urls.py
+++ b/tests/related_resource/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from related_resource.api.resources import NoteResource, UserResource, \
         CategoryResource, TagResource, TaggableTagResource, TaggableResource, \

--- a/tests/related_resource/tests.py
+++ b/tests/related_resource/tests.py
@@ -1,7 +1,11 @@
+import django
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError: # < Python 2.6
+    from django.utils import simplejson as json
 from django.core.urlresolvers import reverse
 from core.models import Note, MediaBit
 from core.tests.resources import HttpRequest
@@ -18,13 +22,17 @@ class RelatedResourceTest(TestCase):
     def setUp(self):
         super(RelatedResourceTest, self).setUp()
         self.user = User.objects.create(username="testy_mctesterson")
+        if django.VERSION >= (1, 4):
+            self.body_attr = "body"
+        else:
+            self.body_attr = "raw_post_data"
 
     def test_cannot_access_user_resource(self):
         resource = api.canonical_resource_for('users')
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
-        request.raw_post_data = '{"username": "foobar"}'
+        setattr(request, self.body_attr, '{"username": "foobar"}')
         resp = resource.wrap_view('dispatch_detail')(request, pk=self.user.pk)
 
         self.assertEqual(resp.status_code, 405)
@@ -36,7 +44,7 @@ class RelatedResourceTest(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'POST'
-        request.raw_post_data = '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00", "author": null}'
+        setattr(request, self.body_attr, '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00", "author": null}')
 
         resp = resource.post_list(request)
         self.assertEqual(resp.status_code, 201)
@@ -45,7 +53,7 @@ class RelatedResourceTest(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'POST'
-        request.raw_post_data = '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back-2", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00", "author": {"id": %s, "username": "foobar"}}' % self.user.id
+        setattr(request, self.body_attr, '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back-2", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00", "author": {"id": %s, "username": "foobar"}}' % self.user.id)
 
         resp = resource.post_list(request)
         self.assertEqual(resp.status_code, 201)
@@ -61,6 +69,10 @@ class CategoryResourceTest(TestCase):
         self.parent_cat_2 = Category.objects.create(parent=None, name='Mom')
         self.child_cat_1 = Category.objects.create(parent=self.parent_cat_1, name='Son')
         self.child_cat_2 = Category.objects.create(parent=self.parent_cat_2, name='Daughter')
+        if django.VERSION >= (1, 4):
+            self.body_attr = "body"
+        else:
+            self.body_attr = "raw_post_data"
 
     def test_correct_relation(self):
         resource = api.canonical_resource_for('category')
@@ -87,7 +99,7 @@ class CategoryResourceTest(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
-        request.raw_post_data = '{"parent": null, "name": "Son"}'
+        setattr(request, self.body_attr, '{"parent": null, "name": "Son"}')
 
         # Before the PUT, there should be a parent.
         self.assertEqual(Category.objects.get(pk=self.child_cat_1.pk).parent.pk, self.parent_cat_1.pk)
@@ -112,6 +124,11 @@ class ExplicitM2MResourceRegressionTest(TestCase):
 
         # Give each tag some extra data (the lookup of this data is what makes the test fail)
         self.extradata_1 = ExtraData.objects.create(tag=self.tag_1, name='additional')
+        
+        if django.VERSION >= (1, 4):
+            self.body_attr = "body"
+        else:
+            self.body_attr = "raw_post_data"
 
     def test_correct_setup(self):
         request = MockRequest()
@@ -148,7 +165,7 @@ class ExplicitM2MResourceRegressionTest(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'POST'
-        request.raw_post_data = '{"name": "school", "taggabletags": [ ]}'
+        setattr(request, self.body_attr, '{"name": "school", "taggabletags": [ ]}')
 
         # Prior to the addition of ``blank=True``, this would
         # fail badly.
@@ -168,6 +185,13 @@ class ExplicitM2MResourceRegressionTest(TestCase):
 
 class OneToManySetupTestCase(TestCase):
     urls = 'related_resource.api.urls'
+    
+    def setUp(self):
+        super(OneToManySetupTestCase, self).setUp()
+        if django.VERSION >= (1, 4):
+            self.body_attr = "body"
+        else:
+            self.body_attr = "raw_post_data"
 
     def test_one_to_many(self):
         # Sanity checks.
@@ -191,7 +215,7 @@ class OneToManySetupTestCase(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'POST'
-        request.raw_post_data = json.dumps(data)
+        setattr(request, self.body_attr, json.dumps(data))
 
         resp = fnr.post_list(request)
         self.assertEqual(resp.status_code, 201)
@@ -207,6 +231,13 @@ class FullCategoryResource(CategoryResource):
 
 class RelatedPatchTestCase(TestCase):
     urls = 'related_resource.api.urls'
+    
+    def setUp(self):
+        super(RelatedPatchTestCase, self).setUp()
+        if django.VERSION >= (1, 4):
+            self.body_attr = "body"
+        else:
+            self.body_attr = "raw_post_data"
 
     def test_patch_to_one(self):
         resource = FullCategoryResource()
@@ -223,7 +254,7 @@ class RelatedPatchTestCase(TestCase):
             'name': 'Kid'
         }
 
-        request._raw_post_data = request._body = json.dumps(data)
+        setattr(request, "_" + self.body_attr, json.dumps(data))
         self.assertEqual(cat2.name, 'Child')
         resp = resource.patch_detail(request, pk=cat2.pk)
         self.assertEqual(resp.status_code, 202)
@@ -233,6 +264,13 @@ class RelatedPatchTestCase(TestCase):
 
 class NestedRelatedResourceTest(TestCase):
     urls = 'related_resource.api.urls'
+
+    def setUp(self):
+        super(NestedRelatedResourceTest, self).setUp()
+        if django.VERSION >= (1, 4):
+            self.body_attr = "body"
+        else:
+            self.body_attr = "raw_post_data"
 
     def test_one_to_one(self):
         """
@@ -257,7 +295,7 @@ class NestedRelatedResourceTest(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'POST'
-        request.raw_post_data = json.dumps(data)
+        setattr(request, self.body_attr, json.dumps(data))
         resp = pr.post_list(request)
         self.assertEqual(resp.status_code, 201)
 
@@ -281,7 +319,7 @@ class NestedRelatedResourceTest(TestCase):
         request.GET = {'format': 'json'}
         request.method = 'PUT'
         request.path = reverse('api_dispatch_detail', kwargs={'pk': pk, 'resource_name': pr._meta.resource_name, 'api_name': pr._meta.api_name})
-        request.raw_post_data = resp.content
+        setattr(request, self.body_attr, resp.content)
         resp = pr.put_detail(request, pk=pk)
         self.assertEqual(resp.status_code, 204)
 
@@ -310,7 +348,7 @@ class NestedRelatedResourceTest(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'POST'
-        request.raw_post_data = json.dumps(data)
+        setattr(request, self.body_attr, json.dumps(data))
         resp = pr.post_list(request)
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(Person.objects.count(), 1)
@@ -338,7 +376,7 @@ class NestedRelatedResourceTest(TestCase):
         request.GET = {'format': 'json'}
         request.method = 'PUT'
         request.path = reverse('api_dispatch_detail', kwargs={'pk': pk, 'resource_name': pr._meta.resource_name, 'api_name': pr._meta.api_name})
-        request.raw_post_data = json.dumps(person)
+        setattr(request, self.body_attr, json.dumps(person))
         resp = pr.put_detail(request, pk=pk)
         self.assertEqual(resp.status_code, 204)
 
@@ -367,7 +405,7 @@ class NestedRelatedResourceTest(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'POST'
-        request.raw_post_data = json.dumps(data)
+        setattr(request, self.body_attr, json.dumps(data))
         resp = pr.post_list(request)
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(Person.objects.count(), 1)
@@ -394,7 +432,7 @@ class NestedRelatedResourceTest(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
-        request.raw_post_data = json.dumps(person)
+        setattr(request, self.body_attr, json.dumps(person))
         request.path = reverse('api_dispatch_detail', kwargs={'pk': pk, 'resource_name': pr._meta.resource_name, 'api_name': pr._meta.api_name})
         resp = pr.put_detail(request, pk=pk)
         self.assertEqual(resp.status_code, 204)
@@ -427,7 +465,7 @@ class NestedRelatedResourceTest(TestCase):
         request.GET = {'format': 'json'}
         request.method = 'POST'
         request.path = reverse('api_dispatch_list', kwargs={'resource_name': pr._meta.resource_name, 'api_name': pr._meta.api_name})
-        request.raw_post_data = json.dumps(data)
+        setattr(request, self.body_attr, json.dumps(data))
         resp = pr.post_list(request)
         self.assertEqual(resp.status_code, 201)
         self.assertEqual(Person.objects.count(), 1)
@@ -455,7 +493,7 @@ class NestedRelatedResourceTest(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
-        request.raw_post_data = json.dumps(person)
+        setattr(request, self.body_attr, json.dumps(person))
         request.path = reverse('api_dispatch_detail', kwargs={'pk': pk, 'resource_name': pr._meta.resource_name, 'api_name': pr._meta.api_name})
         resp = pr.put_detail(request, pk=pk)
         self.assertEqual(resp.status_code, 204)

--- a/tests/slashless/api/urls.py
+++ b/tests/slashless/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from slashless.api.resources import NoteResource, UserResource
 

--- a/tests/slashless/tests.py
+++ b/tests/slashless/tests.py
@@ -2,7 +2,10 @@ from django.conf import settings
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.http import HttpRequest
 from django.test import TestCase
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError: # < Python 2.6
+    from django.utils import simplejson as json
 
 
 class ViewsWithoutSlashesTestCase(TestCase):

--- a/tests/validation/api/urls.py
+++ b/tests/validation/api/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError: # Django < 1.4
+    from django.conf.urls.defaults import *
 from tastypie.api import Api
 from validation.api.resources import NoteResource, UserResource, AnnotatedNoteResource
 

--- a/tests/validation/tests.py
+++ b/tests/validation/tests.py
@@ -2,7 +2,10 @@ from django.conf import settings
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.http import HttpRequest
 from django.test import TestCase
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError: # < Python 2.6
+    from django.utils import simplejson as json
 #settings.DEBUG = True
 
 from basic.models import Note


### PR DESCRIPTION
- Now uses native json module rather than simplejson where supported
- No longer uses django.conf.urls.defaults on newer versions of Django
- Uses native copy module rather than Django's deprecated copycompat if the python version is >= 2.5.  This was the release that the native copy module started to support copying functions.
- Now using request.body instead of the deprecated request.raw_post_data.
