### PR TITLE
Fixed broken datetime now for django 1.5

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,6 +76,7 @@ Contributors:
 * Vitaly Babiy (vbabiy) form validation, and django 1.5 support. 
 * Nathaniel Tucker (ntucker) django 1.5 support.
 * Soren Hansen (sorenh) Fixing tests for django 1.3.
+* Michal Dub (MichalMaM) Fixed broken datetime now for django 1.5 with setting USE_TZ set to False
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/tastypie/utils/timezone.py
+++ b/tastypie/utils/timezone.py
@@ -17,6 +17,8 @@ try:
         return value
 
     def now():
+        if hasattr(timezone, "template_localtime"):
+            return timezone.template_localtime(timezone.now())
         return timezone.localtime(timezone.now())
 
 except ImportError:


### PR DESCRIPTION
Fixed broken datetime now for django 1.5 with setting USE_TZ set to False, becouse django 1.5 in localtime function does not check if datetime is valid (but function template_localtime check it).