### PR TITLE
Support unicode HTTP method names in Python 2.x

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -543,7 +543,7 @@ class Resource(object):
             allowed = []
 
         request_method = request.method.lower()
-        allows = ','.join(map(str.upper, allowed))
+        allows = ','.join([s.upper() for s in allowed])
 
         if request_method == "options":
             response = HttpResponse(allows)

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -108,9 +108,6 @@ class BasicResource(Resource):
     def get_list(self, request, **kwargs):
         raise NotImplementedError
 
-class BasicResourceWithUnicodeListAllowedMethods(BasicResource):
-    class Meta(BasicResource.Meta):
-        list_allowed_methods = [u'get']
 
 class AnotherBasicResource(BasicResource):
     name = fields.CharField(attribute='name')


### PR DESCRIPTION
This is a very simple fix for toastdriven/django-tastypie#935 with a regression test.

(I have just found a nearly-identical fix, without a test, at toastdriven/django-tastypie#863)
