### PR TITLE
Force attribute name to be string in Exception

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -127,7 +127,7 @@ class ApiField(object):
                         # accesses will fail miserably.
                         break
                     else:
-                        raise ApiFieldError("The object '%r' has an empty attribute '%s' and doesn't allow a default or null value." % (previous_object, attr))
+                        raise ApiFieldError(b"The object '%r' has an empty attribute '%s' and doesn't allow a default or null value." % (previous_object, str(attr)))
 
             if callable(current_object):
                 current_object = current_object()


### PR DESCRIPTION
When an exception is to be thrown, and previous_objects's representation containts unicode characters, as Django encodes them to utf-8, the string formatting dies with an unicode error. This fixes that.
