### PR TITLE
RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -3,10 +3,10 @@ import datetime
 from dateutil.parser import parse
 from decimal import Decimal
 import re
-try :
-    from django.utils import importlib
-except ImportError:
+try:
     import importlib
+except ImportError:
+    from django.utils import importlib
 from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from django.utils import datetime_safe
 from django.utils import six


### PR DESCRIPTION
Let's do not show this notification:

```
/env/src/django-tastypie/tastypie/fields.py:7: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
  from django.utils import datetime_safe, importlib
```

