### PR TITLE
Raise an error if a model doesn't have an attribute

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -856,6 +856,7 @@ class ToManyField(RelatedField):
         if the_m2ms is None:
             if not self.null:
                 raise ApiFieldError("The model '%r' has an empty attribute '%s' and doesn't allow a null value." % (previous_obj, attr))
+            raise ApiFieldError("The model '%r' does not have the attribute '%s'", (previous_obj, attr))
 
         if isinstance(the_m2ms, models.Manager):
             the_m2ms = the_m2ms.all()


### PR DESCRIPTION
This PR addresses the issue https://github.com/django-tastypie/django-tastypie/issues/1537

Description of the problem
====================

As explained in the issue, in version 0.14.0 this bug was introduced. I just restored the previous status of the code.