### PR TITLE
Adding support for partial response

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -84,7 +84,7 @@ Contributors:
 * Revolution Systems & The Python Software Foundation for funding a significant portion of the port to Python 3!
 * tunix for a patch related to Tastypie's timezone-aware dates.
 * Steven Davidson (damycra) for a documentation patch.
-
+* Rahul Tanwani (tanwanirahul) for adding a feature to implement partial response. This gives users ability to specify fields needed by users.
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -331,6 +331,19 @@ you require more granular control, both ``list_allowed_methods`` and
 ``detail_allowed_methods`` options are supported.
 
 
+Allowing Clients To Specify The Data They Need (Partial Response)
+=================================================================
+
+There are often cases where APIs are being consumed by multiple clients, and
+all are intrested in small subset of the data that the API actually returns.
+To get the specific fields from API response, clients can pass in the fields
+patameter specifying the fields they are intrested in during GET API calls.
+
+Continuing with the same ``UserResource``, if you call 
+``/api/v1/user/?fields=username,id`` you will get back the list of objects
+containing only the mentioned fields.
+
+
 Beyond The Basics
 =================
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -806,16 +806,36 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 
     # Data preparation.
 
+    def determine_fields(self, bundle):
+        '''
+            Returns the fields that needs to be deserialized.
+            This is useful if we want client to control what fields they are
+            interested in. This a simple implementation of partial response.
+        '''
+        filters = bundle.request.GET.copy()
+
+        # Grab the fields requested by client.
+        required_fields = filters.get("fields", "")
+
+        # All fields that we have registered for this resource.
+        resource_fields = self.fields.keys()
+        if not required_fields:
+            return resource_fields
+
+        # Rerturn the intersection of fields requested and all the resource_fields.
+        return set(required_fields.split(",")) & set(resource_fields)
+
     def full_dehydrate(self, bundle, for_list=False):
         """
         Given a bundle with an object instance, extract the information from it
         to populate the resource.
         """
-        use_in = ['all', 'list' if for_list else 'detail']
-
         # Dehydrate each field.
-        for field_name, field_object in self.fields.items():
+        fields = self.determine_fields(bundle)
+        use_in = ['all', 'list' if for_list else 'detail']
+        for field_name in fields:
             # If it's not for use in this mode, skip
+            field_object = self.fields.get(field_name)
             field_use_in = getattr(field_object, 'use_in', 'all')
             if callable(field_use_in):
                 if not field_use_in(bundle):
@@ -823,7 +843,6 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             else:
                 if field_use_in not in use_in:
                     continue
-
             # A touch leaky but it makes URI resolution work.
             if getattr(field_object, 'dehydrated_type', None) == 'related':
                 field_object.api_name = self._meta.api_name

--- a/tests/basic/tests/http.py
+++ b/tests/basic/tests/http.py
@@ -70,6 +70,14 @@ class HTTPTestCase(TestServerTestCase):
         self.assertEqual(response.status, 200)
         self.assertEqual(response.read().decode('utf-8'), '{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null, "total_count": 2}, "objects": [{"content": "This is my very first post using my shiny new API. Pretty sweet, huh?", "created": "2010-03-30T20:05:00", "id": 1, "is_active": true, "resource_uri": "/api/v1/notes/1/", "slug": "first-post", "title": "First Post!", "updated": "2010-03-30T20:05:00", "user": "/api/v1/users/1/"}, {"content": "The dog ate my cat today. He looks seriously uncomfortable.", "created": "2010-03-31T20:05:00", "id": 2, "is_active": true, "resource_uri": "/api/v1/notes/2/", "slug": "another-post", "title": "Another Post", "updated": "2010-03-31T20:05:00", "user": "/api/v1/users/1/"}]}')
 
+    def test_get_list_with_fields(self):
+        connection = self.get_connection()
+        connection.request('GET', '/api/v1/notes/?fields=is_active,id,title', headers={'Accept': 'application/json'})
+        response = connection.getresponse()
+        connection.close()
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.read().decode('utf-8'), '{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null, "total_count": 2}, "objects": [{"id": 1, "is_active": true, "title": "First Post!"}, {"id": 2, "is_active": true, "title": "Another Post"}]}')
+
     def test_post_object(self):
         connection = self.get_connection()
         post_data = '{"content": "A new post.", "is_active": true, "title": "New Title", "slug": "new-title", "user": "/api/v1/users/1/"}'


### PR DESCRIPTION
Adding support for partial response. This will allow users of the API to specify what fields they need in response to API call. Adding test cases and updating the documentation to reflect the same.
