### PR TITLE
prefetch_related causes api to return outdated data

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1430,6 +1430,9 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             if not self._meta.always_return_data:
                 return http.HttpNoContent()
             else:
+                # Invalidate prefetched_objects_cache for bundled object
+                # because we might have changed a prefetched field
+                updated_bundle.obj._prefetched_objects_cache = {}
                 updated_bundle = self.full_dehydrate(updated_bundle)
                 updated_bundle = self.alter_detail_data_to_serialize(request, updated_bundle)
                 return self.create_response(request, updated_bundle)

--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -167,6 +167,7 @@ class DogResource(ModelResource):
         resource_name = 'dog'
         authorization = Authorization()
 
+
 class LabelResource(ModelResource):
     class Meta:
         resource_name = 'label'
@@ -182,6 +183,7 @@ class PostResource(ModelResource):
         resource_name = 'post'
         authorization = Authorization()
 
+
 class PaymentResource(ModelResource):
     job = fields.ToOneField('related_resource.api.resources.JobResource', 'job')
 
@@ -189,7 +191,8 @@ class PaymentResource(ModelResource):
         queryset = Payment.objects.all()
         resource_name = 'payment'
         authorization = Authorization()
-        allowed_methods = ('get','put','post')
+        allowed_methods = ('get', 'put', 'post')
+
 
 class JobResource(ModelResource):
     payment = fields.ToOneField(PaymentResource, 'payment', related_name='job')
@@ -198,11 +201,12 @@ class JobResource(ModelResource):
         queryset = Job.objects.all()
         resource_name = 'job'
         authorization = Authorization()
-        allowed_methods = ('get','put','post')
+        allowed_methods = ('get', 'put', 'post')
+
 
 class ForumResource(ModelResource):
     moderators = fields.ManyToManyField(UserResource, 'moderators', full=True)
-    members    = fields.ManyToManyField(UserResource, 'members', full=True)
+    members = fields.ManyToManyField(UserResource, 'members', full=True)
 
     class Meta:
         resource_name = 'forum'

--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -210,7 +210,7 @@ class ForumResource(ModelResource):
 
     class Meta:
         resource_name = 'forum'
-        queryset = Forum.objects.all()
+        queryset = Forum.objects.prefetch_related('moderators', 'members')
         authorization = Authorization()
         always_return_data = True
 

--- a/tests/related_resource/models.py
+++ b/tests/related_resource/models.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import User
 from django.db import models
 
+
 # A self-referrential model to test regressions.
 class Category(models.Model):
     parent = models.ForeignKey('self', null=True)
@@ -20,14 +21,14 @@ class TaggableTag(models.Model):
     tag = models.ForeignKey(
             'Tag',
             related_name='taggabletags',
-            null=True, blank=True, # needed at creation time
+            null=True, blank=True,  # needed at creation time
         )
     taggable = models.ForeignKey(
             'Taggable',
             related_name='taggabletags',
-            null=True, blank=True, # needed at creation time
+            null=True, blank=True,  # needed at creation time
     )
-    extra = models.IntegerField(default=0) #extra data about the relationship
+    extra = models.IntegerField(default=0)  # extra data about the relationship
 
 
 # Tags to Taggable model through explicit M2M table
@@ -78,6 +79,7 @@ class Product(models.Model):
     def __unicode__(self):
         return u"%s" % (self.name)
 
+
 class Person(models.Model):
     name = models.CharField(max_length=32)
     company = models.ForeignKey(Company, related_name="employees", null=True)
@@ -85,11 +87,13 @@ class Person(models.Model):
     def __unicode__(self):
         return u"%s" % (self.name)
 
+
 class DogHouse(models.Model):
     color = models.CharField(max_length=32)
 
     def __unicode__(self):
         return u"%s" % (self.color)
+
 
 class Dog(models.Model):
     name = models.CharField(max_length=32)
@@ -99,6 +103,7 @@ class Dog(models.Model):
     def __unicode__(self):
         return u"%s" % (self.name)
 
+
 class Bone(models.Model):
     dog = models.ForeignKey(Dog, related_name='bones', null=True)
     color = models.CharField(max_length=32)
@@ -106,19 +111,24 @@ class Bone(models.Model):
     def __unicode__(self):
         return u"%s" % (self.color)
 
+
 class Forum(models.Model):
     moderators = models.ManyToManyField(User, related_name='forums_moderated')
     members = models.ManyToManyField(User, related_name='forums_member')
 
+
 class Label(models.Model):
     name = models.CharField(max_length=32)
+
 
 class Job(models.Model):
     name = models.CharField(max_length=200)
 
