### PR TITLE
Add test for issue #1267, DateField is formatted as DateTimeField when using always_return_data = True

### DIFF
--- a/tests/basic/api/resources.py
+++ b/tests/basic/api/resources.py
@@ -4,7 +4,7 @@ from tastypie import fields
 from tastypie.resources import ModelResource
 from tastypie.authentication import SessionAuthentication
 from tastypie.authorization import Authorization
-from basic.models import Note, AnnotatedNote, SlugBasedNote
+from basic.models import Note, AnnotatedNote, SlugBasedNote, SignedNote
 
 
 class UserResource(ModelResource):
@@ -62,6 +62,14 @@ class SlugBasedNoteResource(ModelResource):
         resource_name = 'slugbased'
         detail_uri_name = 'slug'
         authorization = Authorization()
+
+
+class SignedNoteResource(ModelResource):
+    class Meta:
+        resource_name = 'signed_notes'
+        queryset = SignedNote.objects.all()
+        authorization = Authorization()
+        always_return_data = True
 
 
 class SessionUserResource(ModelResource):

--- a/tests/basic/api/urls.py
+++ b/tests/basic/api/urls.py
@@ -3,7 +3,7 @@ try:
 except ImportError: # Django < 1.4
     from django.conf.urls.defaults import *
 from tastypie.api import Api
-from basic.api.resources import NoteResource, UserResource, BustedResource, CachedUserResource, PublicCachedUserResource, PrivateCachedUserResource, SlugBasedNoteResource, SessionUserResource
+from basic.api.resources import NoteResource, UserResource, BustedResource, CachedUserResource, PublicCachedUserResource, PrivateCachedUserResource, SlugBasedNoteResource, SessionUserResource, SignedNoteResource
 
 api = Api(api_name='v1')
 api.register(NoteResource(), canonical=True)
@@ -17,4 +17,7 @@ v2_api.register(BustedResource(), canonical=True)
 v2_api.register(SlugBasedNoteResource())
 v2_api.register(SessionUserResource())
 
-urlpatterns = v2_api.urls + api.urls
+v3_api = Api(api_name='v3')
+v3_api.register(SignedNoteResource(), canonical=True)
+
+urlpatterns = v3_api.urls + v2_api.urls + api.urls

--- a/tests/basic/models.py
+++ b/tests/basic/models.py
@@ -46,6 +46,14 @@ class SlugBasedNote(models.Model):
         return u"SlugBased %s" % self.title
 
 
+class SignedNote(models.Model):
+    title = models.CharField(max_length=255)
+    content = models.TextField()
+    signed_by = models.CharField(max_length=255)
+    created = models.DateField(default=now)
+    updated = models.DateField(default=now)
+
+
 class UserForm(forms.ModelForm):
     class Meta:
         model = User

--- a/tests/basic/tests/http.py
+++ b/tests/basic/tests/http.py
@@ -149,3 +149,28 @@ class HTTPTestCase(TestServerTestCase):
 
         self.assertEqual(cache_control, set(["s-maxage=3600", "max-age=3600", "private"]))
         self.assertTrue('"johndoe"' in response.read().decode('utf-8'))
+
+    def test_always_return_true_datefield(self):
+        # Create a signed note via POST
+        post_data = dict(
+            title = 'A Fancy Note',
+            content = 'Why are so many animals eating eachother?',
+            signed_by = 'tastyPie',
+            created = '2014-04-01',
+        )
+        connection = self.get_connection()
+        connection.request('POST', '/api/v3/signed_notes/', body=json.dumps(post_data), headers={'Accept': 'application/json', 'Content-type': 'application/json'})
+        response = connection.getresponse()
+        note = json.loads(response.read().decode('utf-8'))
+        self.assertEqual(note['created'], '2014-04-01')
+
+        # Update the note via PUT
+        note['signed_by'] = 'Tastypie'
+        note['updated'] = '2015-01-29'
+        connection.request('PUT', '/api/v3/signed_notes/%d/' % note['id'], body=json.dumps(note), headers={'Accept': 'application/json', 'Content-type': 'application/json'})
+        response = connection.getresponse()
+        updated_note = json.loads(response.read().decode('utf-8'))
+
+        # The created field should match on the two notes, we didn't change it
+        self.assertEqual(note['created'], updated_note['created'])
+        self.assertEqual(updated_note['created'], '2014-04-01')


### PR DESCRIPTION
I opened issue #1267 because DateFields are formatted as DateTimeFields in the response when `always_return_data` is enabled on a resource. At first I thought it was only for PUT requests, but as the test shows, it actually is for POST requests as well. The test fails the assertion in the middle as well as the one at the end.

I added the test to the basic set in http.py. I apologize if this was not the appropriate location, the docs weren't explicit with where to put new tests.