### PR TITLE
Silence deprecation warnings

### DIFF
--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import warnings
 from django.conf.urls import url, include
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse, HttpResponseBadRequest
 from tastypie.exceptions import NotRegistered, BadRequest
 from tastypie.serializers import Serializer

--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -2,8 +2,8 @@ from __future__ import unicode_literals
 import warnings
 from django.conf.urls import url, include
 from django.core.exceptions import ImproperlyConfigured
-from django.urls import reverse
 from django.http import HttpResponse, HttpResponseBadRequest
+from tastypie.compat import reverse
 from tastypie.exceptions import NotRegistered, BadRequest
 from tastypie.serializers import Serializer
 from tastypie.utils import is_valid_jsonp_callback_value, string_to_python, trailing_slash

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -13,7 +13,9 @@ from django.middleware.csrf import _sanitize_token, constant_time_compare
 from django.utils.six.moves.urllib.parse import urlparse
 from django.utils.translation import ugettext as _
 
-from tastypie.compat import get_user_model, get_username_field, unsalt_token
+from tastypie.compat import (
+    get_user_model, get_username_field, unsalt_token, is_authenticated
+)
 from tastypie.http import HttpUnauthorized
 
 try:
@@ -301,11 +303,12 @@ class SessionAuthentication(Authentication):
         # wrong.
         # We also can't risk accessing ``request.POST``, which will break with
         # the serialized bodies.
+
         if request.method in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
-            return request.user.is_authenticated()
+            return is_authenticated(request.user)
 
         if getattr(request, '_dont_enforce_csrf_checks', False):
-            return request.user.is_authenticated()
+            return is_authenticated(request.user)
 
         csrf_token = _sanitize_token(request.COOKIES.get(settings.CSRF_COOKIE_NAME, ''))
 
@@ -327,7 +330,7 @@ class SessionAuthentication(Authentication):
                                      unsalt_token(csrf_token)):
             return False
 
-        return request.user.is_authenticated()
+        return is_authenticated(request.user)
 
     def get_identifier(self, request):
         """

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -4,8 +4,10 @@ import django
 from django.conf import settings
 from django.contrib.auth import get_user_model  # flake8: noqa
 
-__all__ = ['get_user_model', 'get_username_field', 'AUTH_USER_MODEL']
-
+try:
+    from django.urls import NoReverseMatch, reverse, Resolver404, get_script_prefix  # flake8: noqa
+except ImportError:  # 1.8 backwards compat
+    from django.core.urlresolvers import NoReverseMatch, reverse, Resolver404, get_script_prefix  # flake8: noqa
 
 AUTH_USER_MODEL = settings.AUTH_USER_MODEL
 

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -9,8 +9,19 @@ try:
 except ImportError:  # 1.8 backwards compat
     from django.core.urlresolvers import NoReverseMatch, reverse, Resolver404, get_script_prefix  # flake8: noqa
 
+
 AUTH_USER_MODEL = settings.AUTH_USER_MODEL
 
+
+def is_authenticated(user):
+    """
+    Django is changing User.is_authenticated into a property.  Calling it
+    will be deprecated by Django 2.0 and a warning in 1.10+.
+    """
+    auth = user.is_authenticated
+    if django.VERSION < (1, 10):
+        return auth()
+    return auth()
 
 def get_username_field():
     return get_user_model().USERNAME_FIELD

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -15,7 +15,6 @@ from django.conf.urls import url
 from django.core.exceptions import (
     ObjectDoesNotExist, MultipleObjectsReturned, ValidationError,
 )
-from django.urls import NoReverseMatch, reverse, Resolver404, get_script_prefix
 from django.core.signals import got_request_exception
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.fields.related import ForeignKey
@@ -41,6 +40,7 @@ from tastypie.authentication import Authentication
 from tastypie.authorization import ReadOnlyAuthorization
 from tastypie.bundle import Bundle
 from tastypie.cache import NoCache
+from tastypie.compat import NoReverseMatch, reverse, Resolver404, get_script_prefix
 from tastypie.constants import ALL, ALL_WITH_RELATIONS
 from tastypie.exceptions import (
     NotFound, BadRequest, InvalidFilterError, HydrationError, InvalidSortError,

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1839,7 +1839,7 @@ class BaseModelResource(Resource):
         if isinstance(field, ForeignKey):
             return True
         # Ignore certain fields (related fields).
-        if getattr(field, 'rel'):
+        if getattr(field, 'remote_field'):
             return True
 
         return False

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -15,11 +15,10 @@ from django.conf.urls import url
 from django.core.exceptions import (
     ObjectDoesNotExist, MultipleObjectsReturned, ValidationError,
 )
-from django.core.urlresolvers import (
-    NoReverseMatch, reverse, Resolver404, get_script_prefix
-)
+from django.urls import NoReverseMatch, reverse, Resolver404, get_script_prefix
 from django.core.signals import got_request_exception
 from django.core.exceptions import ImproperlyConfigured
+from django.db.models.fields.related import ForeignKey
 try:
     from django.contrib.gis.db.models.fields import GeometryField
 except (ImproperlyConfigured, ImportError):
@@ -1837,6 +1836,8 @@ class BaseModelResource(Resource):
         Given a Django model field, return if it should be included in the
         contributed ApiFields.
         """
