### PR TITLE
Abstract resources

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -631,10 +631,10 @@ The inner ``Meta`` class allows for class-level configuration of how the
 ``abstract``
 ------------
 
-  In concrete ``Resource`` and ``ModelResource`` instances, ``object_class`` or
-  ``queryset`` are required parameters.  If you wish to build an abstract base
-  ``Resource`` class, you can bypass this requirement by setting ``abstract``
-  to ``True``.
+  In concrete ``Resource`` and ``ModelResource`` instances, either 
+  ``object_class`` or ``queryset`` is required.
+  If you wish to build an abstract base ``Resource`` class, you can bypass 
+  this requirement by setting ``abstract`` to ``True``.
 
 ``fields``
 ----------

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -628,6 +628,14 @@ The inner ``Meta`` class allows for class-level configuration of how the
   the ``Meta`` class is instantiated). This especially affects things that
   are date/time related. Please see the :doc:`cookbook` for a way around this.
 
+``abstract``
+------------
+
+  In concrete ``Resource`` and ``ModelResource`` instances, ``object_class`` or
+  ``queryset`` are required parameters.  If you wish to build an abstract base
+  ``Resource`` class, you can bypass this requirement by setting ``abstract``
+  to ``True``.
+
 ``fields``
 ----------
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -154,6 +154,8 @@ class DeclarativeMetaclass(type):
         attrs['declared_fields'] = declared_fields
         new_class = super(DeclarativeMetaclass, cls).__new__(cls, name, bases, attrs)
         opts = getattr(new_class, 'Meta', None)
+        if getattr(opts, 'abstract', False):
+            return new_class
         new_class._meta = ResourceOptions(opts)
 
         if not getattr(new_class._meta, 'resource_name', None):
@@ -1781,6 +1783,10 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
 class ModelDeclarativeMetaclass(DeclarativeMetaclass):
     def __new__(cls, name, bases, attrs):
         meta = attrs.get('Meta')
+        if getattr(meta, 'abstract', False):
+            # abstract resources do nothing on declaration
+            return super(ModelDeclarativeMetaclass, cls).__new__(cls, name, bases, attrs)
+        
         # Sanity check: ModelResource needs either a queryset or object_class:
         if meta and not hasattr(meta, 'queryset') and not hasattr(meta, 'object_class'):
             msg = "ModelResource (%s) requires Meta.object_class or Meta.queryset"

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -165,14 +165,15 @@ class DeclarativeMetaclass(type):
             new_class._meta.resource_name = resource_name
 
         if getattr(new_class._meta, 'include_resource_uri', True):
-            if 'resource_uri' not in new_class.base_fields and not abstract:
+            if 'resource_uri' not in new_class.base_fields:
                 new_class.base_fields['resource_uri'] = fields.CharField(readonly=True, verbose_name="resource uri")
         elif 'resource_uri' in new_class.base_fields and 'resource_uri' not in attrs:
             del(new_class.base_fields['resource_uri'])
 
         if abstract and 'resource_uri' not in attrs:
             # abstract classes don't have resource_uris unless explicitly provided
-            del(new_class.base_fields['resource_uri'])
+            if 'resource_uri' in new_class.base_fields:
+                del(new_class.base_fields['resource_uri'])
 
         for field_name, field_object in new_class.base_fields.items():
             if hasattr(field_object, 'contribute_to_class'):

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1641,6 +1641,7 @@ class ModelResourceTestCase(TestCase):
             class Meta(FieldsNotSpecifiedNoteResource.Meta):
                 resource_name = 'emptyfieldsnotes'
                 fields = []
+                
 
         resource = EmptyFieldsNoteResource(api_name='v1')
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1628,8 +1628,8 @@ class ModelResourceTestCase(TestCase):
         class AbstractNoteResource(ModelResource):
             class Meta:
                 abstract = True
+
         # AbstractNoteResource should have none of the dynamic attributes generated on declaration
-        print AbstractNoteResource.base_fields
         for attr in ('object_class', 'queryset', 'fields', 'base_fields', 'absolute_url'):
             self.assertFalse(getattr(AbstractNoteResource, attr, False),
                              "AbstractNoteResource has non-falsey %s" % attr)

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1655,7 +1655,6 @@ class ModelResourceTestCase(TestCase):
             class Meta(FieldsNotSpecifiedNoteResource.Meta):
                 resource_name = 'emptyfieldsnotes'
                 fields = []
-                
 
         resource = EmptyFieldsNoteResource(api_name='v1')
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1634,6 +1634,43 @@ class ModelResourceTestCase(TestCase):
             self.assertFalse(getattr(AbstractNoteResource, attr, False),
                              "AbstractNoteResource has non-falsey %s" % attr)
 
+    def test_abstract_resource_subclass_good(self):
+        """
+        Subclassing an abstract base resource should work as expected.
+        """
+        class AbstractNoteResource(ModelResource):
+            class Meta:
+                abstract = True
+
+        class ConcreteNoteResource(AbstractNoteResource):
+            class Meta:
+                queryset = Note.objects.all()
+        resource = ConcreteNoteResource(api_name='v1')
+        resource_fields = set(resource.fields.keys())
+        self.assertEqual(resource_fields, {
+            'updated',
+            'title',
+            'created',
+            'is_active',
+            'id',
+            'content',
+            'slug',
+            'resource_uri',
+        })
+
+    def test_abstract_resource_subclass_bad(self):
+        """
+        Subclassing an abstract base resource requires model_class or queryset.
+        """
+        class AbstractNoteResource(ModelResource):
+            class Meta:
+                abstract = True
+
+        with self.assertRaises(ImproperlyConfigured):
+            class ConcreteNoteResource(AbstractNoteResource):
+                class Meta:
+                    fields = []
+
     def test_fields__empty_list(self):
         class EmptyFieldsNoteResource(ModelResource):
             class Meta:

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1620,6 +1620,20 @@ class ModelResourceTestCase(TestCase):
                     resource_name = 'invalidnotes'
         self.assertTrue('InvalidNoteResource' in str(exception_context.exception))
 
+    def test_abstract_model_resource(self):
+        """
+        Abstract ModelResource classes don't require object_class or queryset,
+        should skip populating fields and url details.
+        """
+        class AbstractNoteResource(ModelResource):
+            class Meta:
+                abstract = True
+        # AbstractNoteResource should have none of the dynamic attributes generated on declaration
+        print AbstractNoteResource.base_fields
+        for attr in ('object_class', 'queryset', 'fields', 'base_fields', 'absolute_url'):
+            self.assertFalse(getattr(AbstractNoteResource, attr, False),
+                             "AbstractNoteResource has non-falsey %s" % attr)
+
     def test_fields__empty_list(self):
         class EmptyFieldsNoteResource(ModelResource):
             class Meta:


### PR DESCRIPTION
Implement abstract ModelResources (partly to bypass `object_class` and `queryset` requirements.)

This came out of a prior change to more explicitly detect ModelResources lacking those attributes - the example cases were due to users creating abstract Resources and inheriting from them.