### PR TITLE
[doc] add missing imports in non-orm example

### DIFF
--- a/docs/non_orm_data_sources.rst
+++ b/docs/non_orm_data_sources.rst
@@ -48,6 +48,7 @@ since it has both a simple API and demonstrate what hooking up to a
 non-relational datastore looks like::
 
     from tastypie import fields
+    from tastypie.authorization import Authorization
     from tastypie.resources import Resource
 
     # We need a generic object to shove data in/get data from.

--- a/docs/non_orm_data_sources.rst
+++ b/docs/non_orm_data_sources.rst
@@ -47,6 +47,9 @@ As an example, we'll take integrating with Riak_ (a Dynamo-like NoSQL store)
 since it has both a simple API and demonstrate what hooking up to a
 non-relational datastore looks like::
 
+    from tastypie import fields
+    from tastypie.resources import Resource
+
     # We need a generic object to shove data in/get data from.
     # Riak generally just tosses around dictionaries, so we'll lightly
     # wrap that.


### PR DESCRIPTION
The example is still missing some but it's nice to show where `Resource` can be imported from.