### PR TITLE
Corrected import of LOOKUP_SEP for Django 1.5+

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned, 
 from django.core.urlresolvers import NoReverseMatch, reverse, resolve, Resolver404, get_script_prefix
 from django.core.signals import got_request_exception
 from django.db import transaction
-from django.db.models.constants import LOOKUP_SEP
+from django.db.models import LOOKUP_SEP
 from django.db.models.sql.constants import QUERY_TERMS
 from django.http import HttpResponse, HttpResponseNotFound, Http404
 from django.utils.cache import patch_cache_control, patch_vary_headers


### PR DESCRIPTION
django/django@c4aa26a983c91b1ec015fe0552077847116dfab7 moved LOOKUP_SEP up a level in 1.5; this file was never adjusted to compensate. Fixed #903.
