### PR TITLE
api_field_from_django_field: use DateField for django DateField

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1790,7 +1790,9 @@ class BaseModelResource(Resource):
         result = default
         internal_type = f.get_internal_type()
 
-        if internal_type in ('DateField', 'DateTimeField'):
+        if internal_type == 'DateField':
+            result = fields.DateField
+        elif internal_type == 'DateTimeField':
             result = fields.DateTimeField
         elif internal_type in ('BooleanField', 'NullBooleanField'):
             result = fields.BooleanField


### PR DESCRIPTION
This fixes a case, when modifying a resource with a DateField and with always_return_data=True, the returned field would have a time part in it.