### PR TITLE
Dynamic auth user model pk name in initial migration.

### DIFF
--- a/tastypie/migrations/0001_initial.py
+++ b/tastypie/migrations/0001_initial.py
@@ -6,6 +6,12 @@ from south.v2 import SchemaMigration
 from django.db import models
 from tastypie.compat import AUTH_USER_MODEL
 
+try:
+    from django.contrib.auth import get_user_model
+except ImportError: # django < 1.5
+    from django.contrib.auth.models import User
+else:
+    User = get_user_model()
 
 class Migration(SchemaMigration):
 
@@ -60,7 +66,7 @@ class Migration(SchemaMigration):
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
             'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
             'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            User._meta.pk.column: ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'blank': 'True'}),
             'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'blank': 'True'}),
             'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'blank': 'True'}),


### PR DESCRIPTION
The **id** column can be something else if **AbstractUser** is in use. In our case it was **person_ptr_id**. This fixes it for me. Provided the same fix to django-reversion yesterday: https://github.com/etianen/django-reversion/pull/301
