### PR TITLE
Fix broken doctests

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -21,7 +21,7 @@ A plugin (actually two different ones that closely mirror each other) that
 nicely reformats JSON data in the browser.
 
 Postman - Rest Client
---------------------
+---------------------
 * Chrome - https://chrome.google.com/webstore/detail/fdmmgilgnpjigdojojpjoooidkmcomcm
 
 A feature rich Chrome extension with JSON and XML support


### PR DESCRIPTION
`/home/travis/build/toastdriven/django-tastypie/docs/tools.rst:24: WARNING: Title underline too short.`
