### PR TITLE
Add setting to include timezone in serialized ISO datetimes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -77,6 +77,7 @@ Contributors:
 * Nathaniel Tucker (ntucker) django 1.5 support.
 * Soren Hansen (sorenh) Fixing tests for django 1.3.
 * Matt DeBoard (mattdeboard) for a patch to optionally set ``abstract = True`` on the ApiKey model.
+* James Rivett-Carnac (yarbelk) for TASTYPIE_DATETIME_FORMAT_TIMEZONE to include timezones in serialized datetimes.
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -99,10 +99,27 @@ An example::
 
 Defaults to ``iso-8601``.
 
+``TASTYPIE_DATETIME_FORMATTING_TIMEZONE``
+=========================================
+
+**Optional**
+
+This setting allows you to include timzone information in your datetime
+formating.  It only effects ``iso-8601``, as ``rfc-2822`` displays timezones
+by default.  If the datetime object has ``tzinfo`` set, it will use that
+timezone.  Otherwise it will use the default timezone set in
+``settings.TIME_ZONE``.
+
+An example::
+
+    TASTYPIE_DATETIME_FORMATTING_TIMEZONE = True
+
+Defaults to ``False``.
+
 .. _settings.TASTYPIE_DEFAULT_FORMATS:
 
 ``TASTYPIE_DEFAULT_FORMATS``
-================================
+============================
 
 **Optional**
 

--- a/tastypie/utils/__init__.py
+++ b/tastypie/utils/__init__.py
@@ -2,4 +2,4 @@ from tastypie.utils.dict import dict_strip_unicode_keys
 from tastypie.utils.formatting import mk_datetime, format_datetime, format_date, format_time
 from tastypie.utils.urls import trailing_slash
 from tastypie.utils.validate_jsonp import is_valid_jsonp_callback_value
-from tastypie.utils.timezone import now, make_aware, make_naive, aware_date, aware_datetime
+from tastypie.utils.timezone import now, make_aware, make_naive, aware_date, aware_datetime, is_naive, is_aware, get_default_timezone

--- a/tastypie/utils/formatting.py
+++ b/tastypie/utils/formatting.py
@@ -2,7 +2,8 @@ import email
 import datetime
 import time
 from django.utils import dateformat
-from tastypie.utils.timezone import make_aware, make_naive, aware_datetime
+from django.conf import settings
+from tastypie.utils.timezone import make_aware, make_naive, aware_datetime, is_naive, is_aware
 
 # Try to use dateutil for maximum date-parsing niceness. Fall back to
 # hard-coded RFC2822 parsing if that's not possible.
@@ -16,7 +17,12 @@ def format_datetime(dt):
     """
     RFC 2822 datetime formatter
     """
