### PR TITLE
Adds iso-8601-strict to TASTYPIE_DATETIME_FORMATTING options

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -77,6 +77,7 @@ Contributors:
 * Nathaniel Tucker (ntucker) django 1.5 support.
 * Soren Hansen (sorenh) Fixing tests for django 1.3.
 * Matt DeBoard (mattdeboard) for a patch to optionally set ``abstract = True`` on the ApiKey model.
+* Paul Grau (graup) Addition of iso-8601-strict to available TASTYPIE_DATETIME_FORMATTING.
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -91,13 +91,13 @@ Defaults to ``False``.
 **Optional**
 
 This setting allows you to globally choose what format your datetime/date/time
-data will be formatted in. Valid options are ``iso-8601`` & ``rfc-2822``.
+data will be formatted in. Valid options are ``iso-8601``, ``iso-8601-strict`` & ``rfc-2822``.
 
 An example::
 
     TASTYPIE_DATETIME_FORMATTING = 'rfc-2822'
 
-Defaults to ``iso-8601``.
+Defaults to ``iso-8601``. ``iso-8601`` includes microseconds if available, use ``iso-8601-strict`` to strip them.
 
 .. _settings.TASTYPIE_DEFAULT_FORMATS:
 

--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -137,7 +137,10 @@ class Serializer(object):
         data = make_naive(data)
         if self.datetime_formatting == 'rfc-2822':
             return format_datetime(data)
-
+        if self.datetime_formatting == 'iso-8601-strict':
+            # Remove microseconds to strictly adhere to iso-8601
+            data = data - datetime.timedelta(microseconds = data.microsecond)
+            
         return data.isoformat()
 
     def format_date(self, data):
@@ -165,6 +168,9 @@ class Serializer(object):
         """
         if self.datetime_formatting == 'rfc-2822':
             return format_time(data)
+        if self.datetime_formatting == 'iso-8601-strict':
+            # Remove microseconds to strictly adhere to iso-8601
+            data = (datetime.datetime.combine(datetime.date(1,1,1),data) - datetime.timedelta(microseconds = data.microsecond)).time()
 
         return data.isoformat()
 

--- a/tests/core/tests/serializers.py
+++ b/tests/core/tests/serializers.py
@@ -120,6 +120,9 @@ class SerializerTestCase(TestCase):
         serializer = Serializer(datetime_formatting='iso-8601')
         self.assertEqual(serializer.format_datetime(datetime.datetime(2010, 12, 16, 2, 31, 33)), '2010-12-16T02:31:33')
 
+        serializer = Serializer(datetime_formatting='iso-8601-strict')
+        self.assertEqual(serializer.format_datetime(datetime.datetime(2010, 12, 16, 2, 31, 33, 10)), '2010-12-16T02:31:33')
+
         serializer = Serializer(datetime_formatting='rfc-2822')
         self.assertEqual(serializer.format_datetime(datetime.datetime(2010, 12, 16, 2, 31, 33)), u'Thu, 16 Dec 2010 02:31:33 -0600')
 
@@ -132,6 +135,10 @@ class SerializerTestCase(TestCase):
         settings.TASTYPIE_DATETIME_FORMATTING = 'iso-8601'
         serializer = Serializer()
         self.assertEqual(serializer.format_datetime(datetime.datetime(2010, 12, 16, 2, 31, 33)), '2010-12-16T02:31:33')
+
+        settings.TASTYPIE_DATETIME_FORMATTING = 'iso-8601-strict'
+        serializer = Serializer()
+        self.assertEqual(serializer.format_datetime(datetime.datetime(2010, 12, 16, 2, 31, 33, 10)), '2010-12-16T02:31:33')
 
         settings.TASTYPIE_DATETIME_FORMATTING = 'rfc-2822'
         serializer = Serializer()
@@ -182,6 +189,9 @@ class SerializerTestCase(TestCase):
         serializer = Serializer(datetime_formatting='iso-8601')
         self.assertEqual(serializer.format_time(datetime.time(2, 31, 33)), '02:31:33')
 
+        serializer = Serializer(datetime_formatting='iso-8601-strict')
+        self.assertEqual(serializer.format_time(datetime.time(2, 31, 33, 10)), '02:31:33')
+
         serializer = Serializer(datetime_formatting='rfc-2822')
         self.assertEqual(serializer.format_time(datetime.time(2, 31, 33)), u'02:31:33 -0600')
 
@@ -194,6 +204,10 @@ class SerializerTestCase(TestCase):
         settings.TASTYPIE_DATETIME_FORMATTING = 'iso-8601'
         serializer = Serializer()
         self.assertEqual(serializer.format_time(datetime.time(2, 31, 33)), '02:31:33')
+
+        settings.TASTYPIE_DATETIME_FORMATTING = 'iso-8601-strict'
+        serializer = Serializer()
+        self.assertEqual(serializer.format_time(datetime.time(2, 31, 33, 10)), '02:31:33')
 
         settings.TASTYPIE_DATETIME_FORMATTING = 'rfc-2822'
         serializer = Serializer()


### PR DESCRIPTION
This is an improved patch for the issue raised here: https://github.com/toastdriven/django-tastypie/pull/460

This patch works by removing the microseconds from the datetime object by appliying a timedelta. Datetime objects without this information are automatically formated as expected (see http://docs.python.org/2/library/datetime.html#datetime.datetime.isoformat)

For time objects, first converts to a datetime to be able to apply timedeltas (see http://stackoverflow.com/questions/12448592/how-to-add-delta-to-python-datetime-time)

This way, timezone information is easily preserved.
