### PR TITLE
Get multiple in one query

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,7 +36,7 @@ Contributors:
 * Ed Summers (edsu) for a setup.py patch.
 * Sébastien Fievet (zyegfryed) for the initial OAuth implementation.
 * Jacob Kaplan-Moss (jacobkm) for the PATCH patch.
-* jorgeecardona for a patch in renaming the ``objects`` name of the response.
+* Jorge E. Cardona (jorgeecardona) for a patch in renaming the ``objects`` name of the response, and get_multiple in one query.
 * vbabiy for a patch on improved use of ``bundle.request`` & related resource validation.
 * philipn (Philip Neustrom) for GeoDjango integration.
 * dgerzo (Daniel Gerzo) for GeoDjango integration, work on PATCH and related fields, improving the ``run_all_tests.sh`` script & several smaller patches..

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1778,16 +1778,19 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
             pass
 
         if queryset is not None:
-            # Fetch the objects from the queryset.
-            not_found = set(obj_identifiers)
+            # Fetch the objects from the queryset to a dictionary.
+            objects_dict = {}
             for obj in queryset:
-                not_found.discard(str(getattr(obj, self._meta.detail_uri_name)))
-                bundle = self.build_bundle(obj=obj, request=request)
-                bundle = self.full_dehydrate(bundle, for_list=True)
-                objects.append(bundle)
+                objects_dict[str(getattr(obj, self._meta.detail_uri_name))] = obj
 
-            # Turn not_found into a list.
-            not_found = list(not_found)
+            # Walk the list of identifiers in order and get the objects or feed the not_found list.
+            for identifier in obj_identifiers:
+                if identifier in objects_dict:
+                    bundle = self.build_bundle(obj=objects_dict[identifier], request=request)
+                    bundle = self.full_dehydrate(bundle, for_list=True)
+                    objects.append(bundle)
+                else:
+                    not_found.append(identifier)
         else:
             # Use the old way.
             for identifier in obj_identifiers:

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1772,7 +1772,8 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         queryset = None
 
         try:
-            queryset = self.obj_get_list(bundle=base_bundle, **{self._meta.detail_uri_name + '__in': obj_identifiers})
+            queryset = self.obj_get_list(bundle=base_bundle).filter(
+                **{self._meta.detail_uri_name + '__in': obj_identifiers})
         except NotImplementedError:
             pass
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -3921,7 +3921,6 @@ class ModelResourceTestCase(TestCase):
 
         self.assertEqual(schema['fields'], expected_schema['fields'])
 
-        
     @patch('tastypie.resources.ModelResource.obj_get_list', side_effect=NotImplementedError)
     def test_get_multiple_without_queryset(self, obj_get_list_mock):
         resource = NoteResource()
@@ -3944,7 +3943,7 @@ class ModelResourceTestCase(TestCase):
         resp = resource.get_multiple(request, pk_list='1;2;4;6')
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content.decode('utf-8'), '{"objects": [{"content": "This is my very first post using my shiny new API. Pretty sweet, huh?", "created": "2010-03-30T20:05:00", "id": 1, "is_active": true, "resource_uri": "/api/v1/notes/1/", "slug": "first-post", "title": "First Post!", "updated": "2010-03-30T20:05:00"}, {"content": "The dog ate my cat today. He looks seriously uncomfortable.", "created": "2010-03-31T20:05:00", "id": 2, "is_active": true, "resource_uri": "/api/v1/notes/2/", "slug": "another-post", "title": "Another Post", "updated": "2010-03-31T20:05:00"}, {"content": "My neighborhood\'s been kinda weird lately, especially after the lava flow took out the corner store. Granny can hardly outrun the magma with her walker.", "created": "2010-04-01T20:05:00", "id": 4, "is_active": true, "resource_uri": "/api/v1/notes/4/", "slug": "recent-volcanic-activity", "title": "Recent Volcanic Activity.", "updated": "2010-04-01T20:05:00"}, {"content": "Man, the second eruption came on fast. Granny didn\'t have a chance. On the upshot, I was able to save her walker and I got a cool shawl out of the deal!", "created": "2010-04-02T10:05:00", "id": 6, "is_active": true, "resource_uri": "/api/v1/notes/6/", "slug": "grannys-gone", "title": "Granny\'s Gone", "updated": "2010-04-02T10:05:00"}]}')
-                
+
     def test_get_multiple(self):
         resource = NoteResource()
         request = HttpRequest()

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -1437,6 +1437,7 @@ class ModelResourceTestCase(TestCase):
     fixtures = ['note_testdata.json']
 
     def setUp(self):
