### PR TITLE
Don't modify Field instances during requests

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2350,7 +2350,7 @@ class BaseModelResource(Resource):
             if related_obj is None:
                 related_obj = bundle.related_objects_to_save.get(field_object.attribute, None)
 
-            if field_object.related_name:
+            if field_object.related_name and related_obj:
                 # this might be a reverse relation, so we need to save this
                 # model, attach it to the related object, and save the related
                 # object.


### PR DESCRIPTION
Unit test for https://github.com/django-tastypie/django-tastypie/issues/1415

Failed test for the first commit https://travis-ci.org/django-tastypie/django-tastypie/builds/103124056

Updating related resource using PATCH method causing following error:

```bash
======================================================================
ERROR: test_one_to_one_two_patches (related_resource.tests.OneToOneTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/alex/www/django-tastypie/tests/related_resource/tests.py", line 1154, in test_one_to_one_two_patches
    resp = self.resource.patch_detail(request, pk=tag2.pk)
  File "/var/alex/www/django-tastypie/tests/../tastypie/resources.py", line 1661, in patch_detail
    self.update_in_place(request, bundle, deserialized)
  File "/var/alex/www/django-tastypie/tests/../tastypie/resources.py", line 1687, in update_in_place
    return self.obj_update(bundle=original_bundle, **kwargs)
  File "/var/alex/www/django-tastypie/tests/../tastypie/resources.py", line 2214, in obj_update
    return self.save(bundle, skip_errors=skip_errors)
  File "/var/alex/www/django-tastypie/tests/../tastypie/resources.py", line 2300, in save
    self.save_related(bundle)
  File "/var/alex/www/django-tastypie/tests/../tastypie/resources.py", line 2360, in save_related
    setattr(related_obj, field_object.related_name, bundle.obj)
AttributeError: 'NoneType' object has no attribute 'tag'

----------------------------------------------------------------------
Ran 32 tests in 1.342s

FAILED (errors=1)
```