### PR TITLE
Update content_types.rst

### DIFF
--- a/docs/content_types.rst
+++ b/docs/content_types.rst
@@ -62,6 +62,10 @@ A simple ModelResource for this model might look like this::
             resource_name = 'tagged_items'
             queryset = TaggedItem.objects.all()
 
+A ModelResource that is to be used as a relation to a GenericForeignKeyField
+must also be registered to the Api instance defined in your URLconf in order
+to provide a reverse uri for lookups.
+
 Like ToOneField, you must add your GenericForeignKey attribute to your
 ModelResource definition. It will not be added automatically like most other
 field or attribute types. When you define it, you must also define the other


### PR DESCRIPTION
It isn't fully clear from reading this documentation that you must register your ModelResources to your Api instance in URLconf.  This update should make it more clear and help those that are receiving a '' for generic related objects from any API calls.
