### PR TITLE
django.utils.http.same_origin not in Django 1.9

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -91,6 +91,7 @@ Contributors:
 * Fedor Baart (siggyf) for an update on the serializer
 * Alexey Kotlyarov (koterpillar) - fixing DateField/DateTimeField.
 * Yuri Govorushchenko (metametadata) for documentation fixes.
+* Guilhem Saurel (Nim65s) for a minor issue with Django 1.9
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.exceptions import ImproperlyConfigured
 from django.middleware.csrf import _sanitize_token, constant_time_compare
-from django.utils.http import same_origin
+from django.utils.six.moves.urllib.parse import urlparse
 from django.utils.translation import ugettext as _
 from tastypie.http import HttpUnauthorized
 from tastypie.compat import get_user_model, get_username_field
@@ -33,6 +33,23 @@ try:
     import oauth_provider
 except ImportError:
     oauth_provider = None
+
+
+def same_origin(url1, url2):
+    """
+    Checks if two URLs are 'same-origin'
+    """
+    PROTOCOL_TO_PORT = {
+        'http': 80,
+        'https': 443,
+    }
+    p1, p2 = urlparse(url1), urlparse(url2)
+    try:
+        o1 = (p1.scheme, p1.hostname, p1.port or PROTOCOL_TO_PORT[p1.scheme])
+        o2 = (p2.scheme, p2.hostname, p2.port or PROTOCOL_TO_PORT[p2.scheme])
+        return o1 == o2
+    except (ValueError, KeyError):
+        return False
 
 
 class Authentication(object):


### PR DESCRIPTION
Refs #1395 

In Django 1.9, the `same_origin` function is gone.

Other projects that also got the same issue copied the code from django<1.9: 
https://github.com/jbittel/django-mama-cas/commit/93b74f960b1db4007189a61804cea2089b6d9402
https://github.com/Osmose/django-browserid/commit/afe60218eabf8f19e69e1f7542bc339f009602e1