### PR TITLE
Changed order of imports, trying to import first newer version of lib…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -85,6 +85,7 @@ Contributors:
 * tunix for a patch related to Tastypie's timezone-aware dates.
 * Steven Davidson (damycra) for a documentation patch.
 * Harish Srinivas for a minor bug fix that raises an exception if a given related resource is none.
+* Miguel Sánchez (miguelsr) for a small fix that prevents unnecesary RemovedInDjango19Warning being shown.
 
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -4,9 +4,9 @@ from dateutil.parser import parse
 from decimal import Decimal
 import re
 try :
-    from django.utils import importlib
-except ImportError:
     import importlib
+except ImportError:
+    from django.utils import importlib
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.utils import datetime_safe
 from django.utils import six


### PR DESCRIPTION
…rary and therefore preventing a RemovedInDjango19Warning being shown.