### PR TITLE
Fixed bug in ToOneFields when attribute is not a string

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -741,7 +741,7 @@ class ToOneField(RelatedField):
 
     def contribute_to_class(self, cls, name):
         super(ToOneField, self).contribute_to_class(cls, name)
-        if not self.related_name:
+        if not self.related_name and isinstance(self.attribute, six.string_types):
             related_field = getattr(self._resource._meta.object_class, self.attribute, None)
             if isinstance(related_field, ReverseOneToOneDescriptor):
                 # This is the case when we are writing to a reverse one to one field.

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1120,6 +1120,24 @@ class RequiredFKNoteResource(ModelResource):
         authorization = Authorization()
 
 
+class NoAttributeFKNoteResource(ModelResource):
+    editor = fields.ForeignKey(UserResource, None)
+
+    class Meta:
+        resource_name = 'noattrfknotes'
+        queryset = NoteWithEditor.objects.all()
+        authorization = Authorization()
+
+
+class FunctionAttributeFKNoteResource(ModelResource):
+    editor = fields.ForeignKey(UserResource, lambda bundle: User.objects.first(), null=True)
+
+    class Meta:
+        resource_name = 'fnattrfknotes'
+        queryset = NoteWithEditor.objects.all()
+        authorization = Authorization()
+
+
 class ThrottledNoteResource(NoteResource):
     class Meta:
         resource_name = 'throttlednotes'
@@ -1488,6 +1506,12 @@ class ModelResourceTestCase(TestCase):
 
         resource_6 = CustomPageNoteResource()
         self.assertEqual(resource_6._meta.paginator_class, CustomPaginator)
+
+        # FK fields with non-string attributes
+        resource_7 = NoAttributeFKNoteResource()
+        self.assertEqual(len(resource_7.fields), 9)
+        resource_8 = FunctionAttributeFKNoteResource()
+        self.assertEqual(len(resource_8.fields), 9)
 
     def test_can_create(self):
         resource_1 = NoteResource()


### PR DESCRIPTION
This addresses a regression introduced in af2c1d667f97a1a576e336766d7ac6245263b39d where a ToOneField with self.attribute set to None or a function would raise an exception during resource initialization.
