### PR TITLE
stop using django.conf.urls.patterns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,17 +71,17 @@ A basic example looks like:
 
     # urls.py
     # =======
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import url, include
     from tastypie.api import Api
     from myapp.api import EntryResource
 
     v1_api = Api(api_name='v1')
     v1_api.register(EntryResource())
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         # The normal jazz here then...
-        (r'^api/', include(v1_api.urls)),
-    )
+        url(r'^api/', include(v1_api.urls)),
+    ]
 
 That gets you a fully working, read-write API for the ``Entry`` model that
 supports all CRUD operations in a RESTful way. JSON/XML/YAML support is already

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,7 @@ Quick Start
 A sample api definition might look something like (usually located in a
 URLconf)::
 
+    from django.conf.urls import url, include
     from tastypie.api import Api
     from myapp.api.resources import UserResource, EntryResource
 
@@ -25,9 +26,9 @@ URLconf)::
     v1_api.register(EntryResource())
 
     # Standard bits...
-    urlpatterns = patterns('',
-        (r'^api/', include(v1_api.urls)),
-    )
+    urlpatterns = [
+        url(r'^api/', include(v1_api.urls)),
+    ]
 
 
 ``Api`` Methods
@@ -83,8 +84,7 @@ Deprecated. Will be removed by v1.0.0. Please use ``Api.prepend_urls`` instead.
 A hook for adding your own URLs or matching before the default URLs. Useful for
 adding custom endpoints or overriding the built-in ones.
 
-Should return a list of individual URLconf lines (**NOT** wrapped in
-``patterns``).
+Should return a list of individual URLconf lines.
 
 ``urls``
 ~~~~~~~~
@@ -103,4 +103,3 @@ Provides URLconf details for the ``Api`` and all registered
 
 A view that returns a serialized list of all resources registers
 to the ``Api``. Useful for discovery.
-

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -32,7 +32,7 @@ OAuth 2.0 authentication with Tasty Pie.::
             resource_name = 'poll'
             authorization = DjangoAuthorization()
             authentication = OAuth20Authentication()
-            
+
 
 Adding Custom Values
 --------------------
@@ -198,15 +198,15 @@ Another alternative approach is to override the ``dispatch`` method::
             return super(EntryResource, self).dispatch(request_type, request, **kwargs)
 
     # urls.py
-    from django.conf.urls import url, patterns, include
+    from django.conf.urls import url, include
     from myapp.api import EntryResource
 
     entry_resource = EntryResource()
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         # The normal jazz here, then...
-        (r'^api/(?P<username>\w+)/', include(entry_resource.urls)),
-    )
+        url(r'^api/(?P<username>\w+)/', include(entry_resource.urls)),
+    ]
 
 
 Nested Resources
@@ -245,7 +245,7 @@ approach uses Haystack_, though you could hook it up to any search technology.
 We leave the CRUD methods of the resource alone, choosing to add a new endpoint
 at ``/api/v1/notes/search/``::
 
-    from django.conf.urls import url, patterns, include
+    from django.conf.urls import url, include
     from django.core.paginator import Paginator, InvalidPage
     from django.http import Http404
     from haystack.query import SearchQuerySet

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,17 +72,18 @@ Quick Start
 
 4. In your root URLconf, add the following code (around where the admin code might be)::
 
+    from django.conf.urls import url, include
     from tastypie.api import Api
     from my_app.api.resources import MyModelResource
 
     v1_api = Api(api_name='v1')
     v1_api.register(MyModelResource())
 
-    urlpatterns = patterns('',
+    urlpatterns = [
       # ...more URLconf bits here...
       # Then add:
-      (r'^api/', include(v1_api.urls)),
-    )
+      url(r'^api/', include(v1_api.urls)),
+    ]
 
 5. Hit http://localhost:8000/api/v1/?format=json in your browser!
 

--- a/docs/interacting.rst
+++ b/docs/interacting.rst
@@ -45,7 +45,7 @@ We'll assume that we're interacting with the following Tastypie code::
 
 
     # urls.py
-    from django.conf.urls import url, patterns, include
+    from django.conf.urls import url, include
     from tastypie.api import Api
     from myapp.api.resources import EntryResource, UserResource
 
@@ -53,11 +53,11 @@ We'll assume that we're interacting with the following Tastypie code::
     v1_api.register(UserResource())
     v1_api.register(EntryResource())
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         # The normal jazz here...
-        (r'^blog/', include('myapp.urls')),
-        (r'^api/', include(v1_api.urls)),
-    )
+        url(r'^blog/', include('myapp.urls')),
+        url(r'^api/', include(v1_api.urls)),
+    ]
 
 Let's fire up a shell & start exploring the API!
 
