### PR TITLE
Fix hydrating/saving of related resources.

### DIFF
--- a/tastypie/bundle.py
+++ b/tastypie/bundle.py
@@ -19,6 +19,7 @@ class Bundle(object):
                  related_name=None,
                  objects_saved=None,
                  related_objects_to_save=None,
+                 via_uri=False,
                  ):
         self.obj = obj
         self.data = data or {}
@@ -28,6 +29,7 @@ class Bundle(object):
         self.errors = {}
         self.objects_saved = objects_saved or set()
         self.related_objects_to_save = related_objects_to_save or {}
+        self.via_uri = via_uri
 
     def __repr__(self):
         return "<Bundle for obj: '%s' and with data: '%s'>" % (self.obj, self.data)

--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -581,7 +581,8 @@ class RelatedField(ApiField):
             obj = fk_resource.get_via_uri(uri, request=request)
             bundle = fk_resource.build_bundle(
                 obj=obj,
-                request=request
+                request=request,
+                via_uri=True
             )
             return fk_resource.full_dehydrate(bundle)
         except ObjectDoesNotExist:
@@ -609,14 +610,14 @@ class RelatedField(ApiField):
         # happens to match other kwargs. In the case of a create, it might be the
         # completely wrong resource.
         # We also need to check to see if updates are allowed on the FK resource.
-        if unique_keys and fk_resource.can_update():
+        if unique_keys:
             try:
-                return fk_resource.obj_update(fk_bundle, skip_errors=True, **data)
-            except (NotFound, TypeError):
+                fk_resource.obj_get(fk_bundle, skip_errors=True, **data)
+            except (ObjectDoesNotExist, NotFound, TypeError):
                 try:
                     # Attempt lookup by primary key
-                    return fk_resource.obj_update(fk_bundle, skip_errors=True, **unique_keys)
-                except NotFound:
+                    fk_resource.obj_get(fk_bundle, skip_errors=True, **unique_keys)
+                except (ObjectDoesNotExist, NotFound):
                     pass
             except MultipleObjectsReturned:
                 pass

--- a/tests/core/tests/mocks.py
+++ b/tests/core/tests/mocks.py
@@ -11,6 +11,9 @@ class MockRequest(object):
         self.path = ''
         self.method = 'GET'
 
+    def _load_post_and_files(self, *args, **kwargs):
+        pass
+
     def get_full_path(self, *args, **kwargs):
         return self.path
 

--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -6,9 +6,9 @@ from tastypie.authorization import Authorization
 
 from core.models import Note, MediaBit
 
-from related_resource.models import Category, Tag, ExtraData, Taggable,\
-    TaggableTag, Person, Company, Product, Address, Dog, DogHouse, Forum,\
-    Bone, Job, Label, Payment, Post, Order, OrderItem
+from related_resource.models import Bone, Category, Contact, ContactGroup,\
+    ExtraData, Person, Company, Product, Address, Dog, DogHouse, Forum,\
+    Job, Label, Order, OrderItem, Payment, Post, Tag, Taggable, TaggableTag
 
 
 class UserResource(ModelResource):
@@ -28,10 +28,19 @@ class UpdatableUserResource(ModelResource):
 
 
 class NoteResource(ModelResource):
-    author = fields.ForeignKey(UpdatableUserResource, 'author')
+    author = fields.ForeignKey(UserResource, 'author')
 
     class Meta:
         resource_name = 'notes'
+        queryset = Note.objects.all()
+        authorization = Authorization()
+
+
+class NoteWithUpdatableUserResource(ModelResource):
+    author = fields.ForeignKey(UpdatableUserResource, 'author')
+
+    class Meta:
+        resource_name = 'noteswithupdatableuser'
         queryset = Note.objects.all()
         authorization = Authorization()
 
@@ -250,4 +259,22 @@ class OrderResource(ModelResource):
     class Meta:
         queryset = Order.objects.all()
         resource_name = 'order'
+        authorization = Authorization()
+
+
+class ContactGroupResource(ModelResource):
+    members = fields.ToManyField('related_resource.api.resources.ContactResource', 'members', related_name='groups', null=True, blank=True)
+
+    class Meta:
+        queryset = ContactGroup.objects.prefetch_related('members')
+        resource_name = 'contactgroup'
+        authorization = Authorization()
+
+
+class ContactResource(ModelResource):
+    groups = fields.ToManyField(ContactGroupResource, 'groups', related_name='members', null=True, blank=True)
+
+    class Meta:
+        queryset = Contact.objects.prefetch_related('groups')
+        resource_name = 'contact'
         authorization = Authorization()

