### PR TITLE
Reduce number of queries in ToManyField

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -802,7 +802,7 @@ class ToManyField(RelatedField):
         elif callable(self.attribute):
             the_m2ms = self.attribute(bundle)
 
-        if not the_m2ms:
+        if the_m2ms is None:
             if not self.null:
                 raise ApiFieldError("The model '%r' has an empty attribute '%s' and doesn't allow a null value." % (previous_obj, attr))
 


### PR DESCRIPTION
By checking to see if the_m2ms is null, and not whether it's null or empty, we prevent performing two of the same queries.