### PR TITLE
[DOCS] Update Nested Resources example in cookbook.rst to work properly

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -107,7 +107,8 @@ handle the children::
 
         def get_children(self, request, **kwargs):
             try:
-                obj = self.cached_obj_get(request=request, **self.remove_api_resource_names(kwargs))
+                bundle = self.build_bundle(data={'pk': kwargs['pk']}, request=request)
+                obj = self.cached_obj_get(bundle=bundle, **self.remove_api_resource_names(kwargs))
             except ObjectDoesNotExist:
                 return HttpGone()
             except MultipleObjectsReturned:


### PR DESCRIPTION
The example on Nested Resources in cookbook.rst seems to be from an old version of tastypie, as `cached_object_get` expects a `Bundle` as its first argument, not a request.  The current code will fail with `AttributeError: 'WSGIRequest' object has no attribute 'request'`.

This patch shows how to build a stub bundle to make the example work correctly.  I am not sure if this is the canonical way to build a bundle from a request - in particular, I don't pass in an `obj`, but then the point of building the bundle is to get the object from `cached_obj_get` in the first place. :)
