### PR TITLE
Provide URL of related resource in schema when type="related" (#782)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -94,6 +94,9 @@ Contributors:
 * Guilhem Saurel (Nim65s) for a minor issue with Django 1.9
 * Jack Cushman (jcushman) for converting ResourceTestCase to ResourceTestCaseMixin.
 * John Lucas (jlucas91) for an improvement to the response for requests with invalid JSON.
+* Judit Novak (juditnovak) for related schema updates
+* Mike Bryant (mikebryant) for unit tests
+
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/docs/interacting.rst
+++ b/docs/interacting.rst
@@ -224,6 +224,8 @@ This time, we get back a lot more data::
                 "nullable": false,
                 "readonly": false,
                 "type": "related"
+                "related_type": "to_one"
+                "related_schema": "/api/v1/user/schema/"
             }
         },
         "filtering": {

--- a/docs/release_notes/dev.rst
+++ b/docs/release_notes/dev.rst
@@ -9,3 +9,4 @@ Bugfixes
 
 * Prevent muting non-tastypie's exceptions (#1297, PR #1404)
 * Gracefully handle UnsupportFormat exception (#1154, PR #1417)
+* Add related schema urls (#782, PR #1309)

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1040,6 +1040,8 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                 else:
                     related_type = 'to_one'
                 data['fields'][field_name]['related_type'] = related_type
+                uri = reverse('api_get_schema', kwargs={'api_name': self._meta.api_name, 'resource_name': field_object.to_class()._meta.resource_name})
+                data['fields'][field_name]['related_schema'] = uri
 
         return data
 

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -954,7 +954,6 @@ class MediaBitResource(ModelResource):
 
 class ToManyFieldTestCase(TestCase):
     fixtures = ['note_testdata.json']
-    urls = 'core.tests.field_urls'
 
     def setUp(self):
         self.note_1 = Note.objects.get(pk=1)

--- a/tests/core/tests/resource_urls.py
+++ b/tests/core/tests/resource_urls.py
@@ -1,14 +1,24 @@
-from django.conf.urls import include, url
+try:
+    from django.conf.urls import patterns, include
+except ImportError:  # Django < 1.4
+    from django.conf.urls.defaults import patterns, include
+from django.contrib.auth.models import User
 from tastypie import fields
 from tastypie.resources import ModelResource
 from core.models import Note, Subject
-from core.tests.api import Api, UserResource
+from core.tests.api import Api
 
 
 class SubjectResource(ModelResource):
     class Meta:
         resource_name = 'subjects'
         queryset = Subject.objects.all()
+
+
+class UserResource(ModelResource):
+    class Meta:
+        resource_name = 'user'
+        queryset = User.objects.all()
 
 
 class CustomNoteResource(ModelResource):
@@ -25,6 +35,6 @@ api.register(CustomNoteResource())
 api.register(UserResource())
 api.register(SubjectResource())
 
-urlpatterns = [
-    url(r'^api/', include(api.urls)),
-]
+urlpatterns = patterns('',
+    (r'^api/', include(api.urls)),
+)

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1349,7 +1349,7 @@ class CounterUpdateDetailResource(ModelResource):
 
 class ModelResourceTestCase(TestCase):
     fixtures = ['note_testdata.json']
-    urls = 'core.tests.field_urls'
+    urls = 'core.tests.resource_urls'
 
     def setUp(self):
         super(ModelResourceTestCase, self).setUp()
@@ -1696,7 +1696,7 @@ class ModelResourceTestCase(TestCase):
         self.assertEqual(resource.determine_format(request), 'application/xml')
 
     def test_build_schema(self):
-        related = RelatedNoteResource()
+        related = RelatedNoteResource(api_name='v1')
         schema = adjust_schema(related.build_schema())
         expected_schema = {
             'filtering': {
@@ -1707,6 +1707,7 @@ class ModelResourceTestCase(TestCase):
             'fields': {
                 'author': {
                     'related_type': 'to_one',
+                    'related_schema': '/api/v1/user/schema/',
                     'nullable': False,
                     'default': 'No default provided.',
                     'readonly': False,
@@ -1763,6 +1764,7 @@ class ModelResourceTestCase(TestCase):
                 },
                 'subjects': {
                     'related_type': 'to_many',
+                    'related_schema': '/api/v1/subjects/schema/',
                     'nullable': False,
                     'default': 'No default provided.',
                     'readonly': False,
@@ -3489,6 +3491,7 @@ class ModelResourceTestCase(TestCase):
                     "type": 'related',
                     "unique": False,
                     "primary_key": False,
+                    "related_schema": '/api/v1/user/schema/',
                     "related_type": 'to_one'
                 },
                 'subjects': {
@@ -3501,6 +3504,7 @@ class ModelResourceTestCase(TestCase):
                     "type": 'related',
                     "unique": False,
                     "primary_key": False,
+                    "related_schema": '/api/v1/subjects/schema/',
                     "related_type": 'to_many'
                 }
             },


### PR DESCRIPTION
…
Fix for issue #782 (https://github.com/django-tastypie/django-tastypie/issues/782)

Schema information only gives information about whether a related field is
'to_one' or 'to_many', but not about the actual resource type of the field. This
fix adds a new field, called 'related_schema' to the fields schema entry, which
defines the exact type of the related field:

    'user': {
        [..]
        'type': 'related'
        'related_type': 'to_one'
        'related_schema': '/api/v1/user/schema/'
        }

Documentation (schema example on the 'Interacting With The API' page) is updated accordingly.