### PR TITLE
update documentation of Advanced Filtering

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -726,7 +726,7 @@ filter the queryset before processing a request::
     from haystack.query import SearchQuerySet
 
     class MyResource(Resource):
-        def build_filters(self, filters=None):
+        def build_filters(self, filters=None, **kwargs):
             if filters is None:
                 filters = {}
 


### PR DESCRIPTION
At some point, a keyword argument "ignore_bad_filters" was added to the build_filters method. This broke custom resources that implemented build_filters with the signature given in the documentation. I have updated the documentation to reflect the possible addition of keyword arguments to build_filters.