### PR TITLE
Changes the BasicAuthentication to have a better fallback value.

### DIFF
--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -145,7 +145,7 @@ class BasicAuthentication(Authentication):
 
         This implementation returns the user's basic auth username.
         """
-        return request.META.get('REMOTE_USER', 'nouser')
+        return request.META.get('REMOTE_USER', request.user.username)
 
 
 class ApiKeyAuthentication(Authentication):


### PR DESCRIPTION
I've been rather confused today. I enabled BasicAuthentication on my API and it seemed to work just fine until I started checking out throttling. When I did that, I learned that the throttle relies on `request.META['REMOTE_USER']`. Since I only use BasicAuth on my API and not on my front end, I don't have the Remote middlewares enabled, and I especially don't have anything (LDAP, AD, Kerberos) setting the REMOTE_USER value.

What I want is for my app to accept Basic Auth credentials on the API and to compare them against the backend. That part works fine, but when it comes to getting the identifier it seems odd to me that it'd use REMOTE_USER, falling back to 'nouser'.

In the change I've made, it makes it so the fallback is the username of the user rather than nothing. This gives them a unique name even if REMOTE_USER isn't configured, and I believe this makes it so that people like me can get Basic Auth going easily, without touching their web server configs.

I'd be very interested in feedback on this change, as I've already overridden BasicAuthentication in my app with this change and am about to put that into production (modulo some more QA). If this looks good, I'll be happy to update the docs as well (as I've done a few times now).
