### PR TITLE
Pass bundle object to build_filters

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -724,7 +724,7 @@ class Resource(object):
             objects_saved=objects_saved
         )
 
-    def build_filters(self, bundle, filters=None):
+    def build_filters(self, filters=None, bundle=None):
         """
         Allows for the filtering of applicable objects.
 
@@ -1956,7 +1956,7 @@ class ModelResource(Resource):
 
         return value
 
-    def build_filters(self, bundle, filters=None):
+    def build_filters(self, filters=None, bundle=None):
         """
         Given a dictionary of filters, create the necessary ORM-level filters.
 
@@ -2106,7 +2106,7 @@ class ModelResource(Resource):
 
         # Update with the provided kwargs.
         filters.update(kwargs)
-        applicable_filters = self.build_filters(bundle, filters=filters)
+        applicable_filters = self.build_filters(filters=filters, bundle=bundle)
 
         try:
             objects = self.apply_filters(bundle.request, applicable_filters)


### PR DESCRIPTION
I was trying to build a custom filter using build_filters and found that I needed access to the bundle.request.user object. After reading through the surrounding code, especially the obj_get_list which immediately calls build_filters, it became more and more apparent that build_filters should also accept the bundle as its first argument.

The main reasoning is that in the filter, you suggest even in the documentation that you can query from the orm or some other source in order to create a custom filter. If one wanted to make a complex query involving contextual information, how could they achieve that behavior without the bundle itself?

The tests appeared to pass.
