### PR TITLE
Update SimpleCache implementation and docs for Django 1.3+

### DIFF
--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -61,9 +61,29 @@ plug. Very useful for development.
 ~~~~~~~~~~~~~~~
 
 This option does basic object caching, attempting to find the object in the
-cache & writing the object to the cache. It uses Django's current
-``CACHE_BACKEND`` to store cached data. The constructor receive a `timeout`
-parameter to control per-resource the default timeout for the cache.
+cache & writing the object to the cache. By default, it uses the ``default``
+cache backend as configured in the ``CACHES`` setting. However, an optional
+`cache_name` parameter can be passed to the constructor to specify a
+different backend. For example, if ``CACHES`` looks like::
+
+  CACHES = {
+      'default': {
+          'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+          'TIMEOUT': 60
+      },
+      'resources': {
+          'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+          'TIMEOUT': 60
+      }
+  }
+
+you can configure your resource's `cache_name` property like so::
+
+  cache = SimpleCache(cache_name='resources', timeout=10)
+
+In this case, the cache used will be the one named, and the default `timeout`
+specified in ``CACHES['resources']`` will be overriden by the `timeout`
+parameter.
 
 
 Implementing Your Own Cache

--- a/tastypie/cache.py
+++ b/tastypie/cache.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.core.cache import cache
+from django.core.cache import get_cache
 
 
 class NoCache(object):
@@ -49,24 +49,26 @@ class NoCache(object):
 
 class SimpleCache(NoCache):
     """
-    Uses Django's current ``CACHE_BACKEND`` to store cached data.
+    Uses Django's current ``CACHES`` configuration to store cached data.
     """
 
-    def __init__(self, timeout=60, public=None, private=None, *args, **kwargs):
+    def __init__(self, cache_name='default', timeout=None, public=None,
+                 private=None, *args, **kwargs):
         """
         Optionally accepts a ``timeout`` in seconds for the resource's cache.
         Defaults to ``60`` seconds.
         """
         super(SimpleCache, self).__init__(*args, **kwargs)
-        self.timeout = timeout
+        self.cache = get_cache(cache_name)
+        self.timeout = timeout or self.cache.default_timeout
         self.public = public
         self.private = private
 
-    def get(self, key):
+    def get(self, key, **kwargs):
         """
         Gets a key from the cache. Returns ``None`` if the key is not found.
         """
-        return cache.get(key)
+        return self.cache.get(key, **kwargs)
 
     def set(self, key, value, timeout=None):
         """
@@ -79,7 +81,7 @@ class SimpleCache(NoCache):
         if timeout == None:
             timeout = self.timeout
 
-        cache.set(key, value, timeout)
+        self.cache.set(key, value, timeout)
 
     def cache_control(self):
         control = {


### PR DESCRIPTION
`SimpleCache.get` now supports `**kwargs`, for returning default values or fetching versions of cache keys.

Additionally, updated references to `CACHE_BACKEND` which was deprecated in Django 1.3.
