### PR TITLE
With MySQL, 0.9.12-alpha, the famous 'Failed to install index for tastypie.ApiKey model: Specified key was too long; max key length is 767 bytes'

### DIFF
--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -32,7 +32,7 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
     from tastypie.compat import AUTH_USER_MODEL
     class ApiKey(models.Model):
         user = models.OneToOneField(AUTH_USER_MODEL, related_name='api_key')
-        key = models.CharField(max_length=256, blank=True, default='', db_index=True)
+        key = models.CharField(max_length=128, blank=True, default='', db_index=True)
         created = models.DateTimeField(default=now)
 
         def __unicode__(self):


### PR DESCRIPTION
This may not be worth addressing. My personal preference would be for Django to just not support MySQL. However...

Tastypie creates the field 'key' as a varchar(256) in the tastypie_apikey table. If you're using a database which is in utf8mb4, the length of the varchar can be 4 \* 256 bytes (excluding whatever storage engine constants), hence MySQL can't actually create a full-length index as 1024 > 767.

There's actually a bug report in Django here: https://code.djangoproject.com/ticket/18392
so probably not worth thinking about. 

For reference, you also do end up with an index being created despite the warning if you use syncdb instead of South, but with South it will stop your migration and you have to work around.  If it gets created it will just be length 191 (as 4\* 191 = 764, the largest it can be while staying less that 768).

Mostly submitting this just so that other people who run into this can verify what's up.

As noted it's not strictly a bug with tastypie, but is a bug to be aware of if using tastypie and certain MySQL configs.

To replicate:
1. Use MySQL.
2. Set the default collation for whatever schema you're using for Django to utf8mb4.
3. Run South migration or regular syncdb after installing the django-tastypie 0.9.12-alpha.

Meh. I'd label this 'really low priority.'
