### PR TITLE
Add explicit error when ModelResource lacks object_class and queryset

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1781,8 +1781,12 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 class ModelDeclarativeMetaclass(DeclarativeMetaclass):
     def __new__(cls, name, bases, attrs):
         meta = attrs.get('Meta')
+        # Sanity check: ModelResource needs either a queryset or object_class:
+        if meta and not hasattr(meta, 'queryset') and not hasattr(meta, 'object_class'):
+            msg = "ModelResource (%s) requires Meta.object_class or Meta.queryset"
+            raise ImproperlyConfigured(msg % name)
 
-        if meta and hasattr(meta, 'queryset'):
+        if hasattr(meta, 'queryset') and not hasattr(meta, 'object_class'):
             setattr(meta, 'object_class', meta.queryset.model)
 
         new_class = super(ModelDeclarativeMetaclass, cls).__new__(cls, name, bases, attrs)

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -16,7 +16,7 @@ import django
 from django import forms
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
-from django.core.exceptions import FieldError, MultipleObjectsReturned, ObjectDoesNotExist
+from django.core.exceptions import FieldError, MultipleObjectsReturned, ObjectDoesNotExist, ImproperlyConfigured
 from django.core import mail
 try:
     from django.urls import reverse
@@ -1609,6 +1609,16 @@ class ModelResourceTestCase(TestCase):
         self.assertEqual(annr.fields['updated'].readonly, False)
         self.assertEqual(annr.fields['updated'].unique, False)
 
+    def test_invalid_model_resource(self):
+        """
+        Test error message regarding ModelResource lacking object_class and queryset.
+        """
+        with self.assertRaises(ImproperlyConfigured) as exception_context:
+            class InvalidNoteResource(ModelResource):
+                class Meta:
+                    resource_name = 'invalidnotes'
+        self.assertTrue('InvalidNoteResource' in exception_context.exception.message)
+
     def test_fields__empty_list(self):
         class EmptyFieldsNoteResource(ModelResource):
             class Meta:
@@ -1627,9 +1637,10 @@ class ModelResourceTestCase(TestCase):
                 object_class = Note
 
         class EmptyFieldsNoteResource(FieldsNotSpecifiedNoteResource):
-            class Meta:
+            class Meta(FieldsNotSpecifiedNoteResource.Meta):
                 resource_name = 'emptyfieldsnotes'
                 fields = []
+                
 
         resource = EmptyFieldsNoteResource(api_name='v1')
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1640,7 +1640,6 @@ class ModelResourceTestCase(TestCase):
             class Meta(FieldsNotSpecifiedNoteResource.Meta):
                 resource_name = 'emptyfieldsnotes'
                 fields = []
-                
 
         resource = EmptyFieldsNoteResource(api_name='v1')
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1617,7 +1617,7 @@ class ModelResourceTestCase(TestCase):
             class InvalidNoteResource(ModelResource):
                 class Meta:
                     resource_name = 'invalidnotes'
-        self.assertTrue('InvalidNoteResource' in exception_context.exception.message)
+        self.assertTrue('InvalidNoteResource' in str(exception_context.exception))
 
     def test_fields__empty_list(self):
         class EmptyFieldsNoteResource(ModelResource):


### PR DESCRIPTION
Addresses recurring not-a-bugs:
#1475, #1517

Note that there's no exception for abstract ModelResource base classes; tastypie doesn't really implement those yet.  I plan to address that in a future PR; for now, they should just set `Meta.queryset = None` and/or `Meta.object_list = None` for now.