### PR TITLE
Added error message when JSON requests cannot be deserialized

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -93,6 +93,7 @@ Contributors:
 * Yuri Govorushchenko (metametadata) for documentation fixes.
 * Guilhem Saurel (Nim65s) for a minor issue with Django 1.9
 * Jack Cushman (jcushman) for converting ResourceTestCase to ResourceTestCaseMixin.
+* John Lucas (jlucas91) for an improvement to the response for requests with invalid JSON.
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/tastypie/serializers.py
+++ b/tastypie/serializers.py
@@ -417,7 +417,7 @@ class Serializer(object):
         try:
             return json.loads(content)
         except ValueError:
-            raise BadRequest
+            raise BadRequest('Request is not valid JSON.')
 
     def to_jsonp(self, data, options=None):
         """

--- a/tests/basic/tests/views.py
+++ b/tests/basic/tests/views.py
@@ -85,6 +85,19 @@ class ViewsTestCase(TestCaseWithFixture):
             }
         )
 
+    def test_invalid_json_error(self):
+        # When the given data is not valid JSON a readable error message should be returned.
+        post_data = '{"content": "More internet memes.", "is_active": true, "title": "IT\'S OVER 9000!", "slug": "its-over",'
+
+        resp = self.client.post('/api/v1/notes/', data=post_data, content_type='application/json')
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(
+            json.loads(resp.content.decode('utf-8')),
+            {
+                "error": "Request is not valid JSON."
+            }
+        )
+
     def test_options(self):
         resp = self.client.options('/api/v1/notes/')
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
As it currently stands, if a user makes a POST/PUT request with invalidly formatted JSON they receive a response that looks something like this like this:

`{"error":""}`

which, of course, isn't very helpful! This change provides a human readable error message when invalidly formatted JSON is submitted. 

@SeanHayes Hope this helps - let me know if there's anything I can do to improve it. 