-    return dateformat.format(make_naive(dt), 'r')
+    aware_formating = getattr(settings, 'TASTYPIE_DATETIME_FORMATTING_TIMEZONE', False)
+    if aware_formating and is_naive(dt):
+        dt = make_aware(dt)
+    if not aware_formating and is_aware(dt):
+        dt = make_naive(dt)
+    return dateformat.format(dt, 'r')
 
 def format_date(d):
     """

--- a/tastypie/utils/timezone.py
+++ b/tastypie/utils/timezone.py
@@ -1,27 +1,92 @@
 import datetime
 from django.conf import settings
+import six
+try:
+    import pytz
+except ImportError:
+    pytz = None
 
 try:
     from django.utils import timezone
+    from django.utils.timezone import get_default_timezone, is_naive, is_aware, make_naive as _make_naive, make_aware as _make_aware
 
-    def make_aware(value):
-        if getattr(settings, "USE_TZ", False) and timezone.is_naive(value):
-            default_tz = timezone.get_default_timezone()
-            value = timezone.make_aware(value, default_tz)
-        return value
-
-    def make_naive(value):
-        if getattr(settings, "USE_TZ", False) and timezone.is_aware(value):
-            default_tz = timezone.get_default_timezone()
-            value = timezone.make_naive(value, default_tz)
-        return value
+    make_aware = lambda value, timezone=None: _make_aware(value, timezone or get_default_timezone())
+    make_naive = lambda value, timezone=None: _make_naive(value, timezone or get_default_timezone())
 
     def now():
         return timezone.localtime(timezone.now())
 
 except ImportError:
-    now = datetime.datetime.now
-    make_aware = make_naive = lambda x: x
+    def get_default_timezone():
+        tzname = getattr(settings, 'TIME_ZONE', None)
+        if pytz is not None:
+            tzinfo = pytz.timezone(tzname).localize(pytz.datetime.datetime.now()).tzinfo
+            return tzinfo
+        try:
+            # This is a proxy for the time.tzinfo proxy, using ('CST', 'CDT')
+            # and the os.environ['TZ'] for setting the timezone.  This behaves
+            # very different from the pytz implementation of timezones.
+            from django.utils.tzinfo import LocalTimezone
+            from datetime import datetime
+            tzinfo = LocalTimezone(datetime.now())
+            return tzinfo
+        except:
+            # using time.tzset() with an olson timezone ('America/Chicago') is
+            # only expected to work on a *nix system, so this may fail in some
+            # strainge way on windows.
+            return None
+
+    def make_aware(value, timezone=None):
+        """
+        Makes a naive datetime.datetime in a given time zone aware.
+        """
+        if timezone is None:
+            timezone = get_default_timezone()
+        if hasattr(timezone, 'localize'):
+            # available for pytz time zones
+            return timezone.localize(value, is_dst=None)
+        else:
+            # may be wrong around DST changes
+            return value.replace(tzinfo=timezone)
+
+    def make_naive(value, timezone=None):
+        """
+        Makes an aware datetime.datetime naive in a given time zone.
+        """
+        if timezone is None:
+            timezone = get_default_timezone()
+        value = value.astimezone(timezone)
+        if hasattr(timezone, 'normalize'):
+            # available for pytz time zones
+            value = timezone.normalize(value)
+        return value.replace(tzinfo=None)
+        def is_naive(dt):
+            """Straight copy of 1.5's is_naive"""
+            return value.tzinfo is None or value.tzinfo.utcoffset(value) is None
+
+    now = lambda : make_aware(datetime.datetime.now())
+
+
+
+def is_aware(value):
+    """
+    Determines if a given datetime.datetime is aware.
+
+    The logic is described in Python's docs:
+    http://docs.python.org/library/datetime.html#datetime.tzinfo
+    """
+    return value.tzinfo is not None and value.tzinfo.utcoffset(value) is not None
+
+def is_naive(value):
+    """
+    Determines if a given datetime.datetime is naive.
+
+    The logic is described in Python's docs:
+    http://docs.python.org/library/datetime.html#datetime.tzinfo
+    """
+    return value.tzinfo is None or value.tzinfo.utcoffset(value) is None
+
+
 
 def aware_date(*args, **kwargs):
     return make_aware(datetime.date(*args, **kwargs))

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -11,7 +11,7 @@ from tastypie.resources import ModelResource
 from core.models import Note, Subject, MediaBit
 from core.tests.mocks import MockRequest
 
-from tastypie.utils import aware_datetime, aware_date
+from tastypie.utils import aware_datetime, aware_date, is_aware, is_naive
 
 
 class ApiFieldTestCase(TestCase):
@@ -417,7 +417,12 @@ class TimeFieldTestCase(TestCase):
         bundle = Bundle(obj=note)
 
         field_1 = TimeField(attribute='created')
-        self.assertEqual(field_1.dehydrate(bundle), aware_datetime(2010, 3, 30, 20, 5))
+        dehydrated = field_1.dehydrate(bundle)
+        if is_aware(dehydrated):
+            expected = aware_datetime(2010, 3, 30, 20, 5)
+        else:
+            expected = datetime.datetime(2010, 3, 30, 20, 5)
+        self.assertEqual(dehydrated, expected)
 
         field_2 = TimeField(default=datetime.time(23, 5, 58))
         self.assertEqual(field_2.dehydrate(bundle), datetime.time(23, 5, 58))
@@ -479,7 +484,12 @@ class DateFieldTestCase(TestCase):
         bundle = Bundle(obj=note)
 
         field_1 = DateField(attribute='created')
-        self.assertEqual(field_1.dehydrate(bundle), aware_datetime(2010, 3, 30, 20, 5))
+        dehydrated = field_1.dehydrate(bundle)
+        if is_aware(dehydrated):
+            expected = aware_datetime(2010, 3, 30, 20, 5)
+        else:
+            expected = datetime.datetime(2010, 3, 30, 20, 5)
+        self.assertEqual(dehydrated, expected)
 
         field_2 = DateField(default=datetime.date(2010, 4, 1))
         self.assertEqual(field_2.dehydrate(bundle), datetime.date(2010, 4, 1))

