### PR TITLE
Fix behavior in case of missing required FK field

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -163,7 +163,7 @@ class ApiField(object):
                     return bundle.related_obj
             if self.blank:
                 return None
-            elif self.attribute and getattr(bundle.obj, self.attribute, None):
+            elif self.attribute and hasattr(bundle.obj, self.attribute) and getattr(bundle.obj, self.attribute):
                 return getattr(bundle.obj, self.attribute)
             elif self.instance_name and hasattr(bundle.obj, self.instance_name):
                 return getattr(bundle.obj, self.instance_name)

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -3743,7 +3743,7 @@ class ModelResourceTestCase(TestCase):
             # ``None`` to a required FK.
             hydrated1 = nmbr.full_hydrate(bundle_1)
             self.fail()
-        except Note.DoesNotExist:
+        except ValueError:
             pass
 
         # So we introduced ``blank=True``.


### PR DESCRIPTION
Even if passed a default value, getattr throws a DoesNotExist exception when getting a null fk field of a model. Using hasattr() first ensures that an ApiFieldError will be thrown in this case, as it should be.
