### PR TITLE
Ignore extra related data

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2078,6 +2078,12 @@ class BaseModelResource(Resource):
         Takes optional ``kwargs``, which are used to narrow the query to find
         the instance.
         """
+        # prevents FieldError when looking up nested resources containing extra data
+        field_names = self._meta.object_class._meta.get_all_field_names()
+        field_names.append('pk')
+        
+        kwargs = dict([(k, v,) for k, v in kwargs.items() if k in field_names])
+        
         try:
             object_list = self.get_object_list(bundle.request).filter(**kwargs)
             stringified_kwargs = ', '.join(["%s=%s" % (k, v) for k, v in kwargs.items()])

--- a/tests/related_resource/tests.py
+++ b/tests/related_resource/tests.py
@@ -479,6 +479,70 @@ class NestedRelatedResourceTest(TestCase):
         resp = pr.put_detail(request, pk=pk)
         self.assertEqual(resp.status_code, 204)
 
+    def test_many_to_one_extra_data_ignored(self):
+        """
+        Test a related ToMany resource with a nested full ToOne resource
+        
+        FieldError would result when extra data is included on an embedded
+        resource for an already saved object.
+        """
+        self.assertEqual(Person.objects.count(), 0)
+        self.assertEqual(Dog.objects.count(), 0)
+        self.assertEqual(DogHouse.objects.count(), 0)
+
+        pr = PersonResource()
+
+        data = {
+            'name': 'Joan Rivers',
+            'dogs': [
+                {
+                    'name': 'Snoopy',
+                    'house': {
+                        'color': 'Red'
+                    }
+                }
+            ]
+        }
+
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'POST'
+        request.set_body(json.dumps(data))
+        resp = pr.post_list(request)
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(Person.objects.count(), 1)
+        self.assertEqual(Dog.objects.count(), 1)
+        self.assertEqual(DogHouse.objects.count(), 1)
+
+        pk = Person.objects.all()[0].pk
+        request = MockRequest()
+        request.method = 'GET'
+        request.path = reverse('api_dispatch_detail', kwargs={'pk': pk, 'resource_name': pr._meta.resource_name, 'api_name': pr._meta.api_name})
+        resp = pr.get_detail(request, pk=pk)
+        self.assertEqual(resp.status_code, 200)
+
+        person = json.loads(resp.content.decode('utf-8'))
+        self.assertEqual(person['name'], 'Joan Rivers')
+        self.assertEqual(len(person['dogs']), 1)
+
+        dog = person['dogs'][0]
+        self.assertEqual(dog['name'], 'Snoopy')
+
+        house = dog['house']
+        self.assertEqual(house['color'], 'Red')
+
+        # clients may include extra data, which should be ignored. Make extra data is ignored on the resource and sub resources.
+        person['thisfieldshouldbeignored'] = 'foobar'
+        person['dogs'][0]['thisfieldshouldbeignored'] = 'foobar'
+        
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'PUT'
+        request.set_body(json.dumps(person))
+        request.path = reverse('api_dispatch_detail', kwargs={'pk': pk, 'resource_name': pr._meta.resource_name, 'api_name': pr._meta.api_name})
+        resp = pr.put_detail(request, pk=pk)
+        self.assertEqual(resp.status_code, 204)
+
     def test_many_to_many(self):
         """
         Test a related ToMany resource with a nested full ToMany resource


### PR DESCRIPTION
Tastypie ignores extra data sent to a resource, but throws errors if there's extra data on a related resource.