### PR TITLE
Replace with python importlib

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -3,8 +3,9 @@ import datetime
 from dateutil.parser import parse
 from decimal import Decimal
 import re
+from importlib import import_module
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
-from django.utils import datetime_safe, importlib
+from django.utils import datetime_safe
 from django.utils import six
 from tastypie.bundle import Bundle
 from tastypie.exceptions import ApiFieldError, NotFound
@@ -537,7 +538,7 @@ class RelatedField(ApiField):
             # Try to import.
             module_bits = self.to.split('.')
             module_path, class_name = '.'.join(module_bits[:-1]), module_bits[-1]
-            module = importlib.import_module(module_path)
+            module = import_module(module_path)
         else:
             # We've got a bare class name here, which won't work (No AppCache
             # to rely on). Try to throw a useful error.

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -3,7 +3,10 @@ import datetime
 from dateutil.parser import parse
 from decimal import Decimal
 import re
-from importlib import import_module
+try :
+    from django.utils import importlib
+except ImportError:
+    import importlib
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.utils import datetime_safe
 from django.utils import six
@@ -538,7 +541,7 @@ class RelatedField(ApiField):
             # Try to import.
             module_bits = self.to.split('.')
             module_path, class_name = '.'.join(module_bits[:-1]), module_bits[-1]
-            module = import_module(module_path)
+            module = importlib.import_module(module_path)
         else:
             # We've got a bare class name here, which won't work (No AppCache
             # to rely on). Try to throw a useful error.


### PR DESCRIPTION
Replace django.utils.importlib with python importlib 
"Warning: django.utils.importlib will be removed in Django 1.9"