### PR TITLE
Don't rely on ``request.path`` or ``request.path_info`` to determine single vs list of resources

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -862,7 +862,7 @@ class Resource(object):
                 field_object.api_name = self._meta.api_name
                 field_object.resource_name = self._meta.resource_name
 
-            bundle.data[field_name] = field_object.dehydrate(bundle)
+            bundle.data[field_name] = field_object.dehydrate(bundle, for_list=for_list)
 
             # Check for an optional method to do further dehydration.
             method = getattr(self, "dehydrate_%s" % field_name, None)

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -719,7 +719,7 @@ class ToOneFieldTestCase(TestCase):
         #list path with full_detail=False
         request.path = "/api/v1/notes/1/"
         field_1 = ToOneField(UserResource, 'author', full=True, full_detail=False)
-        self.assertEqual(field_1.dehydrate(bundle), '/api/v1/users/1/')
+        self.assertEqual(field_1.dehydrate(bundle, for_list=False), '/api/v1/users/1/')
 
     def test_hydrate(self):
         note = Note()
@@ -1090,7 +1090,7 @@ class ToManyFieldTestCase(TestCase):
         request = MockRequest()
         request.path = "/api/v1/subjects/%(pk)s/" % {'pk': self.note_1.pk}
         bundle_1 = Bundle(obj=self.note_1, request=request)
-        self.assertEqual(field_1.dehydrate(bundle_1), ['/api/v1/subjects/1/', '/api/v1/subjects/2/'])
+        self.assertEqual(field_1.dehydrate(bundle_1, for_list=False), ['/api/v1/subjects/1/', '/api/v1/subjects/2/'])
 
         #list path with full_detail=False
         field_2 = ToManyField(SubjectResource, 'subjects', full=True, full_detail=False)
@@ -1125,7 +1125,7 @@ class ToManyFieldTestCase(TestCase):
         request = MockRequest()
         request.path = "/api/v1/subjects/%(pk)s/" % {'pk': self.note_1.pk}
         bundle_4 = Bundle(obj=self.note_1, request=request)
-        subject_bundle_list = field_4.dehydrate(bundle_4)
+        subject_bundle_list = field_4.dehydrate(bundle_4, for_list=False)
         self.assertEqual(len(subject_bundle_list), 2)
         self.assertEqual(isinstance(subject_bundle_list[0], Bundle), True)
         self.assertEqual(subject_bundle_list[0].data['name'], u'News')
@@ -1190,7 +1190,7 @@ class ToManyFieldTestCase(TestCase):
         request = MockRequest()
         request.path = "/api/v1/subjects/%(pk)s/" % {'pk': self.note_1.pk}
         bundle_8 = Bundle(obj=self.note_1, request=request)
-        self.assertEqual(field_8.dehydrate(bundle_8), ['/api/v1/subjects/1/', '/api/v1/subjects/2/'])
+        self.assertEqual(field_8.dehydrate(bundle_8, for_list=False), ['/api/v1/subjects/1/', '/api/v1/subjects/2/'])
 
         #detail url with full_detail=True and get parameters
         field_9 = ToManyField(SubjectResource, 'subjects', full=True, full_detail=True)

--- a/tests/related_resource/tests.py
+++ b/tests/related_resource/tests.py
@@ -358,7 +358,6 @@ class NestedRelatedResourceTest(TestCase):
         pk = Person.objects.all()[0].pk
         request = MockRequest()
         request.method = 'GET'
-        request.path = reverse('api_dispatch_detail', kwargs={'pk': pk, 'resource_name': pr._meta.resource_name, 'api_name': pr._meta.api_name})
         resp = pr.get_detail(request, pk=pk)
         self.assertEqual(resp.status_code, 200)
 
@@ -375,7 +374,6 @@ class NestedRelatedResourceTest(TestCase):
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
-        request.path = reverse('api_dispatch_detail', kwargs={'pk': pk, 'resource_name': pr._meta.resource_name, 'api_name': pr._meta.api_name})
         setattr(request, self.body_attr, json.dumps(person))
         resp = pr.put_detail(request, pk=pk)
         self.assertEqual(resp.status_code, 204)


### PR DESCRIPTION
Fixes #850.
Instead of using path to determin if we are dehydrating a list of resources or a single resource, we explicitly pass a boolean.

This should also make writing tests easier as we no longer need to have path defined for requests.
