### PR TITLE
Updated Cookbook doc to replace apply_authorization_limits with get_obje...

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -266,7 +266,7 @@ and every user will be working only with objects associated with them. Let's see
 how to implement it for two basic operations: listing and creation of an object.
 
 For listing we want to list only objects for which 'user' field matches
-'request.user'. This could be done by applying a filter in the ``apply_authorization_limits``
+'request.user'. This could be done by applying a filter in the ``get_object_list``
 method of your resource.
 
 For creating we'd have to wrap ``obj_create`` method of ``ModelResource``. Then the
@@ -284,8 +284,8 @@ resulting code will look something like::
         def obj_create(self, bundle, **kwargs):
             return super(EnvironmentResource, self).obj_create(bundle, user=bundle.request.user)
 
-        def apply_authorization_limits(self, request, object_list):
-            return object_list.filter(user=request.user)
+        def get_object_list(self, request):
+            return super(EnvironmentResource, self).get_object_list(request).filter(user=request.user)
 
 camelCase JSON Serialization
 ----------------------------

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1189,16 +1189,6 @@ A hook to allow making returning the list of available objects.
 ``ModelResource`` includes a full working version specific to Django's
 ``Models``.
 
-``apply_authorization_limits``
-------------------------------
-
-.. method:: Resource.apply_authorization_limits(self, request, object_list)
-
-Allows the ``Authorization`` class to further limit the object list.
-Also a hook to customize per ``Resource``.
-
-Calls ``Authorization.apply_limits`` if available.
-
 ``can_create``
 --------------
 


### PR DESCRIPTION
...ct_list, updated Resource doc to remove reference to deprecated apply_authorization_limits

Fixes #837 by removing the deprecated apply_authorization_limits method description from Resources documentation and updating cookbook example to replace apply_authorization_limits with get_object_list.