### PR TITLE
Make sure that related_obj and related_name are set on bundles when saving m2m or foreign key fields

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -737,7 +737,8 @@ class ToOneField(RelatedField):
         if value is None:
             return value
 
-        return self.build_related_resource(value, request=bundle.request)
+        return self.build_related_resource(value, request=bundle.request, related_obj=bundle.obj, related_name=self.related_name)
+
 
 class ForeignKey(ToOneField):
     """

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -806,7 +806,7 @@ class ToManyField(RelatedField):
         elif callable(self.attribute):
             the_m2ms = self.attribute(bundle)
 
-        if not the_m2ms:
+        if the_m2ms is None:
             if not self.null:
                 raise ApiFieldError("The model '%r' has an empty attribute '%s' and doesn't allow a null value." % (previous_obj, attr))
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -672,7 +672,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 
         return auth_result
 
-    def build_bundle(self, obj=None, data=None, request=None, objects_saved=None):
+    def build_bundle(self, obj=None, data=None, request=None, objects_saved=None, related_obj=None, related_name=None):
         """
         Given either an object, a data dictionary or both, builds a ``Bundle``
         for use throughout the ``dehydrate/hydrate`` cycle.
@@ -688,7 +688,9 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             obj=obj,
             data=data,
             request=request,
-            objects_saved=objects_saved
+            objects_saved=objects_saved,
+            related_obj=related_obj,
+            related_name=related_name
         )
 
     def build_filters(self, filters=None):
@@ -2288,12 +2290,20 @@ class BaseModelResource(Resource):
                     continue
 
                 if bundle.data.get(field_name) and hasattr(bundle.data[field_name], 'keys'):
+                    bundle_related_obj = bundle.obj
+                    bundle_related_name = None
+
+                    if field_object.related_name:
+                        bundle_related_name = field_object.related_name
+
                     # Only build & save if there's data, not just a URI.
                     related_bundle = related_resource.build_bundle(
                         obj=related_obj,
                         data=bundle.data.get(field_name),
                         request=bundle.request,
-                        objects_saved=bundle.objects_saved
+                        objects_saved=bundle.objects_saved,
+                        related_obj=bundle_related_obj,
+                        related_name=bundle_related_name
                     )
                     related_resource.save(related_bundle)
 
@@ -2355,7 +2365,9 @@ class BaseModelResource(Resource):
                     obj=related_bundle.obj,
                     data=related_bundle.data,
                     request=bundle.request,
-                    objects_saved=bundle.objects_saved
+                    objects_saved=bundle.objects_saved,
+                    related_obj=related_bundle.related_obj,
+                    related_name=related_bundle.related_name
                 )
 
                 #Only save related models if they're newly added.


### PR DESCRIPTION
This allows for more fine grained authorization down the line (i.e., only allow update operations when they happen on nested resources).