### PR TITLE
Django 1.7 compatibility for applications making use of django.contrib.a...

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -84,6 +84,7 @@ Contributors:
 * Revolution Systems & The Python Software Foundation for funding a significant portion of the port to Python 3!
 * tunix for a patch related to Tastypie's timezone-aware dates.
 * Steven Davidson (damycra) for a documentation patch.
+* Andrew Grossman (AndrewGrossman) for a patch for Django 1.7 compatibility when using django.contrib.auth.
 
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.

--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -29,9 +29,16 @@ class ApiAccess(models.Model):
 
 if 'django.contrib.auth' in settings.INSTALLED_APPS:
     import uuid
-    from tastypie.compat import AUTH_USER_MODEL
+    try:
+        from django.core.exceptions import AppRegistryNotReady
+        from tastypie.compat import AUTH_USER_MODEL as user_model_reference  
+    except ImportError:  # No app registry ready functionality (probably Django < 1.7), import the actual model as it had been done previously
+        from tastypie.compat import AUTH_USER_MODEL as user_model_reference
+    except AppRegistryNotReady:  # Django 1.7+, the app is not ready yet, so instead use the string listed in settings as a model reference
+        user_model_reference = settings.AUTH_USER_MODEL
+
     class ApiKey(models.Model):
-        user = models.OneToOneField(AUTH_USER_MODEL, related_name='api_key')
+        user = models.OneToOneField(user_model_reference, related_name='api_key')
         key = models.CharField(max_length=128, blank=True, default='', db_index=True)
         created = models.DateTimeField(default=now)
 


### PR DESCRIPTION
...uth. Potential premature import of the auth user model was resulting in an AppRegistryNotReady("Models aren't loaded yet") error. Fix for #1219, #1115.