+        if isinstance(field, ForeignKey):
+            return True
         # Ignore certain fields (related fields).
         if getattr(field, 'rel'):
             return True

--- a/tastypie/test.py
+++ b/tastypie/test.py
@@ -1,9 +1,7 @@
 from __future__ import unicode_literals
 import time
-import warnings
 
 from django.conf import settings
-from django.test import TestCase
 from django.test.client import Client
 from django.utils.encoding import force_text
 
@@ -557,16 +555,3 @@ class ResourceTestCaseMixin(object):
         changes.
         """
         self.assertEqual(sorted(data.keys()), sorted(expected))
-
-
-class ResourceTestCase(ResourceTestCaseMixin, TestCase):
-    """
-    This class exists for backwards compatibility, from before ResourceTestCaseMixin was added.
-    It throws a deprecation warning.
-    """
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "'ResourceTestCase' is deprecated & will be removed by v1.0.0. "
-            "Please use ``ResourceTestCaseMixin`` instead. "
-            "For example: ``class MyTest(ResourceTestCaseMixin, django.test.TestCase):``.")
-        super(ResourceTestCase, self).__init__(*args, **kwargs)

--- a/tests/authorization/models.py
+++ b/tests/authorization/models.py
@@ -6,7 +6,7 @@ from tastypie.utils.timezone import now
 
 
 class AuthorProfile(models.Model):
-    user = models.OneToOneField(User, related_name='author_profile')
+    user = models.OneToOneField(User, related_name='author_profile', on_delete=models.CASCADE)
     short_bio = models.CharField(max_length=255, blank=True, default='')
     bio = models.TextField(blank=True, default='')
     # We'll use the ``sites`` the author is assigned to as a way to control

--- a/tests/authorization/tests.py
+++ b/tests/authorization/tests.py
@@ -3,7 +3,8 @@ import mock
 
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
-from tastypie.test import ResourceTestCase
+from django.test import TestCase
+from tastypie.test import ResourceTestCaseMixin
 from .models import AuthorProfile, Article
 from .api.resources import PerUserAuthorization
 
@@ -15,7 +16,7 @@ def ret_false(*args):
     return False
 
 
-class PerUserAuthorizationTestCase(ResourceTestCase):
+class PerUserAuthorizationTestCase(ResourceTestCaseMixin, TestCase):
     def setUp(self):
         super(PerUserAuthorizationTestCase, self).setUp()
 

--- a/tests/content_gfk/models.py
+++ b/tests/content_gfk/models.py
@@ -22,6 +22,6 @@ class Rating(models.Model):
     RATINGS = [(x, x) for x in range(1, 6)]
 
     rating = models.PositiveIntegerField(choices=RATINGS, default=3)
-    content_type = models.ForeignKey(ContentType)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey('content_type', 'object_id')

--- a/tests/manage_alphanumeric.py
+++ b/tests/manage_alphanumeric.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_alphanumeric")

--- a/tests/manage_authorization.py
+++ b/tests/manage_authorization.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_authorization")

--- a/tests/manage_basic.py
+++ b/tests/manage_basic.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_basic")

--- a/tests/manage_content_gfk.py
+++ b/tests/manage_content_gfk.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_content_gfk")

--- a/tests/manage_core.py
+++ b/tests/manage_core.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_core")

--- a/tests/manage_customuser.py
+++ b/tests/manage_customuser.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_customuser")

--- a/tests/manage_gis.py
+++ b/tests/manage_gis.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_gis")

--- a/tests/manage_gis_spatialite.py
+++ b/tests/manage_gis_spatialite.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_gis_spatialite")

--- a/tests/manage_namespaced.py
+++ b/tests/manage_namespaced.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_namespaced")

--- a/tests/manage_profilingtests.py
+++ b/tests/manage_profilingtests.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_profilingtests")

--- a/tests/manage_related.py
+++ b/tests/manage_related.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_related")

--- a/tests/manage_slashless.py
+++ b/tests/manage_slashless.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_slashless")

--- a/tests/manage_validation.py
+++ b/tests/manage_validation.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import os
 import sys
+import warnings
+warnings.simplefilter('always')
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings_validation")

--- a/tests/related_resource/models.py
+++ b/tests/related_resource/models.py
@@ -132,7 +132,7 @@ class Payment(models.Model):
 
 class Post(models.Model):
     name = models.CharField(max_length=200)
-    label = models.ManyToManyField(Label, null=True)
+    label = models.ManyToManyField(Label)
 
 
 class Order(models.Model):
@@ -160,7 +160,6 @@ class Contact(models.Model):
     groups = models.ManyToManyField(
         ContactGroup,
         related_name='members',
-        null=True,
         blank=True,
         help_text="The Contact Groups this Contact belongs to."
     )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -79,6 +79,10 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+
+if DJANGO_VERSION < DJANGO_11:
+    MIDDLEWARE_CLASSES = MIDDLEWARE

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -74,7 +74,7 @@ TASTYPIE_FULL_DEBUG = False
 
 USE_TZ = True
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/tests/settings_alphanumeric.py
+++ b/tests/settings_alphanumeric.py
@@ -2,3 +2,5 @@ from settings import *  # flake8: noqa
 INSTALLED_APPS.append('alphanumeric')
 
 ROOT_URLCONF = 'alphanumeric.urls'
+
+USE_TZ = False

--- a/tests/settings_authorization.py
+++ b/tests/settings_authorization.py
@@ -4,3 +4,5 @@ INSTALLED_APPS.append('django.contrib.sites')
 INSTALLED_APPS.append('authorization')
 
 ROOT_URLCONF = 'authorization.urls'
+
+USE_TZ = False

--- a/tests/settings_basic.py
+++ b/tests/settings_basic.py
@@ -3,3 +3,5 @@ INSTALLED_APPS.append('django.contrib.sessions')
 INSTALLED_APPS.append('basic')
 
 ROOT_URLCONF = 'basic.urls'
+
+USE_TZ = False

--- a/tests/settings_gis_spatialite.py
+++ b/tests/settings_gis_spatialite.py
@@ -5,3 +5,5 @@ from settings_gis import *  # flake8: noqa
 # "InitSpatiaMetaData ()error:"table spatial_ref_sys already exists" can be ignored.
 DATABASES['default']['ENGINE'] = 'django.contrib.gis.db.backends.spatialite'
 DATABASES['default']['NAME'] = 'tastypie-spatialite.db'
+
+USE_TZ = False

--- a/tests/settings_namespaced.py
+++ b/tests/settings_namespaced.py
@@ -3,3 +3,5 @@ INSTALLED_APPS.append('basic')
 INSTALLED_APPS.append('namespaced')
 
 ROOT_URLCONF = 'namespaced.api.urls'
+
+USE_TZ = False

--- a/tests/settings_slashless.py
+++ b/tests/settings_slashless.py
@@ -6,3 +6,5 @@ ROOT_URLCONF = 'slashless.api.urls'
 
 APPEND_SLASH = False
 TASTYPIE_ALLOW_MISSING_SLASH = True
+
+USE_TZ = False

--- a/tests/settings_validation.py
+++ b/tests/settings_validation.py
@@ -3,3 +3,5 @@ INSTALLED_APPS.append('basic')
 INSTALLED_APPS.append('validation')
 
 ROOT_URLCONF = 'validation.api.urls'
+
+USE_TZ = False


### PR DESCRIPTION
- Makes warnings noisy during tests to make silencing them easier.
- Silences several deprecation warnings, as well as fixes some ancient warnings during tests.