### PR TITLE
Don't try to update resources in case of a create

### DIFF
--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -4,7 +4,7 @@ from tastypie.resources import ModelResource
 from tastypie.authorization import Authorization
 from core.models import Note, MediaBit
 from related_resource.models import Category, Tag, ExtraData, Taggable,\
-    TaggableTag, Person, Company, Product, Address, Dog, DogHouse, Bone
+    TaggableTag, Person, Company, Product, Address, Dog, DogHouse, Bone, Job, Payment
 from tests.related_resource.models import Label, Post
 
 
@@ -179,3 +179,21 @@ class PostResource(ModelResource):
         queryset = Post.objects.all()
         resource_name = 'post'
         authorization = Authorization()
+
+class PaymentResource(ModelResource):
+    job = fields.ToOneField('related_resource.api.resources.JobResource', 'job')
+
+    class Meta:
+        queryset = Payment.objects.all()
+        resource_name = 'payment'
+        authorization = Authorization()
+        allowed_methods = ('get','put','post')
+
+class JobResource(ModelResource):
+    payment = fields.ToOneField(PaymentResource, 'payment', related_name='job')
+
+    class Meta:
+        queryset = Job.objects.all()
+        resource_name = 'job'
+        authorization = Authorization()
+        allowed_methods = ('get','put','post')

--- a/tests/related_resource/models.py
+++ b/tests/related_resource/models.py
@@ -102,7 +102,6 @@ class Dog(models.Model):
     def __unicode__(self):
         return u"%s" % (self.name)
 
-
 class Bone(models.Model):
     dog = models.ForeignKey(Dog, related_name='bones')
     color = models.CharField(max_length=32)
@@ -110,11 +109,17 @@ class Bone(models.Model):
     def __unicode__(self):
         return u"%s" % (self.color)
 
-
 class Label(models.Model):
     name = models.CharField(max_length=32)
-
 
 class Post(models.Model):
     name = models.CharField(max_length=200)
     label = models.ManyToManyField(Label, null=True)
+
+
+class Job(models.Model):
+    name = models.CharField(max_length=200)
+
+class Payment(models.Model):
+    scheduled = models.DateTimeField()
+    job = models.OneToOneField(Job, related_name="payment", null=True)


### PR DESCRIPTION
The resource_from_data method creates a resource based on a data dictionary. However, when this method is called on a related resource in the process of a create, and a primary key is not included in the related resource, a resource may inadvertently be selected that is not at all supposed to be updated.

In the following scenario:

``` python
class PaymentResource(ModelResource):
    class Meta:
        fields = ['id','scheduled']

class JobResource(ModelResource):
    payment = ToOneField(PaymentResource, 'payment')
    class Meta:
        fields = ['id','name']
```

When I submit a POST request to /api/job with the following:

``` javascript
{
    name: 'some_job',
    payment: {
        scheduled: '2013-06-01'
    }
}
```

The resource_from_data will be called with the dictionary of the payment, matching any payment that has the same scheduled date, not related to the current job being created at all. For safety, when a unique key is not supplied in the dictionary, we should not try to find a resource to update.
