### PR TITLE
Removed py26-dev tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33-dev,py27-dev,py26-dev,py33-1.5,py27-1.5,py26-1.5,docs
+envlist = py33-dev,py27-dev,py33-1.5,py27-1.5,py26-1.5,docs
 
 [testenv]
 setenv =


### PR DESCRIPTION
This was missed in commit 4320db4ac, I believe.

Closes #312. (Further, commit 4320db4ac + this should close #996.)
