### PR TITLE
Security fix to prevent jsonp by default

### DIFF
--- a/tastypie/utils/mime.py
+++ b/tastypie/utils/mime.py
@@ -27,7 +27,7 @@ def determine_format(request, serializer, default_format='application/json'):
             return serializer.get_mime_for_format(request.GET['format'])
 
     # If callback parameter is present, use JSONP.
-    if 'callback' in request.GET:
+    if 'callback' in request.GET and 'jsonp' in serializer.formats:
         return serializer.get_mime_for_format('jsonp')
 
     # Try to fallback on the Accepts header.


### PR DESCRIPTION
The callback parameter in the request query string should not activate the jsonp format without checking the serializer.formats.