### PR TITLE
Update models.py

### DIFF
--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -57,5 +57,9 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
         """
         A signal for hooking up automatic ``ApiKey`` creation.
         """
+        # Turn off signal when loading fixture data
+        # cf https://code.djangoproject.com/ticket/20136
+        if kwargs['raw']:
+            return
         if kwargs.get('created') is True:
             ApiKey.objects.create(user=kwargs.get('instance'))

--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -59,7 +59,7 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
         """
         # Turn off signal when loading fixture data
         # cf https://code.djangoproject.com/ticket/20136
-        if kwargs['raw']:
+        if kwargs.get('raw', False):
             return
         if kwargs.get('created') is True:
             ApiKey.objects.create(user=kwargs.get('instance'))


### PR DESCRIPTION
loaddata breaks because of the tastypie signal. This is probably a bug in django, but until it gets fixed, the solution is just to disable signals on loaddata.