### PR TITLE
Allow filtering against foreign resources by using the resource URI

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,12 +79,11 @@ Contributors:
 * Matt DeBoard (mattdeboard) for a patch to optionally set ``abstract = True`` on the ApiKey model.
 * Paul Grau (graup) Addition of iso-8601-strict to available TASTYPIE_DATETIME_FORMATTING.
 * Eric Plumb (professorplumb) for fixing the nested resource example in the cookbook.
-* Willem Bult (willembult) for fixing a bug with updating updating foreign key resources during create.
+* Willem Bult (willembult) for fixing a bug with updating updating foreign key resources during create and a patch that allows filtering foreign resources by their resource URI.
 * Yuri Govorushchenko (metametadata) for enhancing documentation on how to convert list of resources into JSON within a django template.
 * Revolution Systems & The Python Software Foundation for funding a significant portion of the port to Python 3!
 * tunix for a patch related to Tastypie's timezone-aware dates.
 * Steven Davidson (damycra) for a documentation patch.
-
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from tastypie import fields
+from tastypie.constants import ALL_WITH_RELATIONS
 from tastypie.resources import ModelResource
 from tastypie.authorization import Authorization
 from core.models import Note, MediaBit
@@ -32,6 +33,7 @@ class CategoryResource(ModelResource):
         resource_name = 'category'
         queryset = Category.objects.all()
         authorization = Authorization()
+        filtering = {'parent': ALL_WITH_RELATIONS}
 
 
 class TagResource(ModelResource):

--- a/tests/related_resource/tests.py
+++ b/tests/related_resource/tests.py
@@ -86,6 +86,19 @@ class CategoryResourceTest(TestCase):
         self.assertEqual(data['parent'], '/v1/category/2/')
         self.assertEqual(data['name'], 'Daughter')
 
+    def test_filter_on_relation(self):
+        resource = api.canonical_resource_for('category')
+        request = MockRequest()
+        request.GET = {'format': 'json', 'parent': '/v1/category/2/'}
+        request.method = 'GET'
+        resp = resource.wrap_view('dispatch_list')(request)
+
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertEqual(data['meta']['total_count'], 1)
+        self.assertEqual(data['objects'][0]['parent'], '/v1/category/2/')
+        self.assertEqual(data['objects'][0]['name'], 'Daughter')
+
     def test_put_null(self):
         resource = api.canonical_resource_for('category')
         request = MockRequest()


### PR DESCRIPTION
The resource URI is used in multiple places to reference ModelResources, rather than the primary key. In filtering against a related ModelResource though, the primary key can be used, but not the resource uri. This patch adds that ability. 

An example use case is given below.

``` python
class UserResource(ModelResource):
    class Meta:
        resource_name = 'user'
        allowed_methods = ['get']
        queryset = User.objects.all()

class BlogPostResource(ModelResource):
    user = fields.ToOneField(UserResource, 'user')

    class Meta:
        resource_name = 'blogpost'
        allowed_methods = ['get']
        queryset = BlogPost.objects.select_related('user')
        fields = ('title','content')
        filtering = {'user': ALL_WITH_RELATIONS}
```

A result from [/api/v1/user?format=json](javascript:void%280%29) might say:

``` javascript
{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null, "total_count": 2}, "objects": [{"resource_uri": "/api/v1/user/1", "name": "Joe"},{"resource_uri": "/api/v1/user/2", "name": "Tom"}]}
```

We can then GET [/api/v1/blogpost?user=/api/v1/user/1&format=json](javascript:void%280%29) to get the blog posts by Joe.
