### PR TITLE
Fix 'initGEOS_r not found' error

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -22,7 +22,7 @@ from django.core.signals import got_request_exception
 from django.core.exceptions import ImproperlyConfigured
 try:
     from django.contrib.gis.db.models.fields import GeometryField
-except (ImproperlyConfigured, ImportError):
+except (ImproperlyConfigured, ImportError, AttributeError):
     GeometryField = None
 from django.db.models.constants import LOOKUP_SEP
 try:


### PR DESCRIPTION
The exception: "AttributeError: function 'initGEOS_r' not found" was raised even if you were not using GeoDjango.