### PR TITLE
HTTP 422 Unprocessable Entity

### DIFF
--- a/tastypie/http.py
+++ b/tastypie/http.py
@@ -62,6 +62,10 @@ class HttpGone(HttpResponse):
     status_code = 410
 
 
+class HttpUnprocessableEntity(HttpResponse):
+    status_code = 422
+
+
 class HttpTooManyRequests(HttpResponse):
     status_code = 429
 

--- a/tastypie/test.py
+++ b/tastypie/test.py
@@ -381,6 +381,12 @@ class ResourceTestCase(TestCase):
         """
         return self.assertEqual(resp.status_code, 410)
 
+    def assertHttpUnprocessableEntity(self, resp):
+        """
+        Ensures the response is returning a HTTP 422.
+        """
+        return self.assertEqual(resp.status_code, 422)
+
     def assertHttpTooManyRequests(self, resp):
         """
         Ensures the response is returning a HTTP 429.


### PR DESCRIPTION
Include HTTP status code 422 Unprocessable Entity (WebDAV; RFC 4918)
