### PR TITLE
Unquote url-s containing escaped characters

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -18,6 +18,7 @@ from django.db import transaction
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.sql.constants import QUERY_TERMS
 from django.http import HttpResponse, HttpResponseNotFound, Http404
+from django.utils.http import urlunquote
 from django.utils.cache import patch_cache_control, patch_vary_headers
 from django.utils.html import escape
 from django.utils import six
@@ -813,7 +814,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         simply override this method.
         """
         prefix = get_script_prefix()
-        chomped_uri = uri
+        chomped_uri = urlunquote(uri)
 
         if prefix and chomped_uri.startswith(prefix):
             chomped_uri = chomped_uri[len(prefix)-1:]


### PR DESCRIPTION
This would allow processing resource_uri's like /~krichy/api/...