### PR TITLE
Fix for ToManyField.dehydrate with a null value regression.

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -856,6 +856,7 @@ class ToManyField(RelatedField):
         if the_m2ms is None:
             if not self.null:
                 raise ApiFieldError("The model '%r' has an empty attribute '%s' and doesn't allow a null value." % (previous_obj, attr))
+            return []
 
         if isinstance(the_m2ms, models.Manager):
             the_m2ms = the_m2ms.all()

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -782,6 +782,13 @@ class ToOneFieldTestCase(TestCase):
         field_1 = ToOneField(UserResource, 'author', full=True, full_detail=False)
         self.assertEqual(field_1.dehydrate(bundle, for_list=False), '/api/v1/users/1/')
 
+    def test_dehydrate_bad_attribute(self):
+        note = Note.objects.get(pk=1)
+        bundle = Bundle(obj=note)
+        field_1 = ToManyField(UserResource, 'bad_attribute_name')
+        with self.assertRaises(ApiFieldError):
+            field_1.dehydrate(bundle)
+
     def test_hydrate(self):
         note = Note()
         bundle = Bundle(obj=note)

--- a/tests/core/tests/fields.py
+++ b/tests/core/tests/fields.py
@@ -763,6 +763,10 @@ class ToOneFieldTestCase(TestCase):
         field_3 = ToOneField(UserResource, lambda bundle: None)
         self.assertRaises(ApiFieldError, field_3.dehydrate, bundle)
 
+        # Regression: dehydrating a field with no related data and null=True should not yield exception
+        field_4 = ToManyField(UserResource, null=True, attribute=lambda bundle: None)
+        self.assertEqual(field_4.dehydrate(bundle), [])
+
     def test_dehydrate_full_detail_list(self):
         note = Note.objects.get(pk=1)
         request = MockRequest()


### PR DESCRIPTION
Probably fixes #1537 but the full extent of that issue remains unclear.  I'd like to add a test for a proper request/response (rather than the extremely simplified test of `dehydrate()`) but I am waiting for enough information in that ticket to reproduce the bug in a real-world situation.
