### PR TITLE
'Fix' for upstream regression regarding non-string query params in tests

### DIFF
--- a/tastypie/paginator.py
+++ b/tastypie/paginator.py
@@ -159,11 +159,10 @@ class Paginator(object):
                 del request_params['limit']
             if 'offset' in request_params:
                 del request_params['offset']
-            request_params.update({'limit': limit, 'offset': offset})
+            request_params.update({'limit': str(limit), 'offset': str(offset)})
             encoded_params = request_params.urlencode()
         except AttributeError:
             request_params = {}
-
             for k, v in self.request_data.items():
                 if isinstance(v, six.text_type):
                     request_params[k] = v.encode('utf-8')

--- a/tests/core/tests/paginator.py
+++ b/tests/core/tests/paginator.py
@@ -268,7 +268,7 @@ class PaginatorTestCase(TestCase):
     def test_multiple(self):
         request = QueryDict('a=1&a=2')
         paginator = Paginator(request, self.data_set,
-            resource_uri='/api/v1/notes/', limit=2, offset=2)
+            resource_uri='/api/v1/notes/', limit='2', offset='2')
         meta = paginator.page()['meta']
         self.assertEqual(meta['limit'], 2)
         self.assertEqual(meta['offset'], 2)


### PR DESCRIPTION
As noted in the target branch:

This test is failing:
FAIL: test_multiple (core.tests.paginator.PaginatorTestCase)

This is due to a regression in django 2.1.  There's a fix here but it hasn't been released yet:
https://github.com/django/django/commit/d8e2be459f97f1773c7edf7d37de180139146176

Note that it says "due to lazily-written tests" and I generally agree; `QueryDict` when populated from an actual HTTP request will always be strings, not ints, and our tests should be written to reflect that.