### PR TITLE
Fixes Issue #966 Extract usernames that include spaces from the Authorization header

### DIFF
--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -160,7 +160,7 @@ class ApiKeyAuthentication(Authentication):
 
     def extract_credentials(self, request):
         if request.META.get('HTTP_AUTHORIZATION') and request.META['HTTP_AUTHORIZATION'].lower().startswith('apikey '):
-            (auth_type, data) = request.META['HTTP_AUTHORIZATION'].split()
+            (auth_type, data) = request.META['HTTP_AUTHORIZATION'].split(' ', 1)
 
             if auth_type.lower() != 'apikey':
                 raise ValueError("Incorrect authorization header.")


### PR DESCRIPTION
Fixes [Issue #966](https://github.com/toastdriven/django-tastypie/issues/966).