### PR TITLE
More speed for dictionary builder

### DIFF
--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -237,9 +237,9 @@ class Serializer(object):
         if isinstance(data, (list, tuple)):
             return [self.to_simple(item, options) for item in data]
         if isinstance(data, dict):
-            return dict((key, self.to_simple(val, options)) for (key, val) in data.items())
+            return {key: self.to_simple(val, options) for (key, val) in data.items()}
         elif isinstance(data, Bundle):
-            return dict((key, self.to_simple(val, options)) for (key, val) in data.data.items())
+            return {key: self.to_simple(val, options)) for (key, val) in data.data.items()}
         elif hasattr(data, 'dehydrated_type'):
             if getattr(data, 'dehydrated_type', None) == 'related' and data.is_m2m == False:
                 if data.full:
@@ -343,9 +343,9 @@ class Serializer(object):
             for element in elements:
                 if element.tag in ('object', 'objects'):
                     return self.from_etree(element)
-            return dict((element.tag, self.from_etree(element)) for element in elements)
+            return {element.tag: self.from_etree(element) for element in elements}
         elif data.tag == 'object' or data.get('type') == 'hash':
-            return dict((element.tag, self.from_etree(element)) for element in data.getchildren())
+            return {element.tag: self.from_etree(element) for element in data.getchildren()}
         elif data.tag == 'objects' or data.get('type') == 'list':
             return [self.from_etree(element) for element in data.getchildren()]
         else:


### PR DESCRIPTION
Construction:
```python
{k: v for k, v in [('a', 1), ('b', 1), ('c', 1)]}
```
is faster than:
```python
dict((k, v) for k, v in [('a', 1), ('b', 1), ('c', 1)])
```

Simple timeit:
```python
In [1]: %timeit {k: v for k, v in [('a', 1), ('b', 1), ('c', 1)]}
1000000 loops, best of 3: 701 ns per loop

In [2]: %timeit dict((k, v) for k, v in [('a', 1), ('b', 1), ('c', 1)])
100000 loops, best of 3: 1.82
```