### PR TITLE
stab at fixing the AppRegistryIsNotReady error.

### DIFF
--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import AppRegistryNotReady
 import django
 
 __all__ = ['User', 'AUTH_USER_MODEL']
@@ -13,7 +13,7 @@ if django.VERSION >= (1, 5):
         from django.contrib.auth import get_user_model
         User = get_user_model()
         username_field = User.USERNAME_FIELD
-    except ImproperlyConfigured:
+    except AppRegistryNotReady:
         # The the users model might not be read yet.
         # This can happen is when setting up the create_api_key signal, in your
         # custom user module.


### PR DESCRIPTION
Hey, I'm a little new to Django and only have 1.7 installed, so I'm sure there are issues using this with Django < 1.7. This fixes tastypie-django with 1.7 for me however.
