### PR TITLE
pin python3-digest to latest version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ python-dateutil>=2.1
 lxml
 defusedxml
 PyYAML
-python3-digest
+python3-digest>=1.8b4
 biplist
 
 # Because the official 0.1.4 release (that added Py3 support) HAS NO FILES.


### PR DESCRIPTION
If one were to follow the "Running the Tests" docs with a current version of pip, the requirements file will fail to install all packages, as pip>=1.4 no longer installs prerelease packages by default.

Instead of globally enabling this by modifying the docs to add a `--pre` flag, which is too big of a hammer and also doesn't exist on pip 1.3, specifying that the latest beta version of python3-digest is acceptable allows us to waive the behavior on just that package. This should preserve behavior for existing cases and fix it for those on the latest versions.
