### PR TITLE
Fixed RemovedInDjango19Warning deprecation warning

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,6 +85,7 @@ Contributors:
 * tunix for a patch related to Tastypie's timezone-aware dates.
 * Steven Davidson (damycra) for a documentation patch.
 * Harish Srinivas for a minor bug fix that raises an exception if a given related resource is none.
+* Ashley Felton (ropable) fixing a RemovedInDjango19Warning deprecation notice.
 
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -2,10 +2,10 @@ from __future__ import unicode_literals
 import datetime
 from dateutil.parser import parse
 from decimal import Decimal
+import importlib
 import re
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
-from django.utils import datetime_safe, importlib
-from django.utils import six
+from django.utils import datetime_safe, six
 from tastypie.bundle import Bundle
 from tastypie.exceptions import ApiFieldError, NotFound
 from tastypie.utils import dict_strip_unicode_keys, make_aware
@@ -719,19 +719,19 @@ class ToOneField(RelatedField):
                     foreign_obj = getattr(foreign_obj, attr, None)
                 except ObjectDoesNotExist:
                     foreign_obj = None
-        
+
         elif callable(self.attribute):
             previous_obj = bundle.obj
             foreign_obj = self.attribute(bundle)
-            
+
         if not foreign_obj:
             if not self.null:
                 if callable(self.attribute):
                     raise ApiFieldError("The related resource for resource %s could not be found." % (previous_obj))
                 else:
                     raise ApiFieldError("The model '%r' has an empty attribute '%s' and doesn't allow a null value." % (previous_obj, attr))
-            
-            return None        
+
+            return None
 
         self.fk_resource = self.get_related_resource(foreign_obj)
         fk_bundle = Bundle(obj=foreign_obj, request=bundle.request)


### PR DESCRIPTION
Fixed RemovedInDjango19Warning deprecation warning related to django.utils.importlib being removed in Django 1.9.

Django version: 1.8.2
Tastypie version: master