### PR TITLE
Fix #1239.

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -802,10 +802,15 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         if prefix and chomped_uri.startswith(prefix):
             chomped_uri = chomped_uri[len(prefix)-1:]
 
+        # We know that we are dealing with a "detail" URI
+        # Look for the beginning of object key (last meaningful part of the URI)
+        end_of_resource_name = chomped_uri.rstrip("/").rfind("/")
+        if end_of_resource_name == -1:
+            raise NotFound("An incorrect URL was provided '%s' for the '%s' resource." % (uri, self.__class__.__name__))
         # We mangle the path a bit further & run URL resolution against *only*
-        # the current class. This ought to prevent bad URLs from resolving to
-        # incorrect data.
-        found_at = chomped_uri.rfind(self._meta.resource_name)
+        # the current class (but up to detail key). This ought to prevent bad 
+        # URLs from resolving to incorrect data.
+        found_at = chomped_uri.rfind(self._meta.resource_name, 0, end_of_resource_name)
         if found_at == -1:
             raise NotFound("An incorrect URL was provided '%s' for the '%s' resource." % (uri, self.__class__.__name__))
         chomped_uri = chomped_uri[found_at:]
@@ -2083,7 +2088,7 @@ class BaseModelResource(Resource):
             if len(object_list) <= 0:
                 raise self._meta.object_class.DoesNotExist("Couldn't find an instance of '%s' which matched '%s'." % (self._meta.object_class.__name__, stringified_kwargs))
             elif len(object_list) > 1:
-                raise MultipleObjectsReturned("More than '%s' matched '%s'." % (self._meta.object_class.__name__, stringified_kwargs))
+                raise MultipleObjectsReturned("More than one '%s' matched '%s'." % (self._meta.object_class.__name__, stringified_kwargs))
 
             bundle.obj = object_list[0]
             self.authorized_read_detail(object_list, bundle)


### PR DESCRIPTION
rfind up to the beginning of the resource key, to allow prefix/resource_name/resource_name/ in case resource_name is a valid identifier for an object