### PR TITLE
Add 'primary_key' Field To Schema

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -962,7 +962,11 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         if self._meta.filtering:
             data['filtering'] = self._meta.filtering
 
-        pk_field_name = self._meta.queryset.model._meta.pk.name
+        #Skip assigning pk_field_name for non-model resources
+        try:
+            pk_field_name = self._meta.queryset.model._meta.pk.name
+        except AttributeError:
+            pk_field_name = None
 
         for field_name, field_object in self.fields.items():
             data['fields'][field_name] = {

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -962,6 +962,8 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         if self._meta.filtering:
             data['filtering'] = self._meta.filtering
 
+        pk_field_name = self._meta.queryset.model._meta.pk.name
+
         for field_name, field_object in self.fields.items():
             data['fields'][field_name] = {
                 'default': field_object.default,
@@ -971,6 +973,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                 'readonly': field_object.readonly,
                 'help_text': field_object.help_text,
                 'unique': field_object.unique,
+                'primary_key': True if field_name == pk_field_name else False,
             }
             if field_object.dehydrated_type == 'related':
                 if getattr(field_object, 'is_m2m', False):

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -578,7 +578,8 @@ class ResourceTestCase(TestCase):
                     'nullable': True,
                     'readonly': False,
                     'type': 'datetime',
-                    'unique': False
+                    'unique': False,
+                    "primary_key": False
                 },
                 'name': {
                     'blank': False,
@@ -587,7 +588,8 @@ class ResourceTestCase(TestCase):
                     'nullable': False,
                     'readonly': False,
                     'type': 'string',
-                    'unique': False
+                    'unique': False,
+                    "primary_key": False
                 },
                 'resource_uri': {
                     'blank': False,
@@ -596,7 +598,8 @@ class ResourceTestCase(TestCase):
                     'nullable': False,
                     'readonly': True,
                     'type': 'string',
-                    'unique': False
+                    'unique': False,
+                    "primary_key": False
                 },
                 'view_count': {
                     'blank': False,
@@ -605,7 +608,8 @@ class ResourceTestCase(TestCase):
                     'nullable': False,
                     'readonly': False,
                     'type': 'integer',
-                    'unique': False
+                    'unique': False,
+                    "primary_key": False
                 }
             }
         })
@@ -629,7 +633,8 @@ class ResourceTestCase(TestCase):
                     'blank': False,
                     'help_text': 'Integer data. Ex: 2673',
                     'unique': False,
-                    'type': 'integer'
+                    'type': 'integer',
+                    "primary_key": False
                 },
                 'date_joined': {
                     'nullable': True,
@@ -638,7 +643,8 @@ class ResourceTestCase(TestCase):
                     'blank': False,
                     'help_text': 'A date & time as a string. Ex: "2010-11-10T03:07:43"',
                     'unique': False,
-                    'type': 'datetime'
+                    'type': 'datetime',
+                    "primary_key": False
                 },
                 'name': {
                     'nullable': False,
@@ -647,7 +653,8 @@ class ResourceTestCase(TestCase):
                     'blank': False,
                     'help_text': 'Unicode string data. Ex: "Hello World"',
                     'unique': False,
-                    'type': 'string'
+                    'type': 'string',
+                    "primary_key": False
                 },
                 'resource_uri': {
                     'nullable': False,
@@ -656,7 +663,8 @@ class ResourceTestCase(TestCase):
                     'blank': False,
                     'help_text': 'Unicode string data. Ex: "Hello World"',
                     'unique': False,
-                    'type': 'string'
+                    'type': 'string',
+                    "primary_key": False
                 }
             },
             'default_format': 'application/json',
@@ -1600,7 +1608,8 @@ class ModelResourceTestCase(TestCase):
                     'blank': False,
                     'help_text': 'A single related resource. Can be either a URI or set of nested resource data.',
                     'unique': False,
