### PR TITLE
Update who_uses.rst

### DIFF
--- a/docs/who_uses.rst
+++ b/docs/who_uses.rst
@@ -8,6 +8,23 @@ interested in adding more sites, so please find me (``daniellindsley``) via
 IRC or start a mailing list thread.
 
 
+CourtListener
+-------------
+Read-only API providing 2.5M legal opinions and other judicial data via Solr/Sunburnt and Postgres (Django models).
+
+* Site: https://www.courtlistener.com
+* Code : https://bitbucket.org/mlissner/search-and-awareness-platform-courtlistener/src
+
+
+Dbpatterns
+----------
+
+Dbpatterns is a service that allows you to create, share, explore database models on the web.
+
+* http://dbpatterns.com
+
+
+
 LJWorld Marketplace
 -------------------
 
@@ -23,14 +40,24 @@ Read-only API access to recipes.
 * http://forkinit.com/api/v1/?format=json
 
 
-Read The Docs
--------------
+I-Am-CC.org
+-----------
 
-A hosted documentation site, primarily for Python docs. General purpose
-read-write access.
+`I-Am-CC.org <http://i-am-cc.org>`_ is a tool for releasing Instagram photos
+under a Creative Commons license.
 
-* http://readthedocs.org/
-* http://readthedocs.org/api/v1/?format=json
+* http://i-am-cc.org/api/?format=json
+
+
+LocalWiki
+---------
+
+`LocalWiki <http://localwiki.org>`_ is a tool for collaborating in local,
+geographic communities. It's using Tastypie to provide an geospatially-aware
+REST API.
+
+* http://localwiki.readthedocs.org/en/latest/api.html
+* http://localwiki.org/blog/2012/aug/31/localwiki-api-released/
 
 
 Luzme
@@ -50,28 +77,12 @@ To power their mobile (iPhone/Android/Playbook) applications.
 * http://www.politifact.com/mobile/
 
 
-LocalWiki
----------
 
-`LocalWiki <http://localwiki.org>`_ is a tool for collaborating in local,
-geographic communities. It's using Tastypie to provide an geospatially-aware
-REST API.
+Read The Docs
+-------------
 
-* http://localwiki.readthedocs.org/en/latest/api.html
-* http://localwiki.org/blog/2012/aug/31/localwiki-api-released/
+A hosted documentation site, primarily for Python docs. General purpose
+read-write access.
 
-
-I-Am-CC.org
------------
-
-`I-Am-CC.org <http://i-am-cc.org>`_ is a tool for releasing Instagram photos
-under a Creative Commons license.
-
-* http://i-am-cc.org/api/?format=json
-
-Dbpatterns
-----------
-
-Dbpatterns is a service that allows you to create, share, explore database models on the web.
-
-* http://dbpatterns.com
+* http://readthedocs.org/
+* http://readthedocs.org/api/v1/?format=json


### PR DESCRIPTION
Alphabetizes then adds my project at the top (for now). Seems self-serving, but I couldn't figure any other order, so I just imposed a fair one.
