### PR TITLE
remove unimplemented to_html/from_html

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -88,6 +88,7 @@ Contributors:
 * Renjith Thankachan for a patch that fixes `django.utils.importlib` error in Django 1.9+ release.
 * Sean Hayes (SeanHayes) for test suite and CI enhancements, various patches
 * Michael Thornhill (mthornhill) for strict dict checking bugfix
+* Fedor Baart (siggyf) for an update on the serializer
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -15,10 +15,10 @@ This is actually not a bug and JSON support is present in your ``Resource``.
 This issue is that Tastypie respects the ``Accept`` header your browser sends.
 Most browsers send something like::
 
-    Accept: application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+    Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
 
-Note that ``application/xml`` comes first, which is a format that Tastypie
-handles by default, hence why you receive XML.
+Note that ``application/xml`` is the first format that Tastypie
+handles, hence you receive XML.
 
 If you use ``curl`` from the command line, you should receive JSON by default::
 

--- a/docs/serialization.rst
+++ b/docs/serialization.rst
@@ -41,7 +41,6 @@ The default ``Serializer`` supports the following formats:
 * jsonp (Disabled by default)
 * xml
 * yaml
-* html
 * plist (see http://explorapp.com/biplist/)
 
 Not everyone wants to install or support all the serialization options. If you
@@ -77,7 +76,7 @@ Enabling the built-in (but disabled by default) JSONP support looks like::
             queryset = User.objects.all()
             resource_name = 'auth/user'
             excludes = ['email', 'password', 'is_superuser']
-            serializer = Serializer(formats=['json', 'jsonp', 'xml', 'yaml', 'html', 'plist'])
+            serializer = Serializer(formats=['json', 'jsonp', 'xml', 'yaml', 'plist'])
 
 
 Serialization Security
@@ -199,7 +198,6 @@ This handles most types of data as well as the following output formats::
     * jsonp
     * xml
     * yaml
-    * html
     * plist
 
 It was designed to make changing behavior easy, either by overridding the
@@ -361,24 +359,3 @@ Given some Python data, produces binary plist output.
 
 Given some binary plist data, returns a Python dictionary of the decoded data.
 
-``to_html``
-~~~~~~~~~~~
-
-.. method:: Serializer.to_html(self, data, options=None):
-
-Reserved for future usage.
-
-The desire is to provide HTML output of a resource, making an API
-available to a browser. This is on the TODO list but not currently
-implemented.
-
-``from_html``
-~~~~~~~~~~~~~
-
-.. method:: Serializer.from_html(self, content):
-
-Reserved for future usage.
-
-The desire is to handle form-based (maybe Javascript?) input, making an
-API available to a browser. This is on the TODO list but not currently
-implemented.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -113,7 +113,7 @@ An example::
 
     TASTYPIE_DEFAULT_FORMATS = ['json', 'xml']
 
-Defaults to ``['json', 'xml', 'yaml', 'html', 'plist']``.
+Defaults to ``['json', 'xml', 'yaml', 'plist']``.
 
 
 ``TASTYPIE_ABSTRACT_APIKEY``

--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -75,7 +75,6 @@ class Serializer(object):
         * jsonp (Disabled by default)
         * xml
         * yaml
-        * html
         * plist (see http://explorapp.com/biplist/)
 
     It was designed to make changing behavior easy, either by overridding the
@@ -83,13 +82,12 @@ class Serializer(object):
     ``formats/content_types`` options or by altering the other hook methods.
     """
 
-    formats = ['json', 'xml', 'yaml', 'html', 'plist']
+    formats = ['json', 'xml', 'yaml', 'plist']
 
     content_types = {'json': 'application/json',
                      'jsonp': 'text/javascript',
                      'xml': 'application/xml',
                      'yaml': 'text/yaml',
-                     'html': 'text/html',
                      'plist': 'application/x-plist'}
 
     def __init__(self, formats=None, content_types=None, datetime_formatting=None):
@@ -445,27 +443,6 @@ class Serializer(object):
             content = smart_bytes(content)
 
         return biplist.readPlistFromString(content)
-
-    def to_html(self, data, options=None):
-        """
-        Reserved for future usage.
-
-        The desire is to provide HTML output of a resource, making an API
-        available to a browser. This is on the TODO list but not currently
-        implemented.
-        """
-        options = options or {}
-        return 'Sorry, not implemented yet. Please append "?format=json" to your URL.'
-
-    def from_html(self, content):
-        """
-        Reserved for future usage.
-
-        The desire is to handle form-based (maybe Javascript?) input, making an
-        API available to a browser. This is on the TODO list but not currently
-        implemented.
-        """
-        pass
 
 def get_type_string(data):
     """

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -819,7 +819,7 @@ class NoteResource(ModelResource):
         }
         ordering = ['title', 'slug', 'resource_uri']
         queryset = Note.objects.filter(is_active=True)
-        serializer = Serializer(formats=['json', 'jsonp', 'xml', 'yaml', 'html', 'plist'])
+        serializer = Serializer(formats=['json', 'jsonp', 'xml', 'yaml', 'plist'])
 
     def get_resource_uri(self, bundle_or_obj=None, url_name='api_dispatch_list'):
         if bundle_or_obj is None:
@@ -1568,13 +1568,22 @@ class ModelResourceTestCase(TestCase):
         request.META = {'HTTP_ACCEPT': 'text/yaml'}
         self.assertEqual(resource.determine_format(request), 'text/yaml')
 
+        # unsupported text/html should return default format
         request.META = {'HTTP_ACCEPT': 'text/html'}
-        self.assertEqual(resource.determine_format(request), 'text/html')
+        self.assertEqual(resource.determine_format(request), 'application/json')
+
+        # unsupported applicaiton/octet-stream returns default format
+        request.META = {'HTTP_ACCEPT': 'application/octet-stream'}
+        self.assertEqual(resource.determine_format(request), 'application/json')
 
         request.META = {'HTTP_ACCEPT': 'application/json,application/xml;q=0.9,*/*;q=0.8'}
         self.assertEqual(resource.determine_format(request), 'application/json')
 
         request.META = {'HTTP_ACCEPT': 'text/plain,application/xml,application/json;q=0.9,*/*;q=0.8'}
+        self.assertEqual(resource.determine_format(request), 'application/xml')
+
+        # your typical browser (chrome, firefoxs, no plugins) should get back xml
+        request.META = {'HTTP_ACCEPT': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'}
         self.assertEqual(resource.determine_format(request), 'application/xml')
 
     def adjust_schema(self, schema_dict):

--- a/tests/core/tests/serializers.py
+++ b/tests/core/tests/serializers.py
@@ -47,13 +47,13 @@ class AnotherNoteResource(ModelResource):
 class SerializerTestCase(TestCase):
     def test_init(self):
         serializer_1 = Serializer()
-        self.assertEqual(serializer_1.formats, ['json', 'xml', 'yaml', 'html', 'plist'])
-        self.assertEqual(serializer_1.content_types, {'xml': 'application/xml', 'yaml': 'text/yaml', 'json': 'application/json', 'jsonp': 'text/javascript', 'html': 'text/html', 'plist': 'application/x-plist'})
-        self.assertEqual(serializer_1.supported_formats, ['application/json', 'application/xml', 'text/yaml', 'text/html', 'application/x-plist'])
+        self.assertEqual(serializer_1.formats, ['json', 'xml', 'yaml', 'plist'])
+        self.assertEqual(serializer_1.content_types, {'xml': 'application/xml', 'yaml': 'text/yaml', 'json': 'application/json', 'jsonp': 'text/javascript', 'plist': 'application/x-plist'})
+        self.assertEqual(serializer_1.supported_formats, ['application/json', 'application/xml', 'text/yaml', 'application/x-plist'])
 
         serializer_2 = Serializer(formats=['json', 'xml'])
         self.assertEqual(serializer_2.formats, ['json', 'xml'])
-        self.assertEqual(serializer_2.content_types, {'xml': 'application/xml', 'yaml': 'text/yaml', 'json': 'application/json', 'jsonp': 'text/javascript', 'html': 'text/html', 'plist': 'application/x-plist'})
+        self.assertEqual(serializer_2.content_types, {'xml': 'application/xml', 'yaml': 'text/yaml', 'json': 'application/json', 'jsonp': 'text/javascript', 'plist': 'application/x-plist'})
         self.assertEqual(serializer_2.supported_formats, ['application/json', 'application/xml'])
 
         serializer_3 = Serializer(formats=['json', 'xml'], content_types={'json': 'text/json', 'xml': 'application/xml'})
@@ -80,7 +80,7 @@ class SerializerTestCase(TestCase):
             s = Serializer()
             self.assertEqual(list(s.formats), ['json', 'xml'])
             self.assertEqual(list(s.supported_formats), ['application/json', 'application/xml'])
-            self.assertEqual(s.content_types, {'xml': 'application/xml', 'yaml': 'text/yaml', 'json': 'application/json', 'jsonp': 'text/javascript', 'html': 'text/html', 'plist': 'application/x-plist'})
+            self.assertEqual(s.content_types, {'xml': 'application/xml', 'yaml': 'text/yaml', 'json': 'application/json', 'jsonp': 'text/javascript', 'plist': 'application/x-plist'})
 
             # Confirm that subclasses which set their own formats list won't be overriden:
             class JSONSerializer(Serializer):
@@ -431,7 +431,6 @@ class StubbedSerializer(Serializer):
         self.from_json_called = False
         self.from_xml_called = False
         self.from_yaml_called = False
-        self.from_html_called = False
         self.from_jsonp_called = False
 
     def from_json(self, data):
@@ -444,10 +443,6 @@ class StubbedSerializer(Serializer):
 
     def from_yaml(self, data):
         self.from_yaml_called = True
-        return True
-
-    def from_html(self, data):
-        self.from_html_called = True
         return True
 
     def from_jsonp(self, data):
@@ -494,14 +489,4 @@ class ContentHeaderTest(TestCase):
         serializer = StubbedSerializer()
         serializer.deserialize('{}', 'text/javascript; charset=UTF-8')
         self.assertTrue(serializer.from_jsonp_called)
-
-    def test_deserialize_html(self):
-        serializer = StubbedSerializer()
-        serializer.deserialize('', 'text/html')
-        self.assertTrue(serializer.from_html_called)
-
-    def test_deserialize_html_with_charset(self):
-        serializer = StubbedSerializer()
-        serializer.deserialize('', 'text/html; charset=UTF-8')
-        self.assertTrue(serializer.from_html_called)
 

--- a/tests/core/tests/utils.py
+++ b/tests/core/tests/utils.py
@@ -28,7 +28,7 @@ class MimeTestCase(TestCase):
 
     def test_determine_format(self):
         serializer = Serializer()
-        full_serializer = Serializer(formats=['json', 'jsonp', 'xml', 'yaml', 'html', 'plist'])
+        full_serializer = Serializer(formats=['json', 'jsonp', 'xml', 'yaml', 'plist'])
         request = HttpRequest()
 
         # Default.
@@ -79,8 +79,13 @@ class MimeTestCase(TestCase):
         request.META = {'HTTP_ACCEPT': 'application/x-plist'}
         self.assertEqual(determine_format(request, serializer), 'application/x-plist')
 
+        # unsupported text/html
         request.META = {'HTTP_ACCEPT': 'text/html'}
-        self.assertEqual(determine_format(request, serializer), 'text/html')
+        self.assertEqual(determine_format(request, serializer), 'application/json')
+
+        # unsupported binary
+        request.META = {'HTTP_ACCEPT': 'application/octet-stream'}
+        self.assertEqual(determine_format(request, serializer), 'application/json')
 
         request.META = {'HTTP_ACCEPT': '*/*'}
         self.assertEqual(determine_format(request, serializer), 'application/json')
@@ -99,6 +104,10 @@ class MimeTestCase(TestCase):
 
         request.META = {'HTTP_ACCEPT': 'bogon'}
         self.assertRaises(BadRequest, determine_format, request, serializer)
+
+        # typical browser (firefox, chrome)
+        request.META = {'HTTP_ACCEPT': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'}
+        self.assertEqual(determine_format(request, serializer), 'application/xml')
 
 
 if TZ_AVAILABLE:


### PR DESCRIPTION
This pull request is a followup on #629. 
I have removed the unimplemented `to_html` and `from_html`. 
This issue solves the problem that text/html is returned where a application/xml or application/json is requested. See details in #629.

I updated tests and docs and added 2 new tests (with Accept header from Chrome/Firefox). The pull request was tested without errors with tox with environments py27, 1.7 and 1.8, py3.4, 1.7 and 1.8.

Please consider incorporating this pull request. 

I also considered implementing the to_html/from_html methods. I could not find a good reference/example where html is used as a serialisation format. For the `to_html` I found the [`_repr_html_`](https://ipython.org/ipython-doc/dev/config/integrating.html#rich-display) in IPython which is appealing, but it's not a data format. Alternatives that one could consider are the [microdata](https://html.spec.whatwg.org/multipage/microdata.html) format (not clear how to_html would look like) and the [data-](http://www.w3.org/TR/html5/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes) attributes. Comments in the code suggested that perhaps the intention was to implement something like a `from_request` method, where a form post request could be used as input. 
