### PR TITLE
Fixes #926, #976, #926 and others.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,7 +103,7 @@ Optional
 --------
 
 * python_digest (https://bitbucket.org/akoha/python-digest/)
-* lxml (http://lxml.de/) if using the XML serializer
+* lxml (http://lxml.de/) and defusedxml (https://bitbucket.org/tiran/defusedxml) if using the XML serializer
 * pyyaml (http://pyyaml.org/) if using the YAML serializer
 * biplist (http://explorapp.com/biplist/) if using the binary plist serializer
 


### PR DESCRIPTION
defusedxml is now a requirement if you wish to support xml requests.
