### PR TITLE
Fix/django2.1 query terms

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -13,11 +13,12 @@ import django
 from django.conf import settings
 from django.conf.urls import url
 from django.core.exceptions import (
-    ObjectDoesNotExist, MultipleObjectsReturned, ValidationError,
+    ObjectDoesNotExist, MultipleObjectsReturned, ValidationError, FieldDoesNotExist
 )
 from django.core.signals import got_request_exception
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.fields.related import ForeignKey
+from django.db import models
 try:
     from django.contrib.gis.db.models.fields import GeometryField
 except (ImproperlyConfigured, ImportError):
@@ -29,7 +30,7 @@ try:
 except ImportError:
     from django.db.models.fields.related_descriptors import\
         ReverseOneToOneDescriptor
-from django.db.models.sql.constants import QUERY_TERMS
+
 from django.http import HttpResponse, HttpResponseNotFound, Http404
 from django.utils import six
 from django.utils.cache import patch_cache_control, patch_vary_headers
@@ -2075,10 +2076,6 @@ class BaseModelResource(Resource):
 
         qs_filters = {}
 
-        query_terms = QUERY_TERMS
-        if django.VERSION >= (1, 8) and GeometryField:
-            query_terms |= set(GeometryField.class_lookups.keys())
-
         for filter_expr, value in filters.items():
             filter_bits = filter_expr.split(LOOKUP_SEP)
             field_name = filter_bits.pop(0)
@@ -2087,6 +2084,17 @@ class BaseModelResource(Resource):
             if field_name not in self.fields:
                 # It's not a field we know about. Move along citizen.
                 continue
+
+            # First-pass validation that filter could work on this field
+            try:
+                django_field_name = self.fields[field_name].attribute
+                django_field = self._meta.object_class._meta.get_field(django_field_name)
+                if hasattr(django_field, 'field'):
+                    django_field = django_field.field  # related field
+            except FieldDoesNotExist:
+                raise InvalidFilterError("The '%s' field is not a valid field name" % field_name)
+
+            query_terms = django_field.class_lookups.keys()
 
             if len(filter_bits) and filter_bits[-1] in query_terms:
                 filter_type = filter_bits.pop()

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2019,6 +2019,7 @@ class BaseModelResource(Resource):
         # Check to see if it's a relational lookup and if that's allowed.
         if len(filter_bits):
             if not getattr(self.fields[field_name], 'is_related', False):
+                print(field_name, filter_type, filter_bits)
                 raise InvalidFilterError("The '%s' field does not support relations." % field_name)
 
             if not self._meta.filtering[field_name] == ALL_WITH_RELATIONS:
@@ -2085,7 +2086,7 @@ class BaseModelResource(Resource):
                 # It's not a field we know about. Move along citizen.
                 continue
 
-            # First-pass validation that filter could work on this field
+            # Validate filter types other than 'exact' that are supported by the field type
             try:
                 django_field_name = self.fields[field_name].attribute
                 django_field = self._meta.object_class._meta.get_field(django_field_name)
@@ -2094,8 +2095,7 @@ class BaseModelResource(Resource):
             except FieldDoesNotExist:
                 raise InvalidFilterError("The '%s' field is not a valid field name" % field_name)
 
-            query_terms = django_field.class_lookups.keys()
-
+            query_terms = django_field.get_lookups().keys()
             if len(filter_bits) and filter_bits[-1] in query_terms:
                 filter_type = filter_bits.pop()
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -2102,12 +2102,18 @@ class ModelResourceTestCase(TestCase):
         resource_4 = AnotherSubjectResource()
         self.assertEqual(resource_4.build_filters(filters={'notes__user__startswith': 'Daniel'}), {'notes__author__startswith': 'Daniel'})
 
-        # Make sure that fields that don't have attributes can't be filtered on.
-        self.assertRaises(InvalidFilterError, resource_4.build_filters, filters={'notes__hello_world': 'News'})
-
         # Make sure build_filters works even on resources without queryset
         resource = NoQuerysetNoteResource()
         self.assertEqual(resource.build_filters(), {})
+
+    def test_build_filters_bad(self):
+        """
+        Test that a nonsensical filter fails validation.
+        """
+        resource = AnotherSubjectResource()
+        # Make sure that fields that don't have attributes can't be filtered on.
+        self.assertRaises(InvalidFilterError, resource.build_filters, filters={'notes__hello_world': 'News'})
+
 
     def test_custom_build_filters(self):
         """


### PR DESCRIPTION
Fix for Django 2.1 removing `QUERY_TERMS` which tastypie was relying on heavily for parsing filters.

Instead of a set of all possible operators, this change digs into the field in question, using Django's `get_lookups()` to retrieve those operators that work for the specific field.

When the field is a relation (ToMany, ToOne, etc) it inquires with the related field.  This only traverses one relation (no chaining), but TastyPie already refuses to support filters more than one layer deep.

This is a pretty big change to filtering; chances are good there are edge cases that aren't well-tested.  On the upside, this code wasn't great to begin with, and most people just use `ALL` or `ALL_WITH_RELATIONS`.

One small upside?  Custom operations will work now, if the user creates custom Django fields and specifies the lookups via `RegisterLookupMixin`.