### PR TITLE
Return 400 error when request body has malformed syntax. (based on PR #649 by piotrbulinski)

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -388,8 +388,10 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 
         Mostly a hook, this uses the ``Serializer`` from ``Resource._meta``.
         """
-        deserialized = self._meta.serializer.deserialize(data, format=request.META.get('CONTENT_TYPE', format))
-        return deserialized
+        try:
+            return self._meta.serializer.deserialize(data, format=request.META.get('CONTENT_TYPE', format))
+        except ValueError as e:
+            raise BadRequest("Invalid data sent: %s" % e)
 
     def alter_list_data_to_serialize(self, request, data):
         """

--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -11,7 +11,7 @@ from django.utils.encoding import force_text, smart_bytes
 from django.core.serializers import json as djangojson
 
 from tastypie.bundle import Bundle
-from tastypie.exceptions import BadRequest, UnsupportedFormat
+from tastypie.exceptions import UnsupportedFormat
 from tastypie.utils import format_datetime, format_date, format_time,\
     make_naive
 
@@ -410,10 +410,7 @@ class Serializer(object):
         """
         Given some JSON data, returns a Python dictionary of the decoded data.
         """
-        try:
-            return json.loads(content)
-        except ValueError:
-            raise BadRequest
+        return json.loads(content)
 
     def to_jsonp(self, data, options=None):
         """
@@ -447,9 +444,8 @@ class Serializer(object):
         """
         Given some XML data, returns a Python dictionary of the decoded data.
 
-        By default XML entity declarations and DTDs will raise a BadRequest
-        exception content but subclasses may choose to override this if
-        necessary.
+        By default XML entity declarations and DTDs will raise a ValueError
+        exception but subclasses may choose to override this if necessary.
         """
         if lxml is None:
             raise ImproperlyConfigured(
@@ -465,7 +461,7 @@ class Serializer(object):
                 forbid_entities=forbid_entities
             )
         except (LxmlError, DefusedXmlException):
-            raise BadRequest()
+            raise ValueError('XML parsing failed.')
 
         return self.from_etree(parsed.getroot())
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -801,6 +801,20 @@ class ResourceTestCase(TestCase):
 
         self.assertNotIn('view_count', basic_resource_list[0])
 
+    def test_deserialization_error_raises_bad_request(self):
+        resource = BasicResource()
+
+        request = MockRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'POST'
+        # missing closing bracket
+        request.body = '{"content": "The cat is back. The dog coughed him up out back.", "created": "2010-04-03 20:05:00", "is_active": true, "slug": "cat-is-back", "title": "The Cat Is Back", "updated": "2010-04-03 20:05:00"'
+
+        with self.assertRaises(BadRequest) as ctx:
+            resource.deserialize(request, request.body)
+
+        self.assertTrue(ctx.exception.args[0].startswith('Invalid data sent: '))
+
 
 # ====================
 # Model-based tests...

--- a/tests/core/tests/serializers.py
+++ b/tests/core/tests/serializers.py
@@ -7,7 +7,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from tastypie.bundle import Bundle
 from tastypie import fields
-from tastypie.exceptions import BadRequest
 from tastypie.serializers import Serializer
 from tastypie.resources import ModelResource
 from core.models import Note
@@ -297,7 +296,7 @@ class SerializerTestCase(TestCase):
     def test_malformed_xml(self):
         serializer = Serializer()
         data = '<?xml version=\'1.0\' encoding=\'utf-8\'?>\n<request><somelist type="list"><valueNO CARRIER'
-        self.assertRaises(BadRequest, serializer.from_xml, data)
+        self.assertRaises(ValueError, serializer.from_xml, data)
 
     def test_to_json(self):
         serializer = Serializer()
@@ -318,7 +317,7 @@ class SerializerTestCase(TestCase):
     def test_from_broken_json(self):
         serializer = Serializer()
         data = '{"foo": "bar",NO CARRIER'
-        self.assertRaises(BadRequest, serializer.from_json, data)
+        self.assertRaises(ValueError, serializer.from_json, data)
 
     def test_round_trip_xml(self):
         serializer = Serializer()
@@ -362,7 +361,7 @@ class SerializerTestCase(TestCase):
         data = """<!DOCTYPE bomb [<!ENTITY a "evil chars">]>
         <bomb>&a;</bomb>
         """
-        self.assertRaises(BadRequest, serializer.from_xml, data)
+        self.assertRaises(ValueError, serializer.from_xml, data)
 
     def test_to_jsonp(self):
         serializer = Serializer()


### PR DESCRIPTION
Serializers no longer raise BadRequest themselves (a Serializer shouldn't know anything about HTTP), they raise a ValueError.