### PR TITLE
Issue #1407: better default for DjangoAuthorization.

### DIFF
--- a/docs/release_notes/dev.rst
+++ b/docs/release_notes/dev.rst
@@ -7,4 +7,4 @@ copied to the release notes for the next release.
 Bugfixes
 --------
 
-* list of changes here
+* Updated DjangoAuthorization to disallow read unless a user has `change` permission (#1407, PR #1409)

--- a/tastypie/authorization.py
+++ b/tastypie/authorization.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-import settings
-
 from tastypie.exceptions import TastypieError, Unauthorized
 from tastypie.compat import get_module_name
 

--- a/tastypie/authorization.py
+++ b/tastypie/authorization.py
@@ -151,22 +151,14 @@ class DjangoAuthorization(Authorization):
         return model_klass
 
     def read_list(self, object_list, bundle):
-        klass = self.base_checks(bundle.request, object_list.model)
+        # By default, follows `ModelAdmin` "convention" to use `app.change_model`
+        # `django.contrib.auth.models.Permission` for both viewing and updating.
+        # https://docs.djangoproject.com/es/1.9/topics/auth/default/#permissions-and-authorization
 
-        if klass is False:
-            return []
-
-        # GET-style methods are always allowed.
-        return object_list
+        return self.update_list(object_list, bundle)
 
     def read_detail(self, object_list, bundle):
-        klass = self.base_checks(bundle.request, bundle.obj.__class__)
-
-        if klass is False:
-            raise Unauthorized("You are not allowed to access that resource.")
-
-        # GET-style methods are always allowed.
-        return True
+        return self.update_detail(object_list, bundle)
 
     def create_list(self, object_list, bundle):
         klass = self.base_checks(bundle.request, object_list.model)
@@ -263,3 +255,88 @@ class DjangoAuthorization(Authorization):
             raise Unauthorized("You are not allowed to access that resource.")
 
         return True
+
+
+class DjangoObjectAuthorization(Authorization):
+    '''
+    Uses permission checking from ``django.contrib.auth`` to map
+    ``POST / PUT / DELETE / PATCH`` to their equivalent Django auth
+    permissions.
+
+    Both the list & detail simply check the object they're based on.
+    Object level authorization api is added since django 1.5. However,
+    it will default to no-access unless an AUTHENTICATION_BACKENDS is
+    setup to handle those checks.
+    '''
+
+    # By default, follows `ModelAdmin` "convention" to use `app.change_model`
+    # `django.contrib.auth.models.Permission` for both viewing and updating.
+    # https://docs.djangoproject.com/es/1.9/topics/auth/default/#permissions-and-authorization
+    READ_PERM_CODE = getattr(settings, 'TASTYPIE_READ_PERM_CODE', 'change')
+
+    def base_checks(self, request, model_klass):
+        # If it doesn't look like a model, we can't check permissions.
+        if not model_klass or not getattr(model_klass, '_meta', None):
+            return False
+
+        # User must be logged in to check permissions.
+        if not hasattr(request, 'user'):
+            return False
+
+        return model_klass
+
+    def perm_list_checks(self, request, code, obj_list):
+        klass = self.base_checks(request, obj_list.model)
+        if klass is False:
+            raise Unauthorized("You are not allowed to access that resource.")
+
+        permission = '%s.%s_%s' % (
+            klass._meta.app_label,
+            code,
+            get_module_name(klass._meta)
+        )
+
+        if request.user.has_perm(permission, obj_list):
+            return obj_list
+
+        return obj_list.none()
+
+    def perm_obj_checks(self, request, code, obj):
+        klass = self.base_checks(request, obj.__class__)
+        if klass is False:
+            raise Unauthorized("You are not allowed to access that resource.")
+
+        permission = '%s.%s_%s' % (
+            klass._meta.app_label,
+            code,
+            get_module_name(klass._meta)
+        )
+
+        if request.user.has_perm(permission, obj):
+            return True
+
+        return False
+
+    def read_list(self, object_list, bundle):
+        return self.perm_list_checks(bundle.request, self.READ_PERM_CODE, object_list)
+
+    def read_detail(self, object_list, bundle):
+        return self.perm_obj_checks(bundle.request, self.READ_PERM_CODE, bundle.obj)
+
+    def create_list(self, object_list, bundle):
+        return self.perm_list_checks(bundle.request, 'add', object_list)
+
+    def create_detail(self, object_list, bundle):
+        return self.perm_obj_checks(bundle.request, 'add', bundle.obj)
+
+    def update_list(self, object_list, bundle):
+        return self.perm_list_checks(bundle.request, 'change', object_list)
+
+    def update_detail(self, object_list, bundle):
+        return self.perm_obj_checks(bundle.request, 'change', bundle.obj)
+
+    def delete_list(self, object_list, bundle):
+        return self.perm_list_checks(bundle.request, 'delete', object_list)
+
+    def delete_detail(self, object_list, bundle):
+        return self.perm_obj_checks(bundle.request, 'delete', bundle.obj)

--- a/tastypie/authorization.py
+++ b/tastypie/authorization.py
@@ -216,19 +216,3 @@ class DjangoAuthorization(Authorization):
 
     def delete_detail(self, object_list, bundle):
         return self.perm_obj_checks(bundle.request, 'delete', bundle.obj)
-
-
-class DjangoObjectAuthorization(DjangoAuthorization):
-    '''
-    Uses permission checking from ``django.contrib.auth`` to map
-    ``POST / PUT / DELETE / PATCH`` to their equivalent Django auth
-    permissions.
-
-    Both the list & detail simply check the object they're based on.
-    Object level authorization api is added since django 1.5. However,
-    it will default to no-access unless an AUTHENTICATION_BACKENDS is
-    setup to handle those checks.
-    '''
-
-    def check_user_perm(self, user, permission, obj_or_list):
-        return user.has_perm(permission, obj_or_list)

--- a/tastypie/authorization.py
+++ b/tastypie/authorization.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import settings
+
 from tastypie.exceptions import TastypieError, Unauthorized
 from tastypie.compat import get_module_name
 

--- a/tests/core/tests/authorization.py
+++ b/tests/core/tests/authorization.py
@@ -113,8 +113,8 @@ class DjangoAuthorizationTestCase(TestCase):
         bundle = resource.build_bundle(request=request)
 
         bundle.request.method = 'GET'
-        self.assertEqual(len(auth.read_list(resource.get_object_list(bundle.request), bundle)), 4)
-        self.assertTrue(auth.read_detail(resource.get_object_list(bundle.request)[0], bundle))
+        self.assertEqual(len(auth.read_list(resource.get_object_list(bundle.request), bundle)), 0)
+        self.assertRaises(Unauthorized, auth.read_detail, resource.get_object_list(bundle.request)[0], bundle)
 
         bundle.request.method = 'POST'
         self.assertEqual(len(auth.create_list(resource.get_object_list(bundle.request), bundle)), 0)
@@ -142,8 +142,8 @@ class DjangoAuthorizationTestCase(TestCase):
         bundle = resource.build_bundle(request=request)
 
         bundle.request.method = 'GET'
-        self.assertEqual(len(auth.read_list(resource.get_object_list(bundle.request), bundle)), 4)
-        self.assertTrue(auth.read_detail(resource.get_object_list(bundle.request)[0], bundle))
+        self.assertEqual(len(auth.read_list(resource.get_object_list(bundle.request), bundle)), 0)
+        self.assertRaises(Unauthorized, auth.read_detail, resource.get_object_list(bundle.request)[0], bundle)
 
         bundle.request.method = 'POST'
         self.assertEqual(len(auth.create_list(resource.get_object_list(bundle.request), bundle)), 4)
@@ -196,8 +196,8 @@ class DjangoAuthorizationTestCase(TestCase):
         bundle = resource.build_bundle(request=request)
 
         bundle.request.method = 'GET'
-        self.assertEqual(len(auth.read_list(resource.get_object_list(bundle.request), bundle)), 4)
-        self.assertTrue(auth.read_detail(resource.get_object_list(bundle.request)[0], bundle))
+        self.assertEqual(len(auth.read_list(resource.get_object_list(bundle.request), bundle)), 0)
+        self.assertRaises(Unauthorized, auth.read_detail, resource.get_object_list(bundle.request)[0], bundle)
 
         bundle.request.method = 'POST'
         self.assertEqual(len(auth.create_list(resource.get_object_list(bundle.request), bundle)), 0)


### PR DESCRIPTION
Fix for Issue #1407, better default for DjangoAuthorization.

Looking at `tastypie/authorization.py` (around like 133 -- master branch on 1/4/2016), the default, both `read_list` and `read_details` bypass `user.has_perm()` check, which is quite unsafe and is a bad default.

Django's Admin default is unconventional. So, I could see how it was misinterpreted.

https://docs.djangoproject.com/es/1.9/topics/auth/default/#permissions-and-authorization

    The Django admin site uses permissions as follows:
    *   ... 
    * Access to view the change list, view the “change” form and change an object is limited to users with the “change” permission for that type of object.

Essentially, "change_xyz" is the permission code for both "read" and "update". I think the better default would be following Django's Admin:
