### PR TITLE
fix django 1.4 incompatibility

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -10,7 +10,11 @@ from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned, 
 from django.core.urlresolvers import NoReverseMatch, reverse, resolve, Resolver404, get_script_prefix
 from django.core.signals import got_request_exception
 from django.db import transaction
-from django.db.models.constants import LOOKUP_SEP
+try:
+    from django.db.models.constants import LOOKUP_SEP
+except:
+    from django.db.models.sql.constants import LOOKUP_SEP
+    
 from django.db.models.sql.constants import QUERY_TERMS
 from django.http import HttpResponse, HttpResponseNotFound, Http404
 from django.utils.cache import patch_cache_control, patch_vary_headers


### PR DESCRIPTION
Django moves LOOKUP_SEP from django.db.models.sql.constants to django.db.models.constants
