### PR TITLE
assertKeys -> use the standard assertItemsEqual

### DIFF
--- a/tastypie/test.py
+++ b/tastypie/test.py
@@ -554,4 +554,4 @@ class ResourceTestCaseMixin(object):
         fragile than testing the full structure, which can be prone to data
         changes.
         """
-        self.assertEqual(sorted(data.keys()), sorted(expected))
+        self.assertItemsEqual(data.keys(), expected)


### PR DESCRIPTION
Use standard assertItemsEqual() unittest method so that the difference
will be printed when an assertion fails