@@ -556,7 +556,7 @@ presumably did not change.
 
 .. note::
 
-    A ``PUT`` request requires that the entire resource representation be enclosed. Missing fields may cause errors, or be filled in by default values. 
+    A ``PUT`` request requires that the entire resource representation be enclosed. Missing fields may cause errors, or be filled in by default values.
 
 
 Partially Updating An Existing Resource (PATCH)
@@ -694,7 +694,7 @@ We should get back::
     Content-Length: 0
     Content-Type: text/html; charset=utf-8
 
-The Accepted response means the server has accepted the request, but gives no details on the result. In order to see any created resources, we would need to do a get ``GET`` on the list endpoint. 
+The Accepted response means the server has accepted the request, but gives no details on the result. In order to see any created resources, we would need to do a get ``GET`` on the list endpoint.
 
 For detailed information on the format of a bulk request, see :ref:`patch-list`.
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -776,8 +776,7 @@ return the response traveling with the exception.
 The standard URLs this ``Resource`` should respond to. These include the
 list, detail, schema & multiple endpoints by default.
 
-Should return a list of individual URLconf lines (**NOT** wrapped in
-``patterns``).
+Should return a list of individual URLconf lines.
 
 ``override_urls``
 -----------------
@@ -795,8 +794,7 @@ instead.
 A hook for adding your own URLs or matching before the default URLs. Useful for
 adding custom endpoints or overriding the built-in ones (from ``base_urls``).
 
-Should return a list of individual URLconf lines (**NOT** wrapped in
-``patterns``).
+Should return a list of individual URLconf lines.
 
 ``urls``
 --------

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -131,16 +131,16 @@ do this, we simply instantiate the resource in our URLconf and hook up its
 ``urls``::
 
     # urls.py
-    from django.conf.urls import url, patterns, include
+    from django.conf.urls import url, include
     from myapp.api import EntryResource
 
     entry_resource = EntryResource()
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         # The normal jazz here...
-        (r'^blog/', include('myapp.urls')),
-        (r'^api/', include(entry_resource.urls)),
-    )
+        url(r'^blog/', include('myapp.urls')),
+        url(r'^api/', include(entry_resource.urls)),
+    ]
 
 Now it's just a matter of firing up server (``./manage.py runserver``) and
 going to http://127.0.0.1:8000/api/entry/?format=json. You should get back a
@@ -253,7 +253,7 @@ We'll go back to our URLconf (``urls.py``) and change it to match the
 following::
 
     # urls.py
-    from django.conf.urls import url, patterns, include
+    from django.conf.urls import url, include
     from tastypie.api import Api
     from myapp.api import EntryResource, UserResource
 
@@ -261,11 +261,11 @@ following::
     v1_api.register(UserResource())
     v1_api.register(EntryResource())
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         # The normal jazz here...
-        (r'^blog/', include('myapp.urls')),
-        (r'^api/', include(v1_api.urls)),
-    )
+        url(r'^blog/', include('myapp.urls')),
+        url(r'^api/', include(v1_api.urls)),
+    ]
 
 Note that we're now creating an :class:`~tastypie.api.Api` instance,
 registering our ``EntryResource`` and ``UserResource`` instances with it and

--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 import warnings
-from django.conf.urls import url, patterns, include
+from django.conf.urls import url, include
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseBadRequest
@@ -108,7 +108,7 @@ class Api(object):
 
         for name in sorted(self._registry.keys()):
             self._registry[name].api_name = self.api_name
-            pattern_list.append((r"^(?P<api_name>%s)/" % self.api_name, include(self._registry[name].urls)))
+            pattern_list.append(url(r"^(?P<api_name>%s)/" % self.api_name, include(self._registry[name].urls)))
 
         urlpatterns = self.prepend_urls()
 
@@ -117,7 +117,7 @@ class Api(object):
             warnings.warn("'override_urls' is a deprecated method & will be removed by v1.0.0. Please rename your method to ``prepend_urls``.")
             urlpatterns += overridden_urls
 
-        urlpatterns += patterns('', *pattern_list)
+        urlpatterns += pattern_list
         return urlpatterns
 
     def top_level(self, request, api_name=None):

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -8,7 +8,7 @@ from wsgiref.handlers import format_date_time
 
 import django
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.exceptions import ObjectDoesNotExist,\
     MultipleObjectsReturned, ValidationError
 from django.core.urlresolvers import NoReverseMatch, reverse, Resolver404,\
@@ -344,7 +344,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             urls += overridden_urls
 
         urls += self.base_urls()
