### PR TITLE
Prevent muting non-tastypie's exceptions (#1297)

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -238,7 +238,9 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                 data = {"error": sanitize(e.messages)}
                 return self.error_response(request, data, response_class=http.HttpBadRequest)
             except Exception as e:
-                if hasattr(e, 'response'):
+                # Prevent muting non-django's exceptions
+                # i.e. RequestException from 'requests' library
+                if hasattr(e, 'response') and isinstance(e.response, HttpResponse):
                     return e.response
 
                 # A real, non-expected exception.

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -4478,7 +4478,7 @@ class BasicAuthResourceTestCase(TestCase):
 
 # Test out the 500 behavior.
 class YouFail(Exception):
-    pass
+    response = None
 
 
 class BustedResource(BasicResource):


### PR DESCRIPTION
Fixes #1297

Prevent muting non-tastypie's exceptions for example [`RequestException`](https://github.com/kennethreitz/requests/blob/f1fd11e54faef9045833432c8505b6681d7526bc/requests/exceptions.py#L13) from 'requests' library

When this kind of errors happens Django raises `ValueError: The view tastypie.resources.wrapper didn't return an HttpResponse object. It returned None instead.` with following stacktrace:

```python
  File "django/core/handlers/base.py", line 130, in get_response
    % (callback.__module__, view_name))
# 
# where `callback` is <function wrapper from tastypie.resources at 0x7f7abace2e60>
```

