### PR TITLE
Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,8 @@ env:
   - MODE=flake8
   - MODE=flake8-strict
   - MODE=docs
-  - DJANGO_VERSION=dj17
   - DJANGO_VERSION=dj18
-  - DJANGO_VERSION=dj19
-  - DJANGO_VERSION=dj110
+  - DJANGO_VERSION=dj111
   - DJANGO_VERSION=djdev
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       env: MODE=flake8
     - python: "3.4"
       env: MODE=flake8-strict
+    - python: "2.7"
+      env: DJANGO_VERSION=djdev
 
 addons:
   apt:

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -1,12 +1,11 @@
 from itertools import count
 import uuid
 
-from django.contrib.auth import get_user_model
 from django.db import models
 
 from tastypie.utils import now, aware_datetime
+from tastypie.compat import AUTH_USER_MODEL
 
-User = get_user_model()
 
 class DateRecord(models.Model):
     date = models.DateField()
@@ -18,7 +17,7 @@ class DateRecord(models.Model):
 
 
 class Note(models.Model):
-    author = models.ForeignKey(User, related_name='notes', blank=True, null=True)
+    author = models.ForeignKey(AUTH_USER_MODEL, related_name='notes', blank=True, null=True)
     title = models.CharField("The Title", max_length=100)
     slug = models.SlugField()
     content = models.TextField(blank=True)
@@ -48,7 +47,7 @@ class Note(models.Model):
 
 
 class NoteWithEditor(Note):
-    editor = models.ForeignKey(User, related_name='notes_edited')
+    editor = models.ForeignKey(AUTH_USER_MODEL, related_name='notes_edited')
 
     class Meta:
         app_label = 'core'

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -117,24 +117,20 @@ class MyDefaultPKModel(models.Model):
         app_label = 'core'
 
 
