### PR TITLE
Catch ImmediateHttpResponse to collect 'not found' objects. Because t…

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1770,7 +1770,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
                 bundle = self.build_bundle(obj=obj, request=request)
                 bundle = self.full_dehydrate(bundle, for_list=True)
                 objects.append(bundle)
-            except (ObjectDoesNotExist, Unauthorized):
+            except (ObjectDoesNotExist, Unauthorized, ImmediateHttpResponse):
                 not_found.append(identifier)
 
         object_list = {


### PR DESCRIPTION
Catch ImmediateHttpResponse to collect 'not found' objects. Because the Tastypie methods raise this Exception instead of Unauthorized (See method: unauthorized_result() ).

The problem here is:

1. The method _get_multiple()_ contains an unauthorized object.

2. The method _authorized_read_detail()_ raise an Unauthorized Exception, that is catched by the method _unauthorized_result()_.

3. That method raise an ImmediateHttpResponse.

4. So that exception won't be catched by  _get_multiple()_ because it waits NotFound or Unauthorized, but not ImmediateHttpResponse Exception.

With this change, the unauthorized objects will be added to "not_found" list.


*Navega, Software Developer at Appfluence.