### PR TITLE
Updated Api class to build correct URLs even when api_name contains s…

### DIFF
--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import re
 import warnings
 from django.conf.urls import url, include
 from django.core.exceptions import ImproperlyConfigured
@@ -103,12 +104,12 @@ class Api(object):
         ``Resources`` beneath it.
         """
         pattern_list = [
-            url(r"^(?P<api_name>%s)%s$" % (self.api_name, trailing_slash), self.wrap_view('top_level'), name="api_%s_top_level" % self.api_name),
+            url(r"^(?P<api_name>%s)%s$" % (re.escape(self.api_name), trailing_slash), self.wrap_view('top_level'), name="api_%s_top_level" % self.api_name),
         ]
 
         for name in sorted(self._registry.keys()):
             self._registry[name].api_name = self.api_name
-            pattern_list.append(url(r"^(?P<api_name>%s)/" % self.api_name, include(self._registry[name].urls)))
+            pattern_list.append(url(r"^(?P<api_name>%s)/" % re.escape(self.api_name), include(self._registry[name].urls)))
 
         urlpatterns = self.prepend_urls()
 


### PR DESCRIPTION
…pecial chars

If api_name contains special regex chars (e.g. "3.0") -- URLs generated would be not correct regular expressions.

Need to escape it first. So that for api_name="3.0" it would change from r"^(?P<api_name>%s)3.0/$" (INVALID!) to r"^(?P<api_name>3\.0)/$".

I've also tried another approach by passing regex into api_name, i.e. api_name=r"3\.0" but it broke some other things.