### PR TITLE
Make user model loading work for Django 1.7

### DIFF
--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -11,7 +11,7 @@ from django.middleware.csrf import _sanitize_token, constant_time_compare
 from django.utils.http import same_origin
 from django.utils.translation import ugettext as _
 from tastypie.http import HttpUnauthorized
-from tastypie.compat import User, username_field
+from tastypie.compat import get_user_model, get_username_field
 
 try:
     from hashlib import sha1
@@ -180,7 +180,6 @@ class ApiKeyAuthentication(Authentication):
         Should return either ``True`` if allowed, ``False`` if not or an
         ``HttpResponse`` if you need something custom.
         """
-        from tastypie.compat import User
 
         try:
             username, api_key = self.extract_credentials(request)
@@ -189,6 +188,9 @@ class ApiKeyAuthentication(Authentication):
 
         if not username or not api_key:
             return self._unauthorized()
+
+        username_field = get_username_field()
+        User = get_user_model()
 
         try:
             lookup_kwargs = {username_field: username}
@@ -280,7 +282,8 @@ class SessionAuthentication(Authentication):
 
         This implementation returns the user's username.
         """
-        return getattr(request.user, username_field)
+
+        return getattr(request.user, get_username_field())
 
 
 class DigestAuthentication(Authentication):
@@ -366,6 +369,9 @@ class DigestAuthentication(Authentication):
         return True
 
     def get_user(self, username):
+        username_field = get_username_field()
+        User = get_user_model()
+
         try:
             lookup_kwargs = {username_field: username}
             user = User.objects.get(**lookup_kwargs)

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -1,24 +1,25 @@
 from __future__ import unicode_literals
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 import django
 
-__all__ = ['User', 'AUTH_USER_MODEL']
+__all__ = ['get_user_model', 'get_username_field', 'AUTH_USER_MODEL']
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 # Django 1.5+ compatibility
 if django.VERSION >= (1, 5):
-    try:
-        from django.contrib.auth import get_user_model
-        User = get_user_model()
-        username_field = User.USERNAME_FIELD
-    except ImproperlyConfigured:
-        # The the users model might not be read yet.
-        # This can happen is when setting up the create_api_key signal, in your
-        # custom user module.
-        User = None
-        username_field = None
+    def get_user_model():
+        from django.contrib.auth import get_user_model as django_get_user_model
+
+        return django_get_user_model()
+
+    def get_username_field():
+        return get_user_model().USERNAME_FIELD
 else:
-    from django.contrib.auth.models import User
-    username_field = 'username'
+    def get_user_model():
+        from django.contrib.auth.models import User
+
+        return User
+
+    def get_username_field():
+        return 'username'


### PR DESCRIPTION
Importing `tastypie.compat` under Django 1.7 would trigger a

```
RuntimeError: App registry isn't ready yet.
```

This PR puts the user model loading into functions to be called later which makes it work under Django 1.7.
