### PR TITLE
Expose for_list flag to use_in callable

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -111,8 +111,8 @@ Defaults to the per-Field definition.
 .. attribute:: ApiField.use_in
 
 Optionally omit this field in list or detail views.  It can be either 'all',
-'list', or 'detail' or a callable which accepts a bundle and returns a boolean
-value.
+'list', or 'detail' or a callable which accepts a bundle and a ``for_list``
+flag and returns a boolean value.
 
 Field Types
 -----------

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -58,11 +58,11 @@ class ApiField(object):
         Defaults to the per-Field definition.
 
         Optionally accepts ``use_in``. This may be one of ``list``, ``detail``
-        ``all`` or a callable which accepts a ``bundle`` and returns
-        ``True`` or ``False``. Indicates wheather this field will be included
-        during dehydration of a list of objects or a single object. If ``use_in``
-        is a callable, and returns ``True``, the field will be included during
-        dehydration.
+        ``all`` or a callable which accepts a ``bundle`` and ``for_list`` flag
+        and returns ``True`` or ``False``. Indicates wheather this field will
+        be included during dehydration of a list of objects or a single object.
+        If ``use_in`` is a callable, and returns ``True``, the field will be
+        included during dehydration.
         Defaults to ``all``.
         """
         # Track what the index thinks this field is called.
@@ -445,11 +445,11 @@ class RelatedField(ApiField):
         Defaults to the per-Field definition.
 
         Optionally accepts ``use_in``. This may be one of ``list``, ``detail``
-        ``all`` or a callable which accepts a ``bundle`` and returns
-        ``True`` or ``False``. Indicates wheather this field will be included
-        during dehydration of a list of objects or a single object. If ``use_in``
-        is a callable, and returns ``True``, the field will be included during
-        dehydration.
+        ``all`` or a callable which accepts a ``bundle`` and ``for_list`` flag
+        and returns ``True`` or ``False``. Indicates wheather this field will
+        be included during dehydration of a list of objects or a single object.
+        If ``use_in`` is a callable, and returns ``True``, the field will be
+        included during dehydration.
         Defaults to ``all``.
 
         Optionally accepts a ``full_list``, which indicated whether or not

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from __future__ import with_statement
 from copy import deepcopy
+import inspect
 import logging
 import warnings
 
@@ -818,8 +819,12 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             # If it's not for use in this mode, skip
             field_use_in = getattr(field_object, 'use_in', 'all')
             if callable(field_use_in):
-                if not field_use_in(bundle):
-                    continue
+                if len(inspect.getargspec(field_use_in)[0]) < 2:
+                    if not field_use_in(bundle):
+                        continue
+                else:
+                    if not field_use_in(bundle, for_list):
+                        continue
             else:
                 if field_use_in not in use_in:
                     continue

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -43,7 +43,7 @@ class ApiFieldTestCase(TestCase):
         field_4 = ApiField(use_in="detail")
         self.assertEqual(field_4.use_in, 'detail')
 
-        use_in_callable = lambda x: True
+        use_in_callable = lambda x, y: True
         field_5 = ApiField(use_in=use_in_callable)
         self.assertTrue(field_5.use_in is use_in_callable)
 
@@ -647,7 +647,7 @@ class ToOneFieldTestCase(TestCase):
         field_6 = ToOneField(UserResource, 'author', default=1, null=True, readonly=True, help_text="Points to a User.", use_in="detail")
         self.assertEqual(field_6.use_in, 'detail')
 
-        use_in_callable = lambda x: True
+        use_in_callable = lambda x, y: True
         field_7 = ToOneField(UserResource, 'author', default=1, null=True, readonly=True, help_text="Points to a User.", use_in=use_in_callable)
         self.assertTrue(field_7.use_in is use_in_callable)
 
@@ -998,7 +998,7 @@ class ToManyFieldTestCase(TestCase):
         field_6 = ToManyField(SubjectResource, 'author', default=1, null=True, readonly=True, help_text="Points to a User.", use_in="detail")
         self.assertEqual(field_6.use_in, 'detail')
 
-        use_in_callable = lambda x: True
+        use_in_callable = lambda x, y: True
         field_7 = ToManyField(SubjectResource, 'author', default=1, null=True, readonly=True, help_text="Points to a User.", use_in=use_in_callable)
         self.assertTrue(field_7.use_in is use_in_callable)
 


### PR DESCRIPTION
When use_in is a string, it is used to determine whether the field should be present when dehydrating for a list, for details, or for either. When it is a callable, however, the callable method previously had no way of knowing if it was dehydrating for a list or detail, so, for example, there was no good way of implementing a field that should be present only under certain conditions _and_ only in a detail view.

This addresses this issue in a backwards-compatible way by passing the for_list flag as the second argument to the use_in callable if the callable is expecting a second argument, or omitting it if it is not.
