### PR TITLE
 dehydrate() got an unexpected keyword argument 'for_list' in GeometryApiField

### DIFF
--- a/tastypie/contrib/gis/resources.py
+++ b/tastypie/contrib/gis/resources.py
@@ -28,7 +28,7 @@ class GeometryApiField(ApiField):
             return value
         return simplejson.dumps(value)
 
-    def dehydrate(self, obj):
+    def dehydrate(self, obj, for_list=False):
         return self.convert(super(GeometryApiField, self).dehydrate(obj))
 
     def convert(self, value):


### PR DESCRIPTION
fix for dehydrate() got an unexpected keyword argument 'for_list' 
