### PR TITLE
Add validate_jsonp doctests to core suite

### DIFF
--- a/tests/core/tests/__init__.py
+++ b/tests/core/tests/__init__.py
@@ -1,5 +1,6 @@
 import warnings
 warnings.simplefilter('ignore', Warning)
+import doctest
 
 from core.tests.api import *  # flake8: noqa
 from core.tests.authentication import *  # flake8: noqa
@@ -14,3 +15,11 @@ from core.tests.serializers import *  # flake8: noqa
 from core.tests.throttle import *  # flake8: noqa
 from core.tests.utils import *  # flake8: noqa
 from core.tests.validation import *  # flake8: noqa
+
+
+# Explicitly add doctests to suite; Django's test runner stopped
+# running them automatically around version 1.6
+def load_tests(loader, tests, ignore):
+    from tastypie.utils import validate_jsonp
+    tests.addTests(doctest.DocTestSuite(validate_jsonp))
+    return tests


### PR DESCRIPTION
Found unexecuted doctests for validating the jsonp callback while researching #1500 part 1;  Explicitly added them to the ``core`` test run.