+
 class Payment(models.Model):
     scheduled = models.DateTimeField()
     job = models.OneToOneField(Job, related_name="payment", null=True)
+
 
 class Post(models.Model):
     name = models.CharField(max_length=200)

--- a/tests/related_resource/tests.py
+++ b/tests/related_resource/tests.py
@@ -1,8 +1,7 @@
-from datetime import datetime, tzinfo, timedelta
+from datetime import datetime
 import json
 
 import django
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db.models.signals import pre_save
@@ -143,7 +142,6 @@ class ExplicitM2MResourceRegressionTest(TestCaseWithFixture):
         # Give each tag some extra data (the lookup of this data is what makes the test fail)
         self.extradata_1 = ExtraData.objects.create(tag=self.tag_1, name='additional')
 
-
     def test_correct_setup(self):
         request = MockRequest()
         request.GET = {'format': 'json'}
@@ -172,7 +170,6 @@ class ExplicitM2MResourceRegressionTest(TestCaseWithFixture):
 
         # and check whether the extradata is present
         self.assertEqual(data['extradata']['name'], u'additional')
-
 
     def test_post_new_tag(self):
         resource = api.canonical_resource_for('tag')
@@ -235,11 +232,12 @@ class OneToManySetupTestCase(TestCaseWithFixture):
 class FullCategoryResource(CategoryResource):
     parent = fields.ToOneField('self', 'parent', null=True, full=True)
 
+
 class RelationshipOppositeFromModelTestCase(TestCaseWithFixture):
-    '''
+    """
         On the model, the Job relationship is defined on the Payment.
         On the resource, the PaymentResource is defined on the JobResource as well
-    '''
+    """
     def setUp(self):
         super(RelationshipOppositeFromModelTestCase, self).setUp()
 
@@ -278,13 +276,12 @@ class RelationshipOppositeFromModelTestCase(TestCaseWithFixture):
         self.assertEqual(new_job, new_payment.job)
 
 
-
 class RelatedPatchTestCase(TestCaseWithFixture):
     urls = 'related_resource.api.urls'
 
     def setUp(self):
         super(RelatedPatchTestCase, self).setUp()
-        #this test doesn't use MockRequest, so the body attribute is different.
+        # this test doesn't use MockRequest, so the body attribute is different.
         if django.VERSION >= (1, 4):
             self.body_attr = "_body"
         else:
@@ -540,7 +537,7 @@ class NestedRelatedResourceTest(TestCaseWithFixture):
         resp = pr.put_detail(request, pk=pk)
         self.assertEqual(resp.status_code, 204)
 
-        #Change just a nested resource via PUT
+        # Change just a nested resource via PUT
         request = MockRequest()
         request.GET = {'format': 'json'}
         request.method = 'PUT'
@@ -575,7 +572,6 @@ class RelatedSaveCallsTest(TestCaseWithFixture):
 
         with self.assertNumQueries(1):
             resp = resource.post_list(request)
-
 
     def test_two_queries_for_post_list(self):
         """
@@ -619,8 +615,7 @@ class RelatedSaveCallsTest(TestCaseWithFixture):
 
         request.set_body(body)
 
