### PR TITLE
Fixed DecimalField to be compatible with py2.6

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -259,7 +259,7 @@ class DecimalField(ApiField):
         if value is None:
             return None
 
-        return Decimal(value)
+        return Decimal(str(value))
 
     def hydrate(self, bundle):
         value = super(DecimalField, self).hydrate(bundle)

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -308,6 +308,9 @@ class DecimalFieldTestCase(TestCase):
         field_2 = DecimalField(default='18.5')
         self.assertEqual(field_2.dehydrate(bundle), Decimal('18.5'))
 
+        field_3 = DecimalField(default=21.5)
+        self.assertEqual(field_3.dehydrate(bundle), Decimal('21.5'))
+
     def test_hydrate(self):
         bundle = Bundle(data={
             'decimal-y': '18.50',


### PR DESCRIPTION
float is not permitted as argument type in python 2.6