### PR TITLE
Fix PendingDeprecationWarning for Django 1.6.2

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2187,7 +2187,7 @@ class BaseModelResource(Resource):
         self.authorized_delete_detail(self.get_object_list(bundle.request), bundle)
         bundle.obj.delete()
 
-    @transaction.commit_on_success()
+    @transaction.atomic()
     def patch_list(self, request, **kwargs):
         """
         An ORM-specific implementation of ``patch_list``.


### PR DESCRIPTION
Django 1.6.2 raises a PendingDeprecationWarning if you use @commit_on_success instead of @atomic. Here's someone else with the same problem: http://stackoverflow.com/questions/22510756/pendingdeprecationwarning-on-django-tastypie

I got the issue on Python 2.7.5, and the poster did on Python 3.3+.
