### PR TITLE
Fix to allow ToOneField/ToManyField on a single ModelResource to point to the same sub-Resource

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2274,8 +2274,8 @@ class ModelResource(Resource):
             if bundle.obj and self.get_bundle_detail_data(bundle):
                 bundle.obj.delete()
 
-    def create_identifier(self, obj):
-        return u"%s.%s.%s" % (obj._meta.app_label, obj._meta.module_name, obj.pk)
+    def create_identifier(self, obj, field_name=None):
+        return u"%s%s.%s.%s" % (field_name + '.' if field_name else '',obj._meta.app_label, obj._meta.module_name, obj.pk)
 
     def save(self, bundle, skip_errors=False):
         self.is_valid(bundle)
@@ -2347,7 +2347,7 @@ class ModelResource(Resource):
 
                 # Before we build the bundle & try saving it, let's make sure we
                 # haven't already saved it.
-                obj_id = self.create_identifier(related_obj)
+                obj_id = self.create_identifier(related_obj,field_name)
 
                 if obj_id in bundle.objects_saved:
                     # It's already been saved. We're done here.
@@ -2410,7 +2410,7 @@ class ModelResource(Resource):
 
                 # Before we build the bundle & try saving it, let's make sure we
                 # haven't already saved it.
-                obj_id = self.create_identifier(related_bundle.obj)
+                obj_id = self.create_identifier(related_bundle.obj,field_name)
 
                 if obj_id in bundle.objects_saved:
                     # It's already been saved. We're done here.


### PR DESCRIPTION
When ModelResource_A has two or more ToOneField/ToManyField that point to the same ModelResource_B, eg:

``` python
class MR_A(ModelResource):
    foo  =  fields.ToManyField('api.MR_B','foo', related_name='a')
    bar  =  fields.ToManyField('api.MR_B','bar', related_name='a')

class MR_B(ModelResource):
   ...

```

This fix allows additional uniqueness by updating the self.create_identifier() method to use the field_name property as part of the identification.  Without this, only the first field pointing to a particular resource is saved/updated, and subsequent fields are ignored as their self.create_identifier() results were identical.

``` python
def create_identifier(self, obj, field_name=None):
    return u"%s%s.%s.%s" % (field_name + '.' if field_name else '',obj._meta.app_label, obj._meta.module_name, obj.pk)
```

The additional field_name argument is then passed during `ModelResource.save_m2m(self, bundle)` and `ModelResource.save_related(self, bundle)` methods.