-        resource.post_list(request) #_save_fails_test will explode if Label is saved
-
+        resource.post_list(request)  #_save_fails_test will explode if Label is saved
 
     def test_save_m2m_changed(self):
         """
@@ -641,7 +636,7 @@ class RelatedSaveCallsTest(TestCaseWithFixture):
         resp = resource.wrap_view('dispatch_list')(request)
         self.assertEqual(resp.status_code, 201)
 
-        #'extra' should have been set
+        # 'extra' should have been set
         tag = Tag.objects.all()[0]
         taggable_tag = tag.taggabletags.all()[0]
         self.assertEqual(taggable_tag.extra, 7)
@@ -656,7 +651,7 @@ class RelatedSaveCallsTest(TestCaseWithFixture):
 
         resource.put_detail(request)
 
-        #'extra' should have changed
+        # 'extra' should have changed
         tag = Tag.objects.all()[0]
         taggable_tag = tag.taggabletags.all()[0]
         self.assertEqual(taggable_tag.extra, 1234)
@@ -717,7 +712,7 @@ class CorrectUriRelationsTestCase(TestCaseWithFixture):
 
         # For this test, we need a ``User`` with the same PK as a ``Note``.
         note_1 = Note.objects.latest('created')
-        user_2 = User.objects.create(
+        User.objects.create(
             id=note_1.pk,
             username='valid',
             email='valid@exmaple.com',

--- a/tests/related_resource/tests.py
+++ b/tests/related_resource/tests.py
@@ -15,7 +15,7 @@ from core.tests.resources import HttpRequest
 
 from related_resource.api.resources import CategoryResource, ForumResource, FreshNoteResource, JobResource, NoteResource, PersonResource, UserResource
 from related_resource.api.urls import api
-from related_resource.models import Category, Label, Tag, Taggable, TaggableTag, ExtraData, Company, Person, Dog, DogHouse, Bone, Product, Address, Job, Payment
+from related_resource.models import Category, Label, Tag, Taggable, TaggableTag, ExtraData, Company, Person, Dog, DogHouse, Bone, Product, Address, Job, Payment, Forum
 from testcases import TestCaseWithFixture
 
 
@@ -741,3 +741,42 @@ class CorrectUriRelationsTestCase(TestCaseWithFixture):
 
         self.assertEqual(str(cm.exception), "An incorrect URL was provided '/v1/notes/2/' for the 'UserResource' resource.")
         self.assertEqual(Note.objects.count(), 2)
+
+
+class TestPutOnRelatedResource(TestCaseWithFixture):
+    def test_m2m_put_prefetch(self):
+        resource = api.canonical_resource_for('forum')
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'PUT'
+        forum = Forum.objects.create()
+        user_data_1 = {
+            'username': 'valid but unique',
+            'email': 'valid.unique@exmaple.com',
+            'password': 'junk',
+            }
+        user_data_2 = {
+            'username': 'valid and very unique',
+            'email': 'valid.very.unique@exmaple.com',
+            'password': 'junk',
+            }
+        user_data_3 = {
+            'username': 'valid again',
+            'email': 'valid.very.unique@exmaple.com',
+            'password': 'junk',
+            }
+
+        forum_data = {'members': [user_data_1, user_data_2, ],
+                      'moderators': [user_data_3, ]}
+        request.set_body(json.dumps(forum_data))
+
+        request.path = reverse('api_dispatch_detail', kwargs={'pk': forum.pk,
+                                                              'resource_name': resource._meta.resource_name,
+                                                              'api_name': resource._meta.api_name})
+
+        response = resource.put_detail(request)
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(len(data['members']), 2)
+        self.assertEqual(len(data['moderators']), 1)

--- a/tests/related_resource/tests.py
+++ b/tests/related_resource/tests.py
@@ -5,6 +5,7 @@ import django
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db.models.signals import pre_save
+from django.test.testcases import TestCase
 
 from tastypie import fields
 from tastypie.exceptions import NotFound
@@ -743,7 +744,7 @@ class CorrectUriRelationsTestCase(TestCaseWithFixture):
         self.assertEqual(Note.objects.count(), 2)
 
 
-class TestPutOnRelatedResource(TestCaseWithFixture):
+class TestPutOnRelatedResource(TestCase):
     def test_m2m_put_prefetch(self):
         resource = api.canonical_resource_for('forum')
         request = MockRequest()
@@ -775,8 +776,11 @@ class TestPutOnRelatedResource(TestCaseWithFixture):
                                                               'api_name': resource._meta.api_name})
 
         response = resource.put_detail(request)
-
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content.decode('utf-8'))
+
+        # Check that the query does what it's supposed to and only the return value is wrong
+        self.assertEqual(User.objects.count(), 3)
+
         self.assertEqual(len(data['members']), 2)
         self.assertEqual(len(data['moderators']), 1)

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -7,6 +7,7 @@ from django.core.servers import basehttp
 from django.db import connections
 from django.test.testcases import TransactionTestCase, TestCase
 
+
 class StoppableWSGIServer(basehttp.WSGIServer):
     """WSGIServer with short timeout, so that server thread can stop this server."""
 
@@ -23,6 +24,7 @@ class StoppableWSGIServer(basehttp.WSGIServer):
             return (sock, address)
         except socket.timeout:
             raise
+
 
 class TestServerThread(threading.Thread):
     """Thread for running a http server while tests are running."""


### PR DESCRIPTION
When issuing a PUT request on a prefetched field, the old data is returned.

A failing test is included. I'll try to fix this myself, but any tips are appreciated :smile: 

**Resource:**
```
    class Meta:
       always_return_data = True
       queryset = Forum.objects.prefetch_related('moderators', 'members')
```

**Pseudo-Code:**
```
    Forum.objects.create()
    request.put('/api/forum/1/', {'moderators': [{'username': 'JannKleen', }, ], })
```

This should return the new moderator, but instead returns an empty list (the old value of the m2m field).