### PR TITLE
Remove 'uncode_literals' from migrations

### DIFF
--- a/tastypie/migrations/0001_initial.py
+++ b/tastypie/migrations/0001_initial.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration

--- a/tastypie/migrations/0002_add_apikey_index.py
+++ b/tastypie/migrations/0002_add_apikey_index.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration


### PR DESCRIPTION
Fixes ticket #1005

South can only handle bytestring values for the class names in the 'models' dict in migration files. After a brief discussion with the south devs, the answer was 'don't use unicode literals'.
