### PR TITLE
Fixes test runner on travis-ci.org.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,23 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
 
 env:
   - DJANGO_VERSION=1.5
+  - DJANGO_VERSION=1.6
   - DJANGO_VERSION=dev
 
 matrix:
   allow_failures:
     - env: DJANGO_VERSION=dev
   exclude:
-    - env: DJANGO_VERSION=dev
-      python: "2.6"
+    - env: DJANGO_VERSION=1.5
+      python: "3.3"
+    - env: DJANGO_VERSION=1.5
+      python: "3.4"
 
 # command to install dependencies
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py33-dev,py27-dev,py33-1.5,py27-1.5,py26-1.5,docs
+envlist = py34-dev,py33-dev,py27-dev,py34-1.6,py33-1.6,py27-1.6,py27-1.5,docs
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests
 commands =
+    {envbindir}/django-admin.py --version
     {envbindir}/django-admin.py test core --settings=settings_core
     {envbindir}/django-admin.py test basic --settings=settings_basic
     #{envbindir}/django-admin.py test complex --settings=settings_complex
@@ -25,37 +26,59 @@ deps-py3 =
     -r{toxinidir}/tests/requirements.txt
     python3-digest>=1.8b4
 
+deps-djangodev =
+    https://github.com/django/django/zipball/master
+
+deps-django1.5 =
+    django>=1.5,<1.6
+
+deps-django1.6 =
+    django>=1.6,<1.7
+
 [testenv:py33-dev]
 basepython = python3.3
 deps =
     {[testenv]deps-py3}
-    https://github.com/django/django/zipball/master
+    {[testenv]deps-djangodev}
 
-[testenv:py33-1.5]
+[testenv:py33-1.6]
 basepython = python3.3
 deps =
     {[testenv]deps-py3}
-    django==1.5.1
+    {[testenv]deps-django1.6}
+
+[testenv:py34-dev]
+basepython = python3.4
+deps =
+    {[testenv]deps-py3}
+    {[testenv]deps-djangodev}
+
+[testenv:py34-1.6]
+basepython = python3.4
+deps =
+    {[testenv]deps-py3}
+    {[testenv]deps-django1.6}
 
 [testenv:py27-dev]
 basepython = python2.7
 deps =
     {[testenv]deps-py2}
-    https://github.com/django/django/zipball/master
+    {[testenv]deps-djangodev}
 
 [testenv:py27-1.5]
 basepython = python2.7
 deps =
     {[testenv]deps-py2}
-    django==1.5.1
+    {[testenv]deps-django1.5}
 
-[testenv:py26-1.5]
-basepython = python2.6
+[testenv:py27-1.6]
+basepython = python2.7
 deps =
     {[testenv]deps-py2}
-    django==1.5.1
+    {[testenv]deps-django1.6}
 
 [testenv:docs]
+basepython = python2.7
 changedir = docs
 deps =
     sphinx


### PR DESCRIPTION
Fix .travis.yml and tox.ini discrepancies.
Add django 1.6 to tox (and kept django-dev).
Remove unsupported python 2.6 from tox.
Remove incompatable combos, like python 3 + django 1.5.

See https://travis-ci.org/georgedorn/django-tastypie for the all-green CI board.
