### PR TITLE
Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - DJANGO_VERSION=dj17
   - DJANGO_VERSION=dj18
   - DJANGO_VERSION=dj19
+  - DJANGO_VERSION=dj110
   - DJANGO_VERSION=djdev
 
 matrix:

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -4,7 +4,6 @@ import django
 from django.conf import settings
 from django.contrib.auth import get_user_model  # flake8: noqa
 
-
 __all__ = ['get_user_model', 'get_username_field', 'AUTH_USER_MODEL']
 
 
@@ -20,3 +19,14 @@ def get_module_name(meta):
 
 
 atomic_decorator = django.db.transaction.atomic
+
+# Compatability for salted vs unsalted CSRF tokens;
+# Django 1.10's _sanitize_token also hashes it, so it can't be compared directly.
+# Solution is to call _sanitize_token on both tokens, then unsalt or noop both
+try:
+    from django.middleware.csrf import _unsalt_cipher_token
+    def unsalt_token(token):
+        return _unsalt_cipher_token(token)
+except ImportError:
+    def unsalt_token(token):
+        return token

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py{34,27}-djdev,
+    py{34,27}-dj110,
     py{34,27}-dj19,
     py{34,27}-dj18,
     py{34,27}-dj17,
@@ -16,17 +17,17 @@ test-executable =
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests
 commands =
-    dj{17,18,19,dev}: {[testenv]test-executable} test -p '*' core.tests --settings=settings_core
-    dj{17,18,19,dev}: {[testenv]test-executable} test basic.tests --settings=settings_basic
-    dj{17,18,19,dev}: {[testenv]test-executable} test related_resource.tests --settings=settings_related
-    dj{17,18,19,dev}: {[testenv]test-executable} test alphanumeric.tests --settings=settings_alphanumeric
-    dj{17,18,19,dev}: {[testenv]test-executable} test authorization.tests --settings=settings_authorization
-    dj{17,18,19,dev}: {[testenv]test-executable} test content_gfk.tests --settings=settings_content_gfk
-    dj{17,18,19,dev}: {[testenv]test-executable} test customuser.tests --settings=settings_customuser
-    dj{17,18,19,dev}: {[testenv]test-executable} test namespaced.tests --settings=settings_namespaced
-    dj{17,18,19,dev}: {[testenv]test-executable} test slashless.tests --settings=settings_slashless
-    dj{17,18,19,dev}: {[testenv]test-executable} test validation.tests --settings=settings_validation
-    dj{17,18,19,dev}: {[testenv]test-executable} test gis.tests --settings=settings_gis_spatialite
+    dj{17,18,19,110,dev}: {[testenv]test-executable} test -p '*' core.tests --settings=settings_core
+    dj{17,18,19,110,dev}: {[testenv]test-executable} test basic.tests --settings=settings_basic
+    dj{17,18,19,110,dev}: {[testenv]test-executable} test related_resource.tests --settings=settings_related
+    dj{17,18,19,110,dev}: {[testenv]test-executable} test alphanumeric.tests --settings=settings_alphanumeric
+    dj{17,18,19,110,dev}: {[testenv]test-executable} test authorization.tests --settings=settings_authorization
+    dj{17,18,19,110,dev}: {[testenv]test-executable} test content_gfk.tests --settings=settings_content_gfk
+    dj{17,18,19,110,dev}: {[testenv]test-executable} test customuser.tests --settings=settings_customuser
+    dj{17,18,19,110,dev}: {[testenv]test-executable} test namespaced.tests --settings=settings_namespaced
+    dj{17,18,19,110,dev}: {[testenv]test-executable} test slashless.tests --settings=settings_slashless
+    dj{17,18,19,110,dev}: {[testenv]test-executable} test validation.tests --settings=settings_validation
+    dj{17,18,19,110,dev}: {[testenv]test-executable} test gis.tests --settings=settings_gis_spatialite
 
     docs: sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
     docs: sphinx-build -W -b doctest -d {envtmpdir}/doctrees . {envtmpdir}/html
@@ -41,14 +42,15 @@ deps =
     dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
+    dj110: Django>=1.10,<1.11
     djdev: https://github.com/django/django/archive/master.tar.gz
 
-    py27-dj{17,18,19}: django-oauth-plus==2.2.8
-    py27-dj{17,18,19,dev}: python-digest
-    py27-dj{17,18,19,dev}: oauth2
-    py27-dj{17,18,19,dev}: pysqlite==2.7.0
-    py34-dj{17,18,19,dev}: python3-digest>=1.8b4
-    dj{17,18,19,dev}: -r{toxinidir}/tests/requirements.txt
+    py27-dj{17,18,19,110}: django-oauth-plus==2.2.8
+    py27-dj{17,18,19,110,dev}: python-digest
+    py27-dj{17,18,19,110,dev}: oauth2
+    py27-dj{17,18,19,110,dev}: pysqlite==2.7.0
+    py34-dj{17,18,19,110,dev}: python3-digest>=1.8b4
+    dj{17,18,19,110,dev}: -r{toxinidir}/tests/requirements.txt
 
     docs: Sphinx
     docs: Django>=1.9,<1.10

--- a/tox.ini
+++ b/tox.ini
@@ -45,8 +45,7 @@ deps =
     dj110: Django>=1.10,<1.11
     djdev: https://github.com/django/django/archive/master.tar.gz
 
-    py27-dj{17,18,19}: django-oauth-plus==2.2.8
-    py27-dj{110,dev}: django-oauth-plus==2.2.9
+    py27-dj{17,18,19}: django-oauth-plus==2.2.9
     py27-dj{17,18,19,110,dev}: python-digest
     py27-dj{17,18,19,110,dev}: oauth2
     py27-dj{17,18,19,110,dev}: pysqlite==2.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,8 @@ deps =
     dj110: Django>=1.10,<1.11
     djdev: https://github.com/django/django/archive/master.tar.gz
 
-    py27-dj{17,18,19,110}: django-oauth-plus==2.2.8
+    py27-dj{17,18,19}: django-oauth-plus==2.2.8
+    py27-dj{110,dev}: django-oauth-plus==2.2.9
     py27-dj{17,18,19,110,dev}: python-digest
     py27-dj{17,18,19,110,dev}: oauth2
     py27-dj{17,18,19,110,dev}: pysqlite==2.7.0


### PR DESCRIPTION
Adds compatibility for Django 1.10 while retaining backwards compatibility.

Issues discovered:
- Django 1.10 added a check during ModelUserBackend.is_authenticated() to disallow authentication by non-active users.  This makes tastypie's require_active flag no longer relevant while also making it basically impossible to allow non-active users to authenticate without rewriting Django's is_authenticated() method.  This invalidated some tests and also revealed some false-positive tests along the way.  Removing the tests for inactive user authentication caused coverage to drop slightly.
- Tastypie's Authenication.is_authenticated() is a bit of a mess, returning a truthy value (HttpUnauthorized) in some cases.  I feel like we should fix this to be a strictly True/False result and raise/return the HttpUnauthorized result at a higher level, which it may actually be doing already, but that's beyond the scope of this pull request.
- CSRF token handling changed slightly in Django 1.10, which broke the SessionAuthentication backend.  This required a fix via the compat module.