### PR TITLE
workaround for exception handling edge case

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -228,7 +228,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                 data = {"error": sanitize(e.messages)}
                 return self.error_response(request, data, response_class=http.HttpBadRequest)
             except Exception as e:
-                if hasattr(e, 'response'):
+                if hasattr(e, 'response') and isinstance(e.response, HttpResponse):
                     return e.response
 
                 # A real, non-expected exception.


### PR DESCRIPTION
don't return a bad response if underlying code happens to throw an exception that has a `.response` defined on it that isn't actually an `HttpResponse`. For example http://benoitc.github.io/restkit/api/restkit.errors.ResourceError-class.html

This prevents more confusing errors later when you try and treat the response like an `HttpResponse`