+        self.maxDiff = None
         super(ModelResourceTestCase, self).setUp()
         self.note_1 = Note.objects.get(pk=1)
         self.subject_1 = Subject.objects.create(
@@ -3920,6 +3921,30 @@ class ModelResourceTestCase(TestCase):
 
         self.assertEqual(schema['fields'], expected_schema['fields'])
 
+        
+    @patch('tastypie.resources.ModelResource.obj_get_list', side_effect=NotImplementedError)
+    def test_get_multiple_without_queryset(self, obj_get_list_mock):
+        resource = NoteResource()
+        request = HttpRequest()
+        request.GET = {'format': 'json'}
+        request.method = 'GET'
+
+        resp = resource.get_multiple(request, pk_list='1')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content.decode('utf-8'), '{"objects": [{"content": "This is my very first post using my shiny new API. Pretty sweet, huh?", "created": "2010-03-30T20:05:00", "id": 1, "is_active": true, "resource_uri": "/api/v1/notes/1/", "slug": "first-post", "title": "First Post!", "updated": "2010-03-30T20:05:00"}]}')
+
+        resp = resource.get_multiple(request, pk_list='1;2')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content.decode('utf-8'), '{"objects": [{"content": "This is my very first post using my shiny new API. Pretty sweet, huh?", "created": "2010-03-30T20:05:00", "id": 1, "is_active": true, "resource_uri": "/api/v1/notes/1/", "slug": "first-post", "title": "First Post!", "updated": "2010-03-30T20:05:00"}, {"content": "The dog ate my cat today. He looks seriously uncomfortable.", "created": "2010-03-31T20:05:00", "id": 2, "is_active": true, "resource_uri": "/api/v1/notes/2/", "slug": "another-post", "title": "Another Post", "updated": "2010-03-31T20:05:00"}]}')
+
+        resp = resource.get_multiple(request, pk_list='2;3')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content.decode('utf-8'), '{"not_found": ["3"], "objects": [{"content": "The dog ate my cat today. He looks seriously uncomfortable.", "created": "2010-03-31T20:05:00", "id": 2, "is_active": true, "resource_uri": "/api/v1/notes/2/", "slug": "another-post", "title": "Another Post", "updated": "2010-03-31T20:05:00"}]}')
+
+        resp = resource.get_multiple(request, pk_list='1;2;4;6')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content.decode('utf-8'), '{"objects": [{"content": "This is my very first post using my shiny new API. Pretty sweet, huh?", "created": "2010-03-30T20:05:00", "id": 1, "is_active": true, "resource_uri": "/api/v1/notes/1/", "slug": "first-post", "title": "First Post!", "updated": "2010-03-30T20:05:00"}, {"content": "The dog ate my cat today. He looks seriously uncomfortable.", "created": "2010-03-31T20:05:00", "id": 2, "is_active": true, "resource_uri": "/api/v1/notes/2/", "slug": "another-post", "title": "Another Post", "updated": "2010-03-31T20:05:00"}, {"content": "My neighborhood\'s been kinda weird lately, especially after the lava flow took out the corner store. Granny can hardly outrun the magma with her walker.", "created": "2010-04-01T20:05:00", "id": 4, "is_active": true, "resource_uri": "/api/v1/notes/4/", "slug": "recent-volcanic-activity", "title": "Recent Volcanic Activity.", "updated": "2010-04-01T20:05:00"}, {"content": "Man, the second eruption came on fast. Granny didn\'t have a chance. On the upshot, I was able to save her walker and I got a cool shawl out of the deal!", "created": "2010-04-02T10:05:00", "id": 6, "is_active": true, "resource_uri": "/api/v1/notes/6/", "slug": "grannys-gone", "title": "Granny\'s Gone", "updated": "2010-04-02T10:05:00"}]}')
+                
     def test_get_multiple(self):
         resource = NoteResource()
         request = HttpRequest()


### PR DESCRIPTION
This solves Issue: https://github.com/django-tastypie/django-tastypie/issues/1547 in a different way that https://github.com/django-tastypie/django-tastypie/pull/701 since I use the already existing method obj_get_list to get a queryset and then filter that by the required ids.