### PR TITLE
fix incorrect error message when datefield

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1793,8 +1793,10 @@ class BaseModelResource(Resource):
         result = default
         internal_type = f.get_internal_type()
 
-        if internal_type in ('DateField', 'DateTimeField'):
+        if internal_type in ('DateTimeField',):
             result = fields.DateTimeField
+        elif internal_type in ('DateField',):
+            result = fields.DateField
         elif internal_type in ('BooleanField', 'NullBooleanField'):
             result = fields.BooleanField
         elif internal_type in ('FloatField',):

--- a/tests/basic/api/urls.py
+++ b/tests/basic/api/urls.py
@@ -4,6 +4,7 @@ except ImportError: # Django < 1.4
     from django.conf.urls.defaults import *
 from tastypie.api import Api
 from basic.api.resources import NoteResource, UserResource, BustedResource, CachedUserResource, PublicCachedUserResource, PrivateCachedUserResource, SlugBasedNoteResource, SessionUserResource
+from customuser.api.resources import CustomUserResource
 
 api = Api(api_name='v1')
 api.register(NoteResource(), canonical=True)
@@ -16,5 +17,6 @@ v2_api = Api(api_name='v2')
 v2_api.register(BustedResource(), canonical=True)
 v2_api.register(SlugBasedNoteResource())
 v2_api.register(SessionUserResource())
+v2_api.register(CustomUserResource())
 
 urlpatterns = v2_api.urls + api.urls

--- a/tests/basic/tests/custom_user_api.py
+++ b/tests/basic/tests/custom_user_api.py
@@ -1,0 +1,26 @@
+import json
+
+from django.test import TestCase
+
+
+class CustomUserTestCase(TestCase):
+
+    def test_datefield_return_correct_error_message(self):
+        """
+        When a invalid date is provided, return the right message in the
+        response object.
+        """
+        data = {
+            "password": "sha1$6efc0$f92efe9fd8542f25a7be94871ea45aa95de57161",
+            "email": "tester@example.com",
+            "is_active": True,
+            "is_admin": False,
+            "date_of_birth": "1976-17-08"  # Format for valid date: YYYY-MM-DD
+        }
+        response = self.client.post('/api/v2/customusers/',
+                                    data=json.dumps(data),
+                                    content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        err = "'1976-17-08' value has the correct format (YYYY-MM-DD) but it" \
+              + " is an invalid date."
+        self.assertIn(err, response.content)

--- a/tests/customuser/api/resources.py
+++ b/tests/customuser/api/resources.py
@@ -1,0 +1,11 @@
+from tastypie.authorization import Authorization
+from tastypie.resources import ModelResource
+
+from customuser.models import CustomUser
+
+
+class CustomUserResource(ModelResource):
+    class Meta:
+        queryset = CustomUser.objects.all()
+        resource_name = 'customusers'
+        authorization = Authorization()

--- a/tests/settings_basic.py
+++ b/tests/settings_basic.py
@@ -1,6 +1,6 @@
 from settings import *
 INSTALLED_APPS.append('django.contrib.sessions')
 INSTALLED_APPS.append('basic')
+INSTALLED_APPS.append('customuser')
 
 ROOT_URLCONF = 'basic.urls'
-


### PR DESCRIPTION
This fixes https://github.com/django-tastypie/django-tastypie/pull/1268

The issue was in https://github.com/django-tastypie/django-tastypie/blob/master/tastypie/resources.py#L1775, where the if statement consider both (`DateField` and `DateTimeField`), but because of tastypie also include a `DateField` inside `tastypie/fields.py`, is just enough to append an additional if to check for it and change the result.