### PR TITLE
Add support for string-path module name for GFK Resources

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,6 +103,7 @@ Contributors:
 * Danny Roberts (dannyroberts) for very small change addressing noisy RemovedInDjango20Warning warnings
 * Sam Thompson (georgedorn) for ongoing maintenance and release management.
 * Matt Briançon (mattbriancon) for various patches
+* François Dupayrat (FrancoisDupayrat) for a patch to ``GenericForeignKeyField``.
 
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.

--- a/tests/content_gfk/tests/fields.py
+++ b/tests/content_gfk/tests/fields.py
@@ -24,7 +24,7 @@ class ContentTypeFieldTestCase(TestCase):
     def test_get_related_resource(self):
         gfk_field = GenericForeignKeyField({
             Note: NoteResource,
-            Quote: QuoteResource
+            Quote: 'content_gfk.api.resources.QuoteResource'
         }, 'nofield')
 
         definition_1 = Definition.objects.create(
@@ -51,7 +51,7 @@ class ContentTypeFieldTestCase(TestCase):
 
         gfk_field = GenericForeignKeyField({
             Note: NoteResource,
-            Quote: QuoteResource
+            Quote: 'content_gfk.api.resources.QuoteResource'
         }, 'nofield')
 
         self.assertEqual(
@@ -65,7 +65,7 @@ class ContentTypeFieldTestCase(TestCase):
     def test_build_related_resource(self):
         gfk_field = GenericForeignKeyField({
             Note: NoteResource,
-            Quote: QuoteResource
+            Quote: 'content_gfk.api.resources.QuoteResource'
         }, 'nofield')
 
         quote_1 = Quote.objects.create(


### PR DESCRIPTION
Hello,

In some case, it's not possible to directly include a Resource from a GenericForeignKeyField, for example if it's self-referencing or if there are mutually dependant endpoints.

This PR add support for string-path module name in GenericForeignKeyField.to, the same way as Tastypie does for RelatedField. 

I didn't find a way to re-use RelatedField code, so instead I wrapped the relevant part in a function.
It cannot be done during __init__, because some class might not be loaded yet.

Let me know if you would like changes to the PR.