### PR TITLE
Add ``alter_queryset`` hook to ``get_list``

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1801,3 +1801,14 @@ relation and recreate the related data as needed.
 Handles generating a resource URI for a single resource.
 
 Uses the model's ``pk`` in order to create the URI.
+
+``alter_queryset``
+-------------------
+
+.. method:: ModelResource.alter_queryset(self, request, qs, **kwargs)
+
+Allows you to make final alterations to the queryset before it is dehydrated into
+a list of resources.
+
+Ideal for applying ``prefetch_related`` to your queryset.
+

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1302,6 +1302,9 @@ class Resource(object):
         paginator = self._meta.paginator_class(request.GET, sorted_objects, resource_uri=self.get_resource_uri(), limit=self._meta.limit, max_limit=self._meta.max_limit, collection_name=self._meta.collection_name)
         to_be_serialized = paginator.page()
 
+        to_be_serialized[self._meta.collection_name] = self.alter_queryset(
+            request, to_be_serialized[self._meta.collection_name], **kwargs)
+
         # Dehydrate the bundles in preparation for serialization.
         bundles = []
 
@@ -1677,6 +1680,16 @@ class Resource(object):
             'request': request,
         }
         return self.obj_update(bundle=original_bundle, **kwargs)
+
+    def alter_queryset(self, request, qs, **kwargs):
+        """
+        Allows you to alter the final QuerySet before it is dehydrated into a
+        list of resources.
+
+        Allows you to apply things like ``prefetch_related`` https://docs.djangoproject.com/en/dev/ref/models/querysets/#prefetch-related
+        to improve performance.
+        """
+        return qs
 
     def get_schema(self, request, **kwargs):
         """


### PR DESCRIPTION
Added a hook point to get_list called alter_queryset. This allows you to apply things like prefetch_related to a queryset after all filtering and pagination has been completed.

Main reason for adding this is so that I don't have to override `get_list` in order to accomplish this.

There are no tests because the default implementation is a no-op. And this patch does not alter the current behaviour of tastypie in any way.
