### PR TITLE
error importing username_field 

### DIFF
--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -17,6 +17,7 @@ if django.VERSION >= (1, 5):
         # This can happen is when setting up the create_api_key signal, in your
         # custom user module.
         User = None
+        username_field = None
 else:
     from django.contrib.auth.models import User
     username_field = 'username'


### PR DESCRIPTION
on Django 1.5 when using a custom user model an error occurs when importing create_api_key.

added a None value for username_field

same error in Ticket #937
