### PR TITLE
Suppress Content-Type header on HTTP 204 (see #111)

### DIFF
--- a/tastypie/http.py
+++ b/tastypie/http.py
@@ -22,6 +22,10 @@ class HttpAccepted(HttpResponse):
 class HttpNoContent(HttpResponse):
     status_code = 204
 
+    def __init__(self, *args, **kwargs):
+        super(HttpNoContent, self).__init__(*args, **kwargs)
+        del self['Content-Type']
+
 
 class HttpMultipleChoices(HttpResponse):
     status_code = 300

--- a/tastypie/test.py
+++ b/tastypie/test.py
@@ -327,7 +327,8 @@ class ResourceTestCase(TestCase):
         """
         Ensures the response is returning either a HTTP 202 or a HTTP 204.
         """
-        return self.assertIn(resp.status_code, [202, 204])
+        self.assertIn(resp.status_code, [202, 204])
+        self.assertNotIn('Content-Type', resp)
 
     def assertHttpMultipleChoices(self, resp):
         """


### PR DESCRIPTION
This is a tidied up version of the patch in #111 with tests