### PR TITLE
added detail_uri_name to Non-PK URL example

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -80,6 +80,7 @@ something like the following::
     class UserResource(ModelResource):
         class Meta:
             queryset = User.objects.all()
+            detail_uri_name = 'username'
 
         def prepend_urls(self):
             return [


### PR DESCRIPTION
This is a crucial detail missing that ought to be included in the example. The resource_uri generated from the example and included in the response is inherently incorrect, given the desired result. EG, if you want to use a non-pk you want to query a ModelResource like this, you'll want the resource_uri updated. If you don't, hopefully you'll notice that the example includes meta.detail_uri_name :)
