### PR TITLE
Make CacheThrottle work with DummyCache

### DIFF
--- a/tastypie/throttle.py
+++ b/tastypie/throttle.py
@@ -79,12 +79,9 @@ class CacheThrottle(BaseThrottle):
         """
         key = self.convert_identifier_to_key(identifier)
 
-        # Make sure something is there.
-        cache.add(key, [])
-
         # Weed out anything older than the timeframe.
         minimum_time = int(time.time()) - int(self.timeframe)
-        times_accessed = [access for access in cache.get(key) if access >= minimum_time]
+        times_accessed = [access for access in cache.get(key, []) if access >= minimum_time]
         cache.set(key, times_accessed, self.expiration)
 
         if len(times_accessed) >= int(self.throttle_at):


### PR DESCRIPTION
This is a tiny change.

I happened to discover that the `CacheThrottle` assumes that the cache isn't blown away between a `set` and a `get` a couple lines later. Of course this issue is hard to discover with any practical cache implementation, but the `DummyCache` always returns `None` so the bug is triggered immediately.

This commit makes the `CacheThrottle` work in all cases.

Cheers,

Kenn