-        return patterns('', *urls)
+        return urls
 
     def determine_format(self, request):
         """

--- a/tests/alphanumeric/urls.py
+++ b/tests/alphanumeric/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 
 
-urlpatterns = patterns('',
-    (r'^api/', include('alphanumeric.api.urls')),
-)
+urlpatterns = [
+    url(r'^api/', include('alphanumeric.api.urls')),
+]

--- a/tests/authorization/urls.py
+++ b/tests/authorization/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 
 from tastypie.api import Api
 
@@ -11,6 +11,6 @@ v1_api.register(AuthorProfileResource())
 v1_api.register(SiteResource())
 v1_api.register(UserResource())
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^api/', include(v1_api.urls)),
-)
+]

--- a/tests/basic/urls.py
+++ b/tests/basic/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 
 
-urlpatterns = patterns('',
-    (r'^api/', include('basic.api.urls')),
-)
+urlpatterns = [
+    url(r'^api/', include('basic.api.urls')),
+]

--- a/tests/content_gfk/urls.py
+++ b/tests/content_gfk/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 
 
-urlpatterns = patterns('',
-    (r'^api/', include('content_gfk.api.urls')),
-)
+urlpatterns = [
+    url(r'^api/', include('content_gfk.api.urls')),
+]

--- a/tests/core/tests/api_urls.py
+++ b/tests/core/tests/api_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 
 from core.tests.api import Api, NoteResource, UserResource
 
@@ -7,6 +7,6 @@ api = Api()
 api.register(NoteResource())
 api.register(UserResource())
 
-urlpatterns = patterns('',
-    (r'^api/', include(api.urls)),
-)
+urlpatterns = [
+    url(r'^api/', include(api.urls)),
+]

--- a/tests/core/tests/field_urls.py
+++ b/tests/core/tests/field_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 from tastypie import fields
 from tastypie.resources import ModelResource
 from core.models import Note, Subject
@@ -25,6 +25,6 @@ api.register(CustomNoteResource())
 api.register(UserResource())
 api.register(SubjectResource())
 
-urlpatterns = patterns('',
-    (r'^api/', include(api.urls)),
-)
+urlpatterns = [
+    url(r'^api/', include(api.urls)),
+]

--- a/tests/core/tests/manual_urls.py
+++ b/tests/core/tests/manual_urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 from core.tests.resources import NoteResource
 
 
 note_resource = NoteResource()
 
-urlpatterns = patterns('',
-    (r'^', include(note_resource.urls)),
-)
+urlpatterns = [
+    url(r'^', include(note_resource.urls)),
+]

--- a/tests/gis/urls.py
+++ b/tests/gis/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 
 
-urlpatterns = patterns('',
-    (r'^api/', include('gis.api.urls')),
-)
+urlpatterns = [
+    url(r'^api/', include('gis.api.urls')),
+]

--- a/tests/namespaced/api/urls.py
+++ b/tests/namespaced/api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from tastypie.api import NamespacedApi
 from namespaced.api.resources import NamespacedNoteResource, NamespacedUserResource
 
@@ -7,6 +7,6 @@ api = NamespacedApi(api_name='v1', urlconf_namespace='special')
 api.register(NamespacedNoteResource(), canonical=True)
 api.register(NamespacedUserResource(), canonical=True)
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^api/', include(api.urls, namespace='special')),
-)
+]

--- a/tests/profilingtests/urls.py
+++ b/tests/profilingtests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import include, url
 
 from tastypie.api import Api
 
@@ -9,6 +9,6 @@ api = Api()
 api.register(NoteResource())
 api.register(UserResource())
 
-urlpatterns = patterns('',
-    (r'^api/', include(api.urls)),
-)
+urlpatterns = [
+    url(r'^api/', include(api.urls)),
+]

--- a/tests/slashless/api/urls.py
+++ b/tests/slashless/api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from tastypie.api import Api
 from slashless.api.resources import NoteResource, UserResource
 
@@ -7,6 +7,6 @@ api = Api(api_name='v1')
 api.register(NoteResource(), canonical=True)
 api.register(UserResource(), canonical=True)
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^api/', include(api.urls)),
-)
+]

--- a/tests/validation/api/urls.py
+++ b/tests/validation/api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from tastypie.api import Api
 
@@ -11,6 +11,6 @@ api.register(NoteResource(), canonical=True)
 api.register(UserResource(), canonical=True)
 api.register(AnnotatedNoteResource(), canonical=True)
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^api/', include(api.urls)),
-)
+]


### PR DESCRIPTION
Stop using `django.conf.url.patterns`, which will be removed in Django 1.10.