### PR TITLE
Fix Django 2.0 deprecation warnings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -101,6 +101,7 @@ Contributors:
 * Sam Thompson(georgedorn) for fixing some docs and tests.
 * Matt Cooper (vtbassmatt) for making ApiKey better in Python 3
 * Nick Sullivan (gorillamania) for admin improvements.
+* Danny Roberts (dannyroberts) for very small change addressing noisy RemovedInDjango20Warning warnings
 
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.

--- a/docs/release_notes/dev.rst
+++ b/docs/release_notes/dev.rst
@@ -18,3 +18,4 @@ Bugfixes
 * Added `Resource.get_response_class_for_exception` hook. (Closes #1154)
 * Added UnsupportedSerializationFormat and UnsupportedDeserializationFormat exceptions, which are caught and result in HttpNotAcceptable (406 status) and HttpUnsupportedMediaType (415 status) responses, respectively. Previously these same types of errors woud have appeared as 400 BadRequest errors.
 * Fix for datetime parsing error. (#1478)
+* Gets rid of RemovedInDjango20Warning warning in Django 1.9 (Closes #1507)

--- a/tastypie/migrations/0001_initial.py
+++ b/tastypie/migrations/0001_initial.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('key', models.CharField(default='', max_length=128, db_index=True, blank=True)),
                 ('created', models.DateTimeField(default=tastypie.utils.timezone.now)),
-                ('user', models.OneToOneField(related_name='api_key', to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(related_name='api_key', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -33,7 +33,7 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
 
     @python_2_unicode_compatible
     class ApiKey(models.Model):
-        user = models.OneToOneField(AUTH_USER_MODEL, related_name='api_key')
+        user = models.OneToOneField(AUTH_USER_MODEL, related_name='api_key', on_delete=models.CASCADE)
         key = models.CharField(max_length=128, blank=True, default='', db_index=True)
         created = models.DateTimeField(default=now)
 


### PR DESCRIPTION
In Django 1.9 and before, `on_delete` defaults to `models.CASCADE`, but in Django 2.0 it will be a required argument. This PR simply adds in the argument set to its default, as suggested by this deprecation warning:

```
[...]lib/python2.7/site-packages/tastypie/models.py:35: RemovedInDjango20Warning: on_delete will be a required arg for OneToOneField in Django 2.0. Set it to models.CASCADE on models and in existing migrations if you want to maintain the current default behavior. See https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.ForeignKey.on_delete
  user = models.OneToOneField(AUTH_USER_MODEL, related_name='api_key')
```