### PR TITLE
Handle skipped m2m fields in patch method

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -882,7 +882,9 @@ class ToManyField(RelatedField):
             return None
 
         if bundle.data.get(self.instance_name) is None:
-            if self.blank:
+            if bundle.request.META.get('REQUEST_METHOD') == 'PATCH':
+                return None
+            elif self.blank:
                 return []
             if self.null:
                 return []

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2449,6 +2449,9 @@ class BaseModelResource(Resource):
             if field_object.readonly:
                 continue
 
+            if bundle.data.get(field_name) is None:
+                continue
+
             # Get the manager.
             related_mngr = None
 


### PR DESCRIPTION
Patch method is for partially updating a resource. This patch allows to update a resource skipping m2m fields also.