### PR TITLE
Do not send 404 exceptions via `got_request_exception`

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -272,8 +272,9 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             log.error('Internal Server Error: %s' % request.path, exc_info=True,
                       extra={'status_code': response_code, 'request': request})
 
-        # Send the signal so other apps are aware of the exception.
-        got_request_exception.send(self.__class__, request=request)
+            # Send the signal so other apps are aware of the exception.
+            # Do not send 404 exceptions unless asked to.
+            got_request_exception.send(self.__class__, request=request)
 
         # Prep the data going out.
         data = {


### PR DESCRIPTION
django-tastypie informs other apps of exceptions that occured in _handle_500, but 404 exceptions aren't
really errors and tastypie encourages to raise 404 for certain cases. 
It seems logical to send `got_request_exception` only under same conditions when error logging is done.

This pull request is motivated by sentry integration, as sentry relies on catching `got_request_exception` signals and get's lots of false positives from tastypie if a resource raises NotFound or Http404.

Is this suggestion reasonable?
Should I add tests to this PullRequest? 
