### PR TITLE
Add more User model Meta information to migrations

### DIFF
--- a/tastypie/migrations/0001_initial.py
+++ b/tastypie/migrations/0001_initial.py
@@ -3,8 +3,13 @@ from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration
+from south.modelsinspector import get_model_meta
 from django.db import models
-from tastypie.compat import AUTH_USER_MODEL
+from tastypie.compat import AUTH_USER_MODEL, User
+
+
+AUTH_USER_META = get_model_meta(User)
+AUTH_USER_META.update({'object_name': AUTH_USER_MODEL.split('.')[-1]})
 
 
 class Migration(SchemaMigration):
@@ -55,7 +60,7 @@ class Migration(SchemaMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
         AUTH_USER_MODEL: {
-            'Meta': {'object_name': AUTH_USER_MODEL.split('.')[-1]},
+            'Meta': AUTH_USER_META,
             'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
             'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),

--- a/tastypie/migrations/0002_add_apikey_index.py
+++ b/tastypie/migrations/0002_add_apikey_index.py
@@ -3,8 +3,13 @@ from __future__ import unicode_literals
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration
+from south.modelsinspector import get_model_meta
 from django.db import models
-from tastypie.compat import AUTH_USER_MODEL
+from tastypie.compat import AUTH_USER_MODEL, User
+
+
+AUTH_USER_META = get_model_meta(User)
+AUTH_USER_META.update({'object_name': AUTH_USER_MODEL.split('.')[-1]})
 
 
 class Migration(SchemaMigration):
@@ -34,7 +39,7 @@ class Migration(SchemaMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
         AUTH_USER_MODEL: {
-            'Meta': {'object_name': AUTH_USER_MODEL.split('.')[-1]},
+            'Meta': AUTH_USER_META,
             'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
             'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),


### PR DESCRIPTION
This gives more meta information like e.g. `db_table` to the the Meta field of the `AUTH_USER_MODEL` in the frozen migration models. [The frozen Meta attributes are explained here](http://south.readthedocs.org/en/latest/ormfreezing.html#frozen-meta-attributes).

I had problems migrating because the Meta information in the frozen models did not have the `db_table` attribute. South then tried to setup an incorrect ForeignKey and ended up with `django.db.utils.ProgrammingError: relation "account_user" does not exist`.

I'm not sure this is the right approach, though. One could argue that the User model can't be properly frozen in tastypie anyways, as it might be completely different. However, maybe this works alright for a common case.

(Also: I don't think `get_model_meta` of South is a public API.)

If this is not worth including, may it serve as a guide for others to fix their migration.