### PR TITLE
Python 2.x Unicode support

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -10,7 +10,6 @@ from django.db import transaction
 from django.db.models.sql.constants import QUERY_TERMS
 from django.http import HttpResponse, HttpResponseNotFound, Http404
 from django.utils.cache import patch_cache_control, patch_vary_headers
-from django.utils.six import text_type
 from tastypie.authentication import Authentication
 from tastypie.authorization import ReadOnlyAuthorization
 from tastypie.bundle import Bundle
@@ -525,7 +524,7 @@ class Resource(object):
             allowed = []
 
         request_method = request.method.lower()
-        allows = ','.join(map(text_type.upper, allowed))
+        allows = ','.join(map(lambda x: x.upper(), allowed))
 
         if request_method == "options":
             response = HttpResponse(allows)


### PR DESCRIPTION
In the tastypie/resources.py: Resource.method_check

``` Python
def method_check(self, request, allowed=None):
        """
        Ensures that the HTTP method used on the request is allowed to be
        handled by the resource.

        Takes an ``allowed`` parameter, which should be a list of lowercase
        HTTP methods to check against. Usually, this looks like::

            # The most generic lookup.
            self.method_check(request, self._meta.allowed_methods)

            # A lookup against what's allowed for list-type methods.
            self.method_check(request, self._meta.list_allowed_methods)

            # A useful check when creating a new endpoint that only handles
            # GET.
            self.method_check(request, ['get'])
        """
        if allowed is None:
            allowed = []

        request_method = request.method.lower()
        allows = ','.join(map(str.upper, allowed))
```

The "allows" line is broken when I defined the allowed_methods in unicode form of Python 2.x.
For example:

``` Python
from __future__ import unicode_literals
allowed_methods = ['get']
```

Probably can be solved with "six" which is shipped with django.

``` Python
from django.utils.six import text_type
allows = ','.join(map(text_type.upper, allowed))
```