--- a/tests/core/tests/serializers.py
+++ b/tests/core/tests/serializers.py
@@ -144,6 +144,68 @@ class SerializerTestCase(TestCase):
         # Restore.
         settings.TASTYPIE_DATETIME_FORMATTING = old_format
 
+    def test_format_datetime_timezone(self):
+        # Timezone aware test. False (default and old behaviour)
+        old_use_tz_formatting = getattr(settings, 'TASTYPIE_DATETIME_FORMATTING_TIMEZONE', False)
+        old_tz_formatting = getattr(settings, 'TASTYPIE_DATETIME_FORMATTING', None)
+        old_use_tz = getattr(settings, 'USE_TZ', None)
+
+        settings.TASTYPIE_DATETIME_FORMATTING_TIMEZONE = False
+        settings.TASTYPIE_DATETIME_FORMATTING = 'iso-8601'
+        settings.USE_TZ = True
+
+        serializer = Serializer()
+        self.assertEqual(serializer.format_datetime(datetime.datetime(2010, 12, 16, 2, 31, 33)), '2010-12-16T02:31:33')
+
+        settings.TASTYPIE_DATETIME_FORMATTING_TIMEZONE = False
+        settings.TASTYPIE_DATETIME_FORMATTING = 'rfc-2822'
+        settings.USE_TZ = True
+        serializer = Serializer()
+        self.assertEqual(serializer.format_datetime(datetime.datetime(2010, 12, 16, 2, 31, 33)), u'Thu, 16 Dec 2010 02:31:33 -0600')
+
+        # with tz info enabled
+        settings.TASTYPIE_DATETIME_FORMATTING_TIMEZONE = True
+        settings.TASTYPIE_DATETIME_FORMATTING = 'iso-8601'
+        settings.USE_TZ = True
+        serializer = Serializer()
+        self.assertEqual(serializer.format_datetime(datetime.datetime(2010, 12, 16, 2, 31, 33)), '2010-12-16T02:31:33-06:00')
+
+        settings.TASTYPIE_DATETIME_FORMATTING_TIMEZONE = True
+        settings.TASTYPIE_DATETIME_FORMATTING = 'rfc-2822'
+        settings.USE_TZ = True
+        serializer = Serializer()
+        self.assertEqual(serializer.format_datetime(datetime.datetime(2010, 12, 16, 2, 31, 33)), u'Thu, 16 Dec 2010 02:31:33 -0600')
+
+        # Test aware datetime
+        from dateutil.tz import gettz
+        settings.TASTYPIE_DATETIME_FORMATTING_TIMEZONE = True
+        settings.TASTYPIE_DATETIME_FORMATTING = 'iso-8601'
+        settings.USE_TZ = True
+        serializer = Serializer()
+        tzinfo = gettz('Asia/Singapore')
+        dt = datetime.datetime(2010, 12, 16, 2, 31, 33, tzinfo=tzinfo)
+        self.assertEqual(serializer.format_datetime(dt), '2010-12-16T02:31:33+08:00')
+
+        settings.TASTYPIE_DATETIME_FORMATTING_TIMEZONE = True
+        settings.TASTYPIE_DATETIME_FORMATTING = 'rfc-2822'
+        settings.USE_TZ = True
+        serializer = Serializer()
+        self.assertEqual(serializer.format_datetime(dt), u'Thu, 16 Dec 2010 02:31:33 +0800')
+
+        if old_use_tz_formatting:
+            settings.TASTYPIE_DATETIME_FORMATTING_TIMEZONE = old_use_tz_formatting
+        else:
+            del settings.TASTYPIE_DATETIME_FORMATTING_TIMEZONE
+        if old_tz_formatting:
+            settings.TASTYPIE_DATETIME_FORMATTING = old_tz_formatting
+        else:
+            del settings.TASTYPIE_DATETIME_FORMATTING
+        if old_use_tz:
+            settings.USE_TZ = old_use_tz
+        else:
+            del settings.USE_TZ
+
+
     def test_format_date(self):
         serializer = Serializer()
         self.assertEqual(serializer.format_date(datetime.date(2010, 12, 16)), '2010-12-16')


### PR DESCRIPTION
Add a setting TASTYPIE_DATETIME_FORMATTING_TIMEZONE, to include timezone
in the serialized format of datetimes.  This defaults to False (prior
behaviour).  If the datetime is naive, it is given the default timezone
of the django project.

Add tests to check that the default (False) setting isn't changed,
and that the formatting change happens when it is enabled.

This is a re-implementation of issue #445, which handles datetimes that
already have tzinfo.
