### PR TITLE
Disabling Dehydration

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -87,6 +87,7 @@ class ResourceOptions(object):
     always_return_data = False
     collection_name = 'objects'
     detail_uri_name = 'pk'
+    dehydrate = True
 
     def __new__(cls, meta=None):
         overrides = {}
@@ -1274,7 +1275,10 @@ class Resource(object):
 
         for obj in to_be_serialized[self._meta.collection_name]:
             bundle = self.build_bundle(obj=obj, request=request)
-            bundles.append(self.full_dehydrate(bundle))
+            if self._meta.dehydrate:
+                bundles.append(self.full_dehydrate(bundle))
+            else:
+                bundles.append(bundle)
 
         to_be_serialized[self._meta.collection_name] = bundles
         to_be_serialized = self.alter_list_data_to_serialize(request, to_be_serialized)


### PR DESCRIPTION
In a project using Tastypie as the API component, was recently looking at performance optimisations for cases where the API has to serve relatively large datasets ~= 10K rows/objects.

Turns out that disabling the loop through the dehydrate cycle for each object gave a factor 8 speedup (worth having).

Adding an option to the resource meta to allow the user disable dehydration if they so wish would seem to be a plausible "sensible-defaults, disable for edge cases" workaround?
