### PR TITLE
dehydrate being passed too many params

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -862,7 +862,7 @@ class Resource(object):
                 field_object.api_name = self._meta.api_name
                 field_object.resource_name = self._meta.resource_name
 
-            bundle.data[field_name] = field_object.dehydrate(bundle, for_list=for_list)
+            bundle.data[field_name] = field_object.dehydrate(bundle)
 
             # Check for an optional method to do further dehydration.
             method = getattr(self, "dehydrate_%s" % field_name, None)


### PR DESCRIPTION
dehydrate was being passed (bundle, for_list=for_list) when it only wants bundle.