### PR TITLE
Resource.save_m2m travels double-underscore relations

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2343,7 +2343,10 @@ class BaseModelResource(Resource):
             related_mngr = None
 
             if isinstance(field_object.attribute, six.string_types):
-                related_mngr = getattr(bundle.obj, field_object.attribute)
+                # recurse with getattr through all double-underscore relations (if any)
+                related_mngr = bundle.obj
+                for related_mngr_attr in field_object.attribute.split('__'):
+                    related_mngr = getattr(related_mngr, related_mngr_attr)
             elif callable(field_object.attribute):
                 related_mngr = field_object.attribute(bundle)
 


### PR DESCRIPTION
**Version:** 12.0
## Problem

```
# resources.py
class QuestionResponseResource(ResourceMixin):
    choices = fields.ToManyField('api.v1.resources.QuestionChoiceResource', 'question__choices', null=True, full=True)
    # ... snip ...
```

**Problem**: `PUT`ing to a resource with a double-underscore m2m relation raises this exception:

```
[26/Oct/2014 23:10:18] "PUT /api/v1/question_response/75/ HTTP/1.1" 200 1162
Traceback (most recent call last):
  File "/home/patrick/code/gridpar/api/v1/resources/questions.py", line 34, in save_m2m
    bundle = super(QuestionResponseResource, self).save_m2m(bundle)
  File "/home/patrick/.virtualenvs/gridpatrick/lib/python2.7/site-packages/tastypie/resources.py", line 2346, in save_m2m
    related_mngr = getattr(bundle.obj, field_object.attribute)
AttributeError: 'QuestionResponse' object has no attribute 'question__choices'
```
## Solution

This patch properly recurses through double-underscore properties to `getattr` the correct m2m related object manager (instead of trying to `getattr(bundle.obj, 'questions__choices')` which does not work).
