### PR TITLE
Handling of ValidationError can lose field names because it uses ValidationError.messages even when ValidationError.message_dict is available.

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -219,7 +219,11 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                 data = {"error": e.args[0] if getattr(e, 'args') else ''}
                 return self.error_response(request, data, response_class=http.HttpBadRequest)
             except ValidationError as e:
-                data = {"error": e.messages}
+                # if there is a message_dict, use that since it's more useful
+                if hasattr(e, 'message_dict'):
+                    data = {"error": e.message_dict}
+                else:
+                    data = {"error": e.messages}
                 return self.error_response(request, data, response_class=http.HttpBadRequest)
             except Exception as e:
                 if hasattr(e, 'response'):

--- a/tests/validation/api/resources.py
+++ b/tests/validation/api/resources.py
@@ -6,6 +6,7 @@ from tastypie.authorization import Authorization
 from basic.models import Note, AnnotatedNote, UserForm
 from django import forms
 from tastypie.validation import FormValidation
+from validation.models import ValidatedModel
 
 # NOTES:
 # model defaults don't matter since we are not rendering a form, if you want to use a default exclude the field.
@@ -51,3 +52,12 @@ class NoteResource(ModelResource):
             "created": ALL
             }
 
+class ValidatedModelResource(ModelResource):
+    """
+    This model is validated somewhere that's not under the validation Meta option.
+    """
+
+    class Meta:
+        resource_name = 'validatedmodels'
+        queryset = ValidatedModel.objects.all()
+        authorization = Authorization()

--- a/tests/validation/api/urls.py
+++ b/tests/validation/api/urls.py
@@ -3,12 +3,13 @@ try:
 except ImportError: # Django < 1.4
     from django.conf.urls.defaults import patterns, include, url
 from tastypie.api import Api
-from validation.api.resources import NoteResource, UserResource, AnnotatedNoteResource
+from validation.api.resources import NoteResource, UserResource, AnnotatedNoteResource, ValidatedModelResource
 
 api = Api(api_name='v1')
 api.register(NoteResource(), canonical=True)
 api.register(UserResource(), canonical=True)
 api.register(AnnotatedNoteResource(), canonical=True)
+api.register(ValidatedModelResource(), canonical=True)
 
 urlpatterns = patterns('',
     url(r'^api/', include(api.urls)),

--- a/tests/validation/models.py
+++ b/tests/validation/models.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+
+class ValidatedModel(models.Model):
+    content = models.CharField(max_length=20)
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super(ValidatedModel, self).save(*args, **kwargs)

--- a/tests/validation/models.py
+++ b/tests/validation/models.py
@@ -2,6 +2,10 @@ from django.db import models
 
 
 class ValidatedModel(models.Model):
+    """
+    Simple model that runs its own validation on save().
+    """
+
     content = models.CharField(max_length=20)
 
     def save(self, *args, **kwargs):

--- a/tests/validation/tests.py
+++ b/tests/validation/tests.py
@@ -160,3 +160,32 @@ class PutListNestResouceValidationTestCase(TestCase):
                 'annotations': ['This field is required.']
             }
         })
+
+class ModelValidationErrorTestCase(TestCase):
+    """
+    Make sure that ValidationErrors raised elsewhere (eg, in Model.save()) are
+    handled the same way as errors under the validation Meta option.
+    """
+
+    urls = 'validation.api.urls'
+
+    def test_valid_data(self):
+        data = json.dumps({
+            'content': 'a' * 20,
+        })
+
+        resp = self.client.post('/api/v1/validatedmodels/', data=data, content_type='application/json')
+        self.assertEqual(resp.status_code, 201)
+
+    def test_invalid_data(self):
+        data = json.dumps({
+            'content': 'a' * 21,
+        })
+
+        resp = self.client.post('/api/v1/validatedmodels/', data=data, content_type='application/json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(json.loads(resp.content.decode('utf-8')), {
+            'error': {
+                'content': ['Ensure this value has at most 20 characters (it has 21).']
+            }
+        })


### PR DESCRIPTION
As of 0.10.0, if a `ValidationError` is raised by the model, Tastypie simply looks for a `messages` attribute holding a list of errors.

https://github.com/toastdriven/django-tastypie/blob/v0.10.0/tastypie/resources.py#L221

However, `ValidationErrors.message_dict` is much more useful if it is available because it tells you what fields your errors are on. And, this will give errors much more in line with what is provided for an `ApiFieldError`.

https://github.com/django/django/blob/1.5.2/django/core/exceptions.py#L63

I am happy to contribute a pull request for this issue, and I'm planning to model the test case after the existing validation tests.

https://github.com/toastdriven/django-tastypie/blob/v0.10.0/tests/validation/tests.py

If anybody has any thoughts or concerns about this, please let me know.