-if hasattr(models, 'UUIDField'):
-    class MyUUIDModel(models.Model):
-        id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-        anotheruuid = models.UUIDField(default=uuid.uuid4)
-        content = models.TextField(blank=True, default='')
-        order = models.IntegerField(default=0, blank=True)
+class MyUUIDModel(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    anotheruuid = models.UUIDField(default=uuid.uuid4)
+    content = models.TextField(blank=True, default='')
+    order = models.IntegerField(default=0, blank=True)
 
-        class Meta:
-            ordering = ('order',)
-            app_label = 'core'
+    class Meta:
+        ordering = ('order',)
+        app_label = 'core'
 
-    class MyRelatedUUIDModel(models.Model):
-        myuuidmodels = models.ManyToManyField(MyUUIDModel)
-        content = models.TextField(blank=True, default='')
 
-        class Meta:
-            app_label = 'core'
+class MyRelatedUUIDModel(models.Model):
+    myuuidmodels = models.ManyToManyField(MyUUIDModel)
+    content = models.TextField(blank=True, default='')
 
-else:
-    MyUUIDModel = None
-    MyRelatedUUIDModel = None
+    class Meta:
+        app_label = 'core'

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -1,16 +1,20 @@
 from itertools import count
 import uuid
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.db import models
 
 from tastypie.utils import now, aware_datetime
 
+User = get_user_model()
 
 class DateRecord(models.Model):
     date = models.DateField()
     username = models.CharField(max_length=20)
     message = models.CharField(max_length=20)
+
+    class Meta:
+        app_label = 'core'
 
 
 class Note(models.Model):
@@ -39,9 +43,15 @@ class Note(models.Model):
     def my_property(self):
         return 'my_property'
 
+    class Meta:
+        app_label = 'core'
+
 
 class NoteWithEditor(Note):
     editor = models.ForeignKey(User, related_name='notes_edited')
+
+    class Meta:
+        app_label = 'core'
 
 
 class Subject(models.Model):
@@ -53,6 +63,9 @@ class Subject(models.Model):
     def __unicode__(self):
         return self.name
 
+    class Meta:
+        app_label = 'core'
+
 
 class MediaBit(models.Model):
     note = models.ForeignKey(Note, related_name='media_bits')
@@ -61,6 +74,9 @@ class MediaBit(models.Model):
 
     def __unicode__(self):
         return self.title
+
+    class Meta:
+        app_label = 'core'
 
 
 class AutoNowNote(models.Model):
@@ -75,6 +91,9 @@ class AutoNowNote(models.Model):
     def __unicode__(self):
         return self.title
 
+    class Meta:
+        app_label = 'core'
+
 
 class Counter(models.Model):
     name = models.CharField(max_length=30)
@@ -84,6 +103,9 @@ class Counter(models.Model):
     def __unicode__(self):
         return self.name
 
+    class Meta:
+        app_label = 'core'
+
 
 int_source = count(1)
 
@@ -91,6 +113,9 @@ int_source = count(1)
 class MyDefaultPKModel(models.Model):
     id = models.IntegerField(primary_key=True, default=lambda: next(int_source), editable=False)
     content = models.TextField(blank=True, default='')
+
+    class Meta:
+        app_label = 'core'
 
 
 if hasattr(models, 'UUIDField'):
@@ -102,10 +127,15 @@ if hasattr(models, 'UUIDField'):
 
         class Meta:
             ordering = ('order',)
+            app_label = 'core'
 
     class MyRelatedUUIDModel(models.Model):
         myuuidmodels = models.ManyToManyField(MyUUIDModel)
         content = models.TextField(blank=True, default='')
+
+        class Meta:
+            app_label = 'core'
+
 else:
     MyUUIDModel = None
     MyRelatedUUIDModel = None

--- a/tests/core/tests/api.py
+++ b/tests/core/tests/api.py
@@ -1,6 +1,6 @@
 import json
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.http import HttpRequest
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -12,6 +12,7 @@ from tastypie.serializers import Serializer
 
 from core.models import Note
 from core.utils import adjust_schema
+User = get_user_model()
 
 
 class NoteResource(ModelResource):

--- a/tests/core/tests/authentication.py
+++ b/tests/core/tests/authentication.py
@@ -355,6 +355,7 @@ class DigestAuthenticationTestCase(TestCase):
 
 
 @skipIf(not oauth2 or not oauth_provider, "oauth provider not installed")
+@skipIf(settings.DJANGO_VERSION >= settings.DJANGO_11, 'oauth-plus not compatible with django 1.11')
 class OAuthAuthenticationTestCase(TestCase):
     fixtures = ['note_testdata.json']
 

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -3,7 +3,7 @@ from dateutil.tz import tzoffset
 from decimal import Decimal
 
 from django.db import models
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.http import HttpRequest
 
@@ -17,6 +17,7 @@ from tastypie.utils import aware_datetime
 
 from core.models import Note, Subject, MediaBit
 from core.tests.mocks import MockRequest
+User = get_user_model()
 
 
 class ApiFieldTestCase(TestCase):

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -14,7 +14,7 @@ from unittest import skipIf
 
 import django
 from django import forms
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core.exceptions import FieldError, MultipleObjectsReturned, ObjectDoesNotExist
 from django.core import mail
@@ -50,6 +50,8 @@ from core.models import (
 )
 from core.tests.mocks import MockRequest
 from core.utils import adjust_schema, SimpleHandler
+
+User = get_user_model()
 
 
 class CustomSerializer(Serializer):

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -41,6 +41,7 @@ for pytestpath in $PYTESTPATHS; do
         spatialite tastypie-spatialite.db "SELECT InitSpatialMetaData();"
     fi
     
-    ./manage_$type.py test $test_name.tests --traceback
+    echo "./manage_$type.py test $test_name.tests --traceback -t $test_name"
+    ./manage_$type.py test $test_name.tests --traceback -t $test_name
     echo; echo
 done

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,12 @@
 import os
 import sys
 
+from distutils.version import StrictVersion
+import django
+DJANGO_VERSION = StrictVersion(django.get_version())
+DJANGO_11 = StrictVersion('1.11')
+DJANGO_18 = StrictVersion('1.8')
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 ADMINS = (

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,6 +7,8 @@ ADMINS = (
     ('test@example.com', 'Mr. Test'),
 )
 
+ALLOWED_HOSTS = [u'example.com']
+
 SITE_ID = 1
 
 BASE_PATH = os.path.abspath(os.path.dirname(__file__))

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,7 +3,11 @@ import sys
 
 from distutils.version import StrictVersion
 import django
-DJANGO_VERSION = StrictVersion(django.get_version())
+django_version_string = django.get_version()
+if django_version_string.startswith('2.0.dev'):
+    DJANGO_VERSION = StrictVersion('2.0')
+else:
+    DJANGO_VERSION = StrictVersion(django.get_version())
 DJANGO_11 = StrictVersion('1.11')
 DJANGO_18 = StrictVersion('1.8')
 

--- a/tests/settings_core.py
+++ b/tests/settings_core.py
@@ -2,11 +2,13 @@ from settings import *  # flake8: noqa
 INSTALLED_APPS.append('django.contrib.sessions')
 INSTALLED_APPS.append('core')
 
-try:
-    import oauth_provider  # flake8: noqa
-    INSTALLED_APPS.append('oauth_provider')
-except ImportError:
-    pass
+
+if DJANGO_VERSION < DJANGO_11:
+    try:
+        import oauth_provider  # flake8: noqa
+        INSTALLED_APPS.append('oauth_provider')
+    except ImportError:
+        pass
 
 ROOT_URLCONF = 'core.tests.api_urls'
 MEDIA_URL = 'http://localhost:8080/media/'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{34,27}-djdev,
+    py{34}-djdev,
     py{34,27}-dj111,
     py{34,27}-dj18,
     py{34,27}-docs,

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,8 @@
 [tox]
 envlist =
     py{34,27}-djdev,
-    py{34,27}-dj110,
-    py{34,27}-dj19,
+    py{34,27}-dj111,
     py{34,27}-dj18,
-    py{34,27}-dj17,
     py{34,27}-docs,
     py27-flake8,
     py27-flake8-strict
@@ -17,17 +15,17 @@ test-executable =
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests
 commands =
-    dj{17,18,19,110,dev}: {[testenv]test-executable} test -p '*' core.tests --settings=settings_core
-    dj{17,18,19,110,dev}: {[testenv]test-executable} test basic.tests --settings=settings_basic
-    dj{17,18,19,110,dev}: {[testenv]test-executable} test related_resource.tests --settings=settings_related
-    dj{17,18,19,110,dev}: {[testenv]test-executable} test alphanumeric.tests --settings=settings_alphanumeric
-    dj{17,18,19,110,dev}: {[testenv]test-executable} test authorization.tests --settings=settings_authorization
-    dj{17,18,19,110,dev}: {[testenv]test-executable} test content_gfk.tests --settings=settings_content_gfk
-    dj{17,18,19,110,dev}: {[testenv]test-executable} test customuser.tests --settings=settings_customuser
-    dj{17,18,19,110,dev}: {[testenv]test-executable} test namespaced.tests --settings=settings_namespaced
-    dj{17,18,19,110,dev}: {[testenv]test-executable} test slashless.tests --settings=settings_slashless
-    dj{17,18,19,110,dev}: {[testenv]test-executable} test validation.tests --settings=settings_validation
-    dj{17,18,19,110,dev}: {[testenv]test-executable} test gis.tests --settings=settings_gis_spatialite
+    dj{18,111,dev}: {[testenv]test-executable} test -p '*' core.tests --settings=settings_core
+    dj{18,111,dev}: {[testenv]test-executable} test basic.tests --settings=settings_basic
+    dj{18,111,dev}: {[testenv]test-executable} test related_resource.tests --settings=settings_related
+    dj{18,111,dev}: {[testenv]test-executable} test alphanumeric.tests --settings=settings_alphanumeric
+    dj{18,111,dev}: {[testenv]test-executable} test authorization.tests --settings=settings_authorization
+    dj{18,111,dev}: {[testenv]test-executable} test content_gfk.tests --settings=settings_content_gfk
+    dj{18,111,dev}: {[testenv]test-executable} test customuser.tests --settings=settings_customuser
+    dj{18,111,dev}: {[testenv]test-executable} test namespaced.tests --settings=settings_namespaced
+    dj{18,111,dev}: {[testenv]test-executable} test slashless.tests --settings=settings_slashless
+    dj{18,111,dev}: {[testenv]test-executable} test validation.tests --settings=settings_validation
+    dj{18,111,dev}: {[testenv]test-executable} test gis.tests --settings=settings_gis_spatialite
 
     docs: sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
     docs: sphinx-build -W -b doctest -d {envtmpdir}/doctrees . {envtmpdir}/html
@@ -39,21 +37,19 @@ basepython =
     py27: python2.7
     py34: python3.4
 deps =
-    dj17: Django>=1.7,<1.8
     dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
-    dj110: Django>=1.10,<1.11
+    dj111: Django>=1.11,<1.12
     djdev: https://github.com/django/django/archive/master.tar.gz
 
-    py27-dj{17,18,19}: django-oauth-plus==2.2.9
-    py27-dj{17,18,19,110,dev}: python-digest
-    py27-dj{17,18,19,110,dev}: oauth2
-    py27-dj{17,18,19,110,dev}: pysqlite==2.7.0
-    py34-dj{17,18,19,110,dev}: python3-digest>=1.8b4
-    dj{17,18,19,110,dev}: -r{toxinidir}/tests/requirements.txt
+    py27-dj{18,111}: django-oauth-plus==2.2.9
+    py27-dj{18,111,dev}: python-digest
+    py27-dj{18,111,dev}: oauth2
+    py27-dj{18,111,dev}: pysqlite==2.7.0
+    py34-dj{18,111,dev}: python3-digest>=1.8b4
+    dj{18,111,dev}: -r{toxinidir}/tests/requirements.txt
 
     docs: Sphinx
-    docs: Django>=1.9,<1.10
+    docs: Django>=1.11,<1.12
     docs: mock
     docs: sphinx_rtd_theme
 


### PR DESCRIPTION
WIP; updating to Django 1.11.

- Remove test matrix for 1.7, 1.9; we should support the most recent version (1.11), the most recent LTE (1.8), and run tests against dev (but allowed to fail).
