### PR TITLE
Allow compatibility with Django 1.7

### DIFF
--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -11,8 +11,8 @@ AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 if django.VERSION >= (1, 5):
     try:
         from django.contrib.auth import get_user_model
-        User = get_user_model()
-        username_field = User.USERNAME_FIELD
+        User = lambda: get_user_model()
+        username_field = lambda: User.USERNAME_FIELD
     except ImproperlyConfigured:
         # The the users model might not be read yet.
         # This can happen is when setting up the create_api_key signal, in your


### PR DESCRIPTION
Prevent the `AppRegistery isn't ready yet` error with Django 1.7+
