### PR TITLE
Deal with bare except statements. See #1540.

### DIFF
--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -76,7 +76,7 @@ class Authentication(object):
 
         try:
             auth_type, data = authorization.split(' ', 1)
-        except:
+        except ValueError:
             raise ValueError('Authorization header must have a space separating auth_type and data.')
 
         if auth_type.lower() != self.auth_type:

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2262,7 +2262,7 @@ class BaseModelResource(Resource):
         if bundle_detail_data is None or (arg_detail_data is not None and str(bundle_detail_data) != str(arg_detail_data)):
             try:
                 lookup_kwargs = self.lookup_kwargs_with_identifiers(bundle, kwargs)
-            except:
+            except:  # flake8: noqa
                 # if there is trouble hydrating the data, fall back to just
                 # using kwargs by itself (usually it only contains a "pk" key
                 # and this will work fine.

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -827,7 +827,7 @@ class ResourceTestCase(TestCase):
         # Allowed (single).
         try:
             basic.is_authenticated(request)
-        except:
+        except ImmediateHttpResponse:
             self.fail()
 
     def test_create_response(self):
@@ -4501,10 +4501,8 @@ class ModelResourceTestCase(TestCase):
         note = NoteResource()
         bundle = Bundle(data={})
 
-        try:
-            note.is_valid(bundle)
-        except:
-            self.fail("Stock 'is_valid' should pass without exception.")
+        note_is_valid = note.is_valid(bundle)
+        self.assertTrue(note_is_valid, "Stock 'is_valid' should return True.")
 
         # An actual form.
         class NoteForm(forms.Form):


### PR DESCRIPTION
Notes about the changes:

* `tastypie.authentication.Authentication.get_authorization_data` change

    This is about re-raising the ValueError with a custom message in case of
    .split() returning one item (instead of two). Made it explicit.

* `tastypie.resources.BaseModelResource.obj_update` change

    I left this as is, because pinpointing **all the possible exceptions** that
    may be raised during data hydration is error-prone. "# flake8: noqa"
    prevents flake8 error.

* `tests.core.tests.resources.ResourceTestCase.test_auth_check` change

    BasicResource.is_authenticated() (without a custom authentication defined
    in "meta") can only raise ImmediateHttpResponse exception. Catch it
    explicitly.

* `tests.core.tests.resources.ModelResourceTestCase.test_is_valid` change

    Current implementation of Resource.is_valid() won't -- in case of errors --
    raise an exception, but will return False. Changed the test to check for
    that.