### PR TITLE
Fix south migrations error

### DIFF
--- a/tastypie/migrations/0001_initial.py
+++ b/tastypie/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/tastypie/migrations/0002_add_apikey_index.py
+++ b/tastypie/migrations/0002_add_apikey_index.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration


### PR DESCRIPTION
Importing unicode_literals causes a problem in South when importing from django.db.models.fields because then the name of the model class that is passed into __import__ is unicode, rather than a byte string. I'm not quite sure why this causes a problem importing from this module but not others. However, removing the unicode_literals import from these migrations fixes the issue, and it doesn't look like the migrations have any literals that need to be unicode.