### PR TITLE
Fixed #1031 - Nested resource example in cookbook returns only one of many possible values

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -171,7 +171,7 @@ handle the children::
                 return HttpMultipleChoices("More than one resource is found at this URI.")
 
             child_resource = ChildResource()
-            return child_resource.get_detail(request, parent_id=obj.pk)
+            return child_resource.get_list(request, parent_id=obj.pk)
 
 Another alternative approach is to override the ``dispatch`` method::
 


### PR DESCRIPTION
`get_children()` method in the example should return multiple objects (if possible) but does not because example code has `child_resource.get_detail(request, parent_id=obj.pk)` instead of `child_resource.get_list(request, parent_id=obj.pk)`.