### PR TITLE
Test against latest django-oauth-plus from PyPI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,7 @@ commands =
 deps-py2 =
     -r{toxinidir}/tests/requirements.txt
     python-digest
-    -ehg+https://bitbucket.org/coagulant/django-oauth-plus/@django-1.7-proper#egg=django-oauth-plus
-    # django-oauth-plus does not support Django 1.7 yet
+    django-oauth-plus==2.2.5
     oauth2
 
 deps-py3 =


### PR DESCRIPTION
This removes remaining fork from my PR #1214 in favor of proper PyPI version containing needed fix.