### PR TITLE
Changes from llonchj; Added tests to cover dots in pks in urls.

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -296,8 +296,8 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         return [
             url(r"^(?P<resource_name>%s)%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('dispatch_list'), name="api_dispatch_list"),
             url(r"^(?P<resource_name>%s)/schema%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('get_schema'), name="api_get_schema"),
-            url(r"^(?P<resource_name>%s)/set/(?P<%s_list>\w[\w/;-]*)%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('get_multiple'), name="api_get_multiple"),
-            url(r"^(?P<resource_name>%s)/(?P<%s>\w[\w/-]*)%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
+            url(r"^(?P<resource_name>%s)/set/(?P<%s_list>.*?)%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('get_multiple'), name="api_get_multiple"),
+            url(r"^(?P<resource_name>%s)/(?P<%s>.*?)%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash()), self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
         ]
 
     def override_urls(self):

--- a/tests/alphanumeric/fixtures/initial_data.json
+++ b/tests/alphanumeric/fixtures/initial_data.json
@@ -46,11 +46,20 @@
     },
     {
         "fields": {
-            "name": "Trampolin",
+            "name": "Human Hamsterball",
             "created": "2010-05-04 20:05:00",
             "updated": "2010-05-04 20:05:00"
         },
         "model": "alphanumeric.product",
         "pk": "WS65150/01-01"
+    },
+    {
+        "fields": {
+            "name": "Ant Farm",
+            "created": "2010-05-04 20:05:00",
+            "updated": "2010-05-04 20:05:00"
+        },
+        "model": "alphanumeric.product",
+        "pk": "WS77.86"
     }
 ]

--- a/tests/alphanumeric/tests/http.py
+++ b/tests/alphanumeric/tests/http.py
@@ -52,7 +52,7 @@ class HTTPTestCase(TestServerTestCase):
         expected = {
             'meta': {
                 'previous': None,
-                'total_count': 6,
+                'total_count': 7,
                 'offset': 0,
                 'limit': 20,
                 'next': None
@@ -96,13 +96,25 @@ class HTTPTestCase(TestServerTestCase):
                 {
                     'updated': '2010-05-04T20:05:00',
                     'resource_uri': '/api/v1/products/WS65150/01-01/',
-                    'name': 'Trampolin',
+                    'name': 'Human Hamsterball',
                     'artnr': 'WS65150/01-01',
+                    'created': '2010-05-04T20:05:00'
+                },
+                {
+                    'updated': '2010-05-04T20:05:00',
+                    'resource_uri': '/api/v1/products/WS77.86/',
+                    'name': 'Ant Farm',
+                    'artnr': 'WS77.86',
                     'created': '2010-05-04T20:05:00'
                 }
             ]
         }
-        self.assertEqual(json.loads(response.read().decode('utf-8')), expected)
+        self.maxDiff = None
+        resp = json.loads(response.read().decode('utf-8'))
+
+        #testing separately to help locate issues        
+        self.assertEqual(resp['meta'], expected['meta'])
+        self.assertEqual(resp['objects'], expected['objects'])
 
     def test_post_object(self):
         connection = self.get_connection()

--- a/tests/alphanumeric/tests/views.py
+++ b/tests/alphanumeric/tests/views.py
@@ -24,9 +24,9 @@ class ViewsTestCase(TestCase):
         deserialized = json.loads(resp.content.decode('utf-8'))
         self.assertEqual(len(deserialized), 2)
         self.assertEqual(deserialized['meta']['limit'], 20)
-        self.assertEqual(len(deserialized['objects']), 6)
+        self.assertEqual(len(deserialized['objects']), 7)
         self.assertEqual([obj['name'] for obj in deserialized['objects']],
-                         [u'Skateboardrampe', u'Bigwheel', u'Trampolin', u'Laufrad', u'Bigwheel', u'Trampolin'])
+                         [u'Skateboardrampe', u'Bigwheel', u'Trampolin', u'Laufrad', u'Bigwheel', u'Human Hamsterball', u'Ant Farm'])
 
         resp = self.client.get('/api/v1/products/11111/', data={'format': 'json'})
         self.assertEqual(resp.status_code, 200)
@@ -73,14 +73,31 @@ class ViewsTestCase(TestCase):
         self.assertEqual(resp.status_code, 200)
         deserialized = json.loads(resp.content.decode('utf-8'))
         self.assertEqual(len(deserialized), 5)
-        self.assertEqual(deserialized['name'], u'Trampolin')
+        self.assertEqual(deserialized['name'], u'Human Hamsterball')
 
         resp = self.client.get('/api/v1/products/set/76123/01;WS65150/01-01/', data={'format': 'json'})
         self.assertEqual(resp.status_code, 200)
         deserialized = json.loads(resp.content.decode('utf-8'))
         self.assertEqual(len(deserialized), 1)
         self.assertEqual(len(deserialized['objects']), 2)
-        self.assertEqual([obj['name'] for obj in deserialized['objects']], [u'Bigwheel', u'Trampolin'])
+        self.assertEqual([obj['name'] for obj in deserialized['objects']], [u'Bigwheel', u'Human Hamsterball'])
+
+        # And now dots
+        resp = self.client.get('/api/v1/products/WS77.86/', data={'format': 'json'})
+        self.assertEqual(resp.status_code, 200)
+        deserialized = json.loads(resp.content.decode('utf-8'))
+        self.assertEqual(len(deserialized), 5)
+        self.assertEqual(deserialized['name'], u'Ant Farm')
+        
+        #slashes, and more dots
+        resp = self.client.get('/api/v1/products/set/76123/01;WS77.86/', data={'format': 'json'})
+        self.assertEqual(resp.status_code, 200)
+        deserialized = json.loads(resp.content.decode('utf-8'))
+        self.assertEqual(len(deserialized), 1)
+        self.assertEqual(len(deserialized['objects']), 2)
+        self.assertEqual([obj['name'] for obj in deserialized['objects']], [u'Bigwheel', u'Ant Farm'])
+
+
 
     def test_posts(self):
         request = HttpRequest()


### PR DESCRIPTION
In the interests of being much more flexible in URLs, now accept more than just word characters, hyphens and forward slashes.

Tests added to cover change proposed by @llonchj in #273. 
