### PR TITLE
Improved admin UI for API Keys

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -84,6 +84,7 @@ Contributors:
 * Revolution Systems & The Python Software Foundation for funding a significant portion of the port to Python 3!
 * tunix for a patch related to Tastypie's timezone-aware dates.
 * Steven Davidson (damycra) for a documentation patch.
+* Nick Sullivan (gorillamania) for admin improvements.
 
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.

--- a/tastypie/admin.py
+++ b/tastypie/admin.py
@@ -6,9 +6,10 @@ from django.contrib import admin
 if 'django.contrib.auth' in settings.INSTALLED_APPS:
     from tastypie.models import ApiKey
 
-    class ApiKeyInline(admin.StackedInline):
-        model = ApiKey
-        extra = 0
+    class ApiKeyAdmin(admin.ModelAdmin):
+        search_fields = ['key', 'user__username']
+        raw_id_fields = ['user']
+        list_display = ['id', 'user', 'key', 'created']
 
     ABSTRACT_APIKEY = getattr(settings, 'TASTYPIE_ABSTRACT_APIKEY', False)
 
@@ -17,4 +18,4 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
                         "or 'False'.")
 
     if not ABSTRACT_APIKEY:
-        admin.site.register(ApiKey)
+        admin.site.register(ApiKey, ApiKeyAdmin)


### PR DESCRIPTION
Improved admin UI for API Keys

* Make api keys searchable, by key or username
* Displays more information on the initial screen, with sortable columns
* Use raw_id_fields for user, because detail page can get very slow when there are a lot of api keys

![api_key_admin](https://cloud.githubusercontent.com/assets/142708/5519873/adf2d9e6-891b-11e4-9b82-d7e8a436f6ec.png)
![raw id field](https://cloud.githubusercontent.com/assets/142708/5519874/adf6c0ec-891b-11e4-9deb-c6562be08793.png)