### PR TITLE
Patch not returning updated data for prefetched fields

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1628,6 +1628,9 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         if not self._meta.always_return_data:
             return http.HttpAccepted()
         else:
+            # Invalidate prefetched_objects_cache for bundled object
+            # because we might have changed a prefetched field
+            bundle.obj._prefetched_objects_cache = {}
             bundle = self.full_dehydrate(bundle)
             bundle = self.alter_detail_data_to_serialize(request, bundle)
             return self.create_response(request, bundle, response_class=http.HttpAccepted)


### PR DESCRIPTION
When patching a resource, patch_detail does not return updated data if field has been prefetched. PUT works fine as put_detail correctly invalidates prefetch cache.

Very similar, if not identical, to this previous bug: https://github.com/django-tastypie/django-tastypie/commit/b78661d76d1e73e2d90a8a1bcfcae90fcafb50b1

