### PR TITLE
Removed django.utils.simplejson due to deprecation in Django 1.6.

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -2,9 +2,9 @@ from __future__ import unicode_literals
 import datetime
 import re
 import django
+import json
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.serializers import json  # FIXME: disambiguate name from JSON module
 from django.utils import six
 from django.utils.encoding import force_text, smart_bytes
 


### PR DESCRIPTION
Django 1.6 emits a warning for deprecation of django.utils.simplejson. Replacing with the standard Python `json` module.
