### PR TITLE
In DecimalField.hydrate, catch decimal.InvalidOperation and raise ApiFieldError

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -1,6 +1,7 @@
 import datetime
 from dateutil.parser import parse
 from decimal import Decimal
+import decimal
 import re
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.utils import datetime_safe, importlib
@@ -264,7 +265,10 @@ class DecimalField(ApiField):
         value = super(DecimalField, self).hydrate(bundle)
 
         if value and not isinstance(value, Decimal):
-            value = Decimal(value)
+            try:
+                value = Decimal(value)
+            except decimal.InvalidOperation:
+                raise ApiFieldError("Invalid decimal string for '%s' field: '%s'" % (self.instance_name, value))
 
         return value
 

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -324,6 +324,11 @@ class DecimalFieldTestCase(TestCase):
         field_3.instance_name='foo'
         self.assertEqual(field_3.hydrate(bundle), Decimal('1.5'))
 
+        bundle = Bundle(data={'foo':'xxx'})
+        field_4 = DecimalField(attribute='foo')
+        field_4.instance_name = 'foo'
+        self.assertRaises(ApiFieldError, field_4.hydrate, bundle)
+
     def test_model_resource_correct_association(self):
         api_field = ModelResource.api_field_from_django_field(models.DecimalField())
         self.assertEqual(api_field, DecimalField)

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -319,6 +319,11 @@ class DecimalFieldTestCase(TestCase):
         field_2 = DecimalField(default='18.5')
         self.assertEqual(field_2.hydrate(bundle), Decimal('18.5'))
 
+        bundle = Bundle(data={'foo':'1.5'})
+        field_3 = DecimalField()
+        field_3.instance_name='foo'
+        self.assertEqual(field_3.hydrate(bundle), Decimal('1.5'))
+
     def test_model_resource_correct_association(self):
         api_field = ModelResource.api_field_from_django_field(models.DecimalField())
         self.assertEqual(api_field, DecimalField)


### PR DESCRIPTION
Current behavior when invalid data is submitted to `DecimalField.hydrate` is to let the `InvalidOperation` error escape to the top level, resulting in a 500 error. This patch adds tests to ensure that this does not happen and, analogously to invalid date formats, raises an `ApiFieldError`.
