### PR TITLE
Prefer related_name on ToOneField to reverse fetch unique referencing object.

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -708,7 +708,9 @@ class ToOneField(RelatedField):
     def dehydrate(self, bundle, for_list=True):
         foreign_obj = None
 
-        if isinstance(self.attribute, six.string_types):
+        if self.related_name:
+            foreign_obj = getattr(bundle.obj, self.related_name).get()
+        elif isinstance(self.attribute, six.string_types):
             attrs = self.attribute.split('__')
             foreign_obj = bundle.obj
 


### PR DESCRIPTION
We treat memberships of resources as their own resource so it is sometimes beneficial for a ModelResource to reference a ToOneField (ForeignKey) that is uniquely joined by another resource. This is similar to the ToManyField functionality, except returns only a single object per the constraints on the ForeignKey uniqueness defined by the membership Model.

```
class NumberResource(ModelResource):                       
    detail = fields.ToOneField(
        'number.api.NumberDetailResource',                                      
        'detail',                                                              
        related_name='numberdetail_set',                                        
        null=True                                                               
        )                                                                       

    class Meta:                                                                 
        queryset = Number.objects.all() 


class NumberDetailResource(ModelResource):                                      
    number = fields.ToOneField(NumberResource, 'number')                        

    class Meta:                                                                 
        queryset = NumberDetail.objects.all()
```
