### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ django-tastypie
 ===============
 
 .. image:: https://readthedocs.org/projects/django-tastypie/badge/
-    :target: https://django-tastypie.readthedocs.org/
+    :target: https://django-tastypie.readthedocs.io/
     :alt: Docs
 
 .. image:: https://travis-ci.org/django-tastypie/django-tastypie.svg
@@ -88,7 +88,7 @@ supports all CRUD operations in a RESTful way. JSON/XML/YAML support is already
 there, and it's easy to add related data/authentication/caching.
 
 You can find more in the documentation at
-http://django-tastypie.readthedocs.org/.
+https://django-tastypie.readthedocs.io/.
 
 
 Why Tastypie?
@@ -110,7 +110,7 @@ common reasons for tastypie.
 Reference Material
 ==================
 
-* https://django-tastypie.readthedocs.org/en/latest/
+* https://django-tastypie.readthedocs.io/en/latest/
 * https://github.com/django-tastypie/django-tastypie/tree/master/tests/basic shows
   basic usage of tastypie
 * http://en.wikipedia.org/wiki/REST

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -114,7 +114,7 @@ objects. Hooking it up looks like::
 
 .. _`this post`: http://www.nerdydork.com/basic-authentication-on-mod_wsgi.html
 .. _`abstract base class`: https://docs.djangoproject.com/en/dev/topics/db/models/#abstract-base-classes
-.. _`the documentation for this setting`: http://django-tastypie.readthedocs.org/en/latest/settings.html#tastypie-abstract-apikey
+.. _`the documentation for this setting`: https://django-tastypie.readthedocs.io/en/latest/settings.html#tastypie-abstract-apikey
 
 ``SessionAuthentication``
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,7 +119,7 @@ common reasons for tastypie.
 Reference Material
 ==================
 
-* https://django-tastypie.readthedocs.org/en/latest/
+* https://django-tastypie.readthedocs.io/en/latest/
 * https://github.com/django-tastypie/django-tastypie/tree/master/tests/basic shows
   basic usage of tastypie
 * http://en.wikipedia.org/wiki/REST

--- a/docs/release_notes/v0.11.0.rst
+++ b/docs/release_notes/v0.11.0.rst
@@ -11,7 +11,7 @@ This release is also the first to be released as a `Python wheel`_ as well. Ex::
     pip install wheel
     pip install --use-wheel django-tastypie
 
-.. _`Python wheel`: http://wheel.readthedocs.org/
+.. _`Python wheel`: https://wheel.readthedocs.io/
 
 
 Bugfixes

--- a/docs/release_notes/v0.9.13.rst
+++ b/docs/release_notes/v0.9.13.rst
@@ -20,12 +20,12 @@ Security hardening improvements
   restrict the set of supported formats
   (closes `#833 <https://github.com/django-tastypie/django-tastypie/pull/833>`_):
 
-  http://django-tastypie.readthedocs.org/en/v0.9.14/settings.html#tastypie-default-formats
+  https://django-tastypie.readthedocs.io/en/v0.9.14/settings.html#tastypie-default-formats
 * Content negotiation will return an error for malformed accept headers (closes `#832 <https://github.com/django-tastypie/django-tastypie/pull/832>`_)
 * The Api class itself now allows a custom serializer (closes `#817 <https://github.com/django-tastypie/django-tastypie/pull/817>`_)
 * The serialization documentation has been upgraded with security advice:
 
-    http://django-tastypie.readthedocs.org/en/v0.9.14/serialization.html#serialization-security
+    https://django-tastypie.readthedocs.io/en/v0.9.14/serialization.html#serialization-security
 
 Upgrade notes:
 

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -69,7 +69,7 @@ Here is what it looks like::
 drest
 -----
 
-http://drest.rtfd.org/
+https://drest.readthedocs.io/
 
 drest is another small Python library. It focuses on extensibility & can also
 work with many different API, with an emphasis on Tastypie.

--- a/docs/who_uses.rst
+++ b/docs/who_uses.rst
@@ -39,7 +39,7 @@ Luzme
 An e-book search site that lets you fetch pricing information.
 
 * http://luzme.com/
-* http://luzme.readthedocs.org/en/latest/
+* https://luzme.readthedocs.io/en/latest/
 
 
 Politifact
@@ -57,7 +57,7 @@ LocalWiki
 geographic communities. It's using Tastypie to provide an geospatially-aware
 REST API.
 
-* http://localwiki.readthedocs.org/en/latest/api.html
+* https://localwiki.readthedocs.io/en/latest/api.html
 * http://localwiki.org/blog/2012/aug/31/localwiki-api-released/
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.