-                    'type': 'related'
+                    'type': 'related',
+                    "primary_key": False
                 },
                 'title': {
                     'nullable': False,
@@ -1609,7 +1618,8 @@ class ModelResourceTestCase(TestCase):
                     'blank': False,
                     'help_text': 'Unicode string data. Ex: "Hello World"',
                     'unique': False,
-                    'type': 'string'
+                    'type': 'string',
+                    "primary_key": False
                 },
                 'created': {
                     'nullable': False,
@@ -1618,7 +1628,8 @@ class ModelResourceTestCase(TestCase):
                     'blank': False,
                     'help_text': 'A date & time as a string. Ex: "2010-11-10T03:07:43"',
                     'unique': False,
-                    'type': 'datetime'
+                    'type': 'datetime',
+                    "primary_key": False
                 },
                 'is_active': {
                     'nullable': False,
@@ -1627,7 +1638,8 @@ class ModelResourceTestCase(TestCase):
                     'blank': True,
                     'help_text': 'Boolean data. Ex: True',
                     'unique': False,
-                    'type': 'boolean'
+                    'type': 'boolean',
+                    "primary_key": False
                 },
                 'content': {
                     'nullable': False,
@@ -1636,7 +1648,8 @@ class ModelResourceTestCase(TestCase):
                     'blank': True,
                     'help_text': 'Unicode string data. Ex: "Hello World"',
                     'unique': False,
-                    'type': 'string'
+                    'type': 'string',
+                    "primary_key": False
                 },
                 'subjects': {
                     'related_type': 'to_many',
@@ -1646,7 +1659,8 @@ class ModelResourceTestCase(TestCase):
                     'blank': False,
                     'help_text': 'Many related resources. Can be either a list of URIs or list of individually nested resource data.',
                     'unique': False,
-                    'type': 'related'
+                    'type': 'related',
+                    "primary_key": False
                 },
                 'slug': {
                     'nullable': False,
@@ -1655,7 +1669,8 @@ class ModelResourceTestCase(TestCase):
                     'blank': False,
                     'help_text': 'Unicode string data. Ex: "Hello World"',
                     'unique': False,
-                    'type': 'string'
+                    'type': 'string',
+                    "primary_key": False
                 },
                 'resource_uri': {
                     'nullable': False,
@@ -1664,7 +1679,8 @@ class ModelResourceTestCase(TestCase):
                     'blank': False,
                     'help_text': 'Unicode string data. Ex: "Hello World"',
                     'unique': False,
-                    'type': 'string'
+                    'type': 'string',
+                    "primary_key": False
                 }
             },
             'default_format': 'application/json',

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -3036,7 +3036,8 @@ class ModelResourceTestCase(TestCase):
                     "nullable": False,
                     "readonly": False,
                     "type": "string",
-                    "unique": False
+                    "unique": False,
+                    "primary_key": False
                 },
                 "created": {
                     "blank": False,
@@ -3045,7 +3046,8 @@ class ModelResourceTestCase(TestCase):
                     "nullable": False,
                     "readonly": False,
                     "type": "datetime",
-                    "unique": False
+                    "unique": False,
+                    "primary_key": False
                 },
                 "id": {
                     "blank": True,
@@ -3054,7 +3056,8 @@ class ModelResourceTestCase(TestCase):
                     "nullable": False,
                     "readonly": False,
                     "type": "integer",
-                    "unique": True
+                    "unique": True,
+                    "primary_key": True
                 },
                 "is_active": {
                     "blank": True,
@@ -3063,7 +3066,8 @@ class ModelResourceTestCase(TestCase):
                     "nullable": False,
                     "readonly": False,
                     "type": "boolean",
-                    "unique": False
+                    "unique": False,
+                    "primary_key": False
                 },
                 "resource_uri": {
                     "blank": False,
@@ -3072,7 +3076,8 @@ class ModelResourceTestCase(TestCase):
                     "nullable": False,
                     "readonly": True,
                     "type": "string",
-                    "unique": False
+                    "unique": False,
+                    "primary_key": False
                 },
                 "slug": {
                     "blank": False,
@@ -3081,7 +3086,8 @@ class ModelResourceTestCase(TestCase):
                     "nullable": False,
                     "readonly": False,
                     "type": "string",
-                    "unique": False
+                    "unique": False,
+                    "primary_key": False
                 },
                 "title": {
                     "blank": False,
@@ -3090,7 +3096,8 @@ class ModelResourceTestCase(TestCase):
                     "nullable": False,
                     "readonly": False,
                     "type": "string",
-                    "unique": False
+                    "unique": False,
+                    "primary_key": False
                 },
                 "updated": {
                     "blank": False,
@@ -3099,7 +3106,8 @@ class ModelResourceTestCase(TestCase):
                     "nullable": False,
                     "readonly": False,
                     "type": "datetime",
-                    "unique": False
+                    "unique": False,
+                    "primary_key": False
                 }
             },
             "filtering": {


### PR DESCRIPTION
Re-created #1082 to reflect new branch/commits. 

This commit adds the field "primary_key" to the resource schema, it can be very useful for auto-generated UI/clients when using explicit primary key columns on your django models. 