--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -19,8 +19,16 @@ class UserResource(ModelResource):
         authorization = Authorization()
 
 
+class UpdatableUserResource(ModelResource):
+    class Meta:
+        resource_name = 'users'
+        queryset = User.objects.all()
+        allowed_methods = ['get', 'put']
+        authorization = Authorization()
+
+
 class NoteResource(ModelResource):
-    author = fields.ForeignKey(UserResource, 'author')
+    author = fields.ForeignKey(UpdatableUserResource, 'author')
 
     class Meta:
         resource_name = 'notes'

--- a/tests/related_resource/api/urls.py
+++ b/tests/related_resource/api/urls.py
@@ -5,11 +5,13 @@ from related_resource.api.resources import NoteResource, UserResource,\
     ExtraDataResource, FreshNoteResource, FreshMediaBitResource,\
     ForumResource, CompanyResource, ProductResource, AddressResource,\
     PersonResource, DogResource, DogHouseResource, BoneResource,\
-    LabelResource, PostResource, OrderResource, OrderItemResource
+    LabelResource, PostResource, OrderResource, OrderItemResource,\
+    NoteWithUpdatableUserResource, ContactResource, ContactGroupResource
 
 
 api = Api(api_name='v1')
 api.register(NoteResource(), canonical=True)
+api.register(NoteWithUpdatableUserResource(), canonical=True)
 api.register(UserResource(), canonical=True)
 api.register(CategoryResource(), canonical=True)
 api.register(TagResource(), canonical=True)
@@ -30,5 +32,7 @@ api.register(PostResource(), canonical=True)
 api.register(LabelResource(), canonical=True)
 api.register(OrderResource(), canonical=True)
 api.register(OrderItemResource(), canonical=True)
+api.register(ContactResource(), canonical=True)
+api.register(ContactGroupResource(), canonical=True)
 
 urlpatterns = api.urls

--- a/tests/related_resource/models.py
+++ b/tests/related_resource/models.py
@@ -142,3 +142,31 @@ class Order(models.Model):
 class OrderItem(models.Model):
     order = models.ForeignKey(Order, related_name="items")
     product = models.CharField(max_length=200)
+
+
+class ContactGroup(models.Model):
+    name = models.CharField(max_length=75, blank=True,
+        help_text="Contact first name.")
+
+    class Meta:
+        ordering = ['id']
+
+    def __unicode__(self):
+        return u'%s' % self.name
+
+
+class Contact(models.Model):
+    name = models.CharField(max_length=255)
+    groups = models.ManyToManyField(
+        ContactGroup,
+        related_name='members',
+        null=True,
+        blank=True,
+        help_text="The Contact Groups this Contact belongs to."
+    )
+
+    class Meta:
+        ordering = ['id']
+
+    def __unicode__(self):
+        return u'%s' % self.name

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -45,7 +45,7 @@ class TestServerThread(threading.Thread):
             httpd = StoppableWSGIServer(server_address, basehttp.WSGIRequestHandler)
             httpd.set_app(handler)
             self.started.set()
-        except basehttp.WSGIServerException as e:
+        except socket.error as e:
             self.error = e
             self.started.set()
             return


### PR DESCRIPTION
Related to #1344 

Some test cases have been split up into separate test case to make debugging easier, and some new tests and assertions were added, but otherwise the same tests are being executed.

Notable changes:
1. We skip saving resources loaded via a URI (RelatedField().resource_from_uri()) since we know there's no changes from the client.
2. In RelatedField().resource_from_data(), we no longer check can_update(). We don't use the can_* methods anywhere else, and those methods don't check permissions, just allowed HTTP methods. Permissions checking still happens in Resource().save().
3. In RelatedField().resource_from_data(), we no longer call Resource().obj_update(). It seemed really inappropriate to be saving anything here (during the hydration step), my guess is this code got checked in without anyone taking too close a look; no permissions checks were being done (!!!), just an HTTP method check (can_update) on the related resource.