### PR TITLE
Fix Django 1.3 tests

### DIFF
--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -1,8 +1,8 @@
 import warnings
 try:
-    from django.conf.urls import *
+    from django.conf.urls import url, patterns, include
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import url, patterns, include
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseBadRequest

--- a/tests/alphanumeric/urls.py
+++ b/tests/alphanumeric/urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, include
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, include
 
 urlpatterns = patterns('',
     (r'^api/', include('alphanumeric.api.urls')),

--- a/tests/basic/urls.py
+++ b/tests/basic/urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, include
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, include
 
 urlpatterns = patterns('',
     (r'^api/', include('basic.api.urls')),

--- a/tests/complex/urls.py
+++ b/tests/complex/urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, include
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, include
 
 urlpatterns = patterns('',
     (r'^api/', include('complex.api.urls')),

--- a/tests/content_gfk/urls.py
+++ b/tests/content_gfk/urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, include
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, include
 
 urlpatterns = patterns('',
     (r'^api/', include('content_gfk.api.urls')),

--- a/tests/core/tests/api_urls.py
+++ b/tests/core/tests/api_urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, include
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, include
 from core.tests.api import Api, NoteResource, UserResource
 
 

--- a/tests/core/tests/field_urls.py
+++ b/tests/core/tests/field_urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, include
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, include
 from tastypie import fields
 from tastypie.resources import ModelResource
 from core.models import Note, Subject

--- a/tests/core/tests/manual_urls.py
+++ b/tests/core/tests/manual_urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, include
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, include
 from core.tests.resources import NoteResource
 
 

--- a/tests/gis/urls.py
+++ b/tests/gis/urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, include
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, include
 
 urlpatterns = patterns('',
     (r'^api/', include('gis.api.urls')),

--- a/tests/namespaced/api/urls.py
+++ b/tests/namespaced/api/urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, include, url
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, include, url
 from tastypie.api import NamespacedApi
 from namespaced.api.resources import NamespacedNoteResource, NamespacedUserResource
 

--- a/tests/slashless/api/urls.py
+++ b/tests/slashless/api/urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, include, url
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, include, url
 from tastypie.api import Api
 from slashless.api.resources import NoteResource, UserResource
 

--- a/tests/validation/api/urls.py
+++ b/tests/validation/api/urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, include, url
 except ImportError: # Django < 1.4
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, include, url
 from tastypie.api import Api
 from validation.api.resources import NoteResource, UserResource, AnnotatedNoteResource
 


### PR DESCRIPTION
Many, many tests were failing in the Django 1.3 tox environments due to
some faulty import logic. This patch fixes them all.
