### PR TITLE
Django 1.8 compatibility

### DIFF
--- a/tastypie/authorization.py
+++ b/tastypie/authorization.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from tastypie.exceptions import TastypieError, Unauthorized
-
+from tastypie.compat import get_module_name
 
 class Authorization(object):
     """
@@ -172,7 +172,7 @@ class DjangoAuthorization(Authorization):
         if klass is False:
             return []
 
-        permission = '%s.add_%s' % (klass._meta.app_label, klass._meta.module_name)
+        permission = '%s.add_%s' % (klass._meta.app_label, get_module_name(klass._meta))
 
         if not bundle.request.user.has_perm(permission):
             return []
@@ -185,7 +185,7 @@ class DjangoAuthorization(Authorization):
         if klass is False:
             raise Unauthorized("You are not allowed to access that resource.")
 
-        permission = '%s.add_%s' % (klass._meta.app_label, klass._meta.module_name)
+        permission = '%s.add_%s' % (klass._meta.app_label, get_module_name(klass._meta))
 
         if not bundle.request.user.has_perm(permission):
             raise Unauthorized("You are not allowed to access that resource.")
@@ -198,7 +198,7 @@ class DjangoAuthorization(Authorization):
         if klass is False:
             return []
 
-        permission = '%s.change_%s' % (klass._meta.app_label, klass._meta.module_name)
+        permission = '%s.change_%s' % (klass._meta.app_label, get_module_name(klass._meta))
 
         if not bundle.request.user.has_perm(permission):
             return []
@@ -211,7 +211,7 @@ class DjangoAuthorization(Authorization):
         if klass is False:
             raise Unauthorized("You are not allowed to access that resource.")
 
-        permission = '%s.change_%s' % (klass._meta.app_label, klass._meta.module_name)
+        permission = '%s.change_%s' % (klass._meta.app_label, get_module_name(klass._meta))
 
         if not bundle.request.user.has_perm(permission):
             raise Unauthorized("You are not allowed to access that resource.")
@@ -224,7 +224,7 @@ class DjangoAuthorization(Authorization):
         if klass is False:
             return []
 
-        permission = '%s.delete_%s' % (klass._meta.app_label, klass._meta.module_name)
+        permission = '%s.delete_%s' % (klass._meta.app_label, get_module_name(klass._meta))
 
         if not bundle.request.user.has_perm(permission):
             return []
@@ -237,7 +237,7 @@ class DjangoAuthorization(Authorization):
         if klass is False:
             raise Unauthorized("You are not allowed to access that resource.")
 
-        permission = '%s.delete_%s' % (klass._meta.app_label, klass._meta.module_name)
+        permission = '%s.delete_%s' % (klass._meta.app_label, get_module_name(klass._meta))
 
         if not bundle.request.user.has_perm(permission):
             raise Unauthorized("You are not allowed to access that resource.")

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -23,3 +23,9 @@ else:
 
     def get_username_field():
         return 'username'
+
+def get_module_name(meta):
+    return getattr(meta, 'model_name', None) or getattr(meta, 'module_name')
+
+# commit_on_success replaced by atomic in Django >=1.8
+atomic_decorator = getattr(django.db.transaction, 'atomic', None) or getattr(django.db.transaction, 'commit_on_success')

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -31,6 +31,7 @@ from tastypie.throttle import BaseThrottle
 from tastypie.utils import is_valid_jsonp_callback_value, dict_strip_unicode_keys, trailing_slash
 from tastypie.utils.mime import determine_format, build_content_type
 from tastypie.validation import Validation
+from tastypie.compat import get_module_name, atomic_decorator
 
 # If ``csrf_exempt`` isn't present, stub it.
 try:
@@ -2207,7 +2208,7 @@ class BaseModelResource(Resource):
         self.authorized_delete_detail(self.get_object_list(bundle.request), bundle)
         bundle.obj.delete()
 
-    @transaction.commit_on_success()
+    @atomic_decorator()
     def patch_list(self, request, **kwargs):
         """
         An ORM-specific implementation of ``patch_list``.
@@ -2229,7 +2230,7 @@ class BaseModelResource(Resource):
                 bundle.obj.delete()
 
     def create_identifier(self, obj):
-        return u"%s.%s.%s" % (obj._meta.app_label, obj._meta.module_name, obj.pk)
+        return u"%s.%s.%s" % (obj._meta.app_label, get_module_name(obj._meta), obj.pk)
 
     def save(self, bundle, skip_errors=False):
         self.is_valid(bundle)


### PR DESCRIPTION
`transaction.commit_on_success` and `Options.module_name` are deprecated in Django 1.7 and will be removed in 1.8