### PR TITLE
Django 2.1: set blank=True on BooleanFields

### DIFF
--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -22,7 +22,7 @@ class Note(models.Model):
     title = models.CharField("The Title", max_length=100)
     slug = models.SlugField()
     content = models.TextField(blank=True)
-    is_active = models.BooleanField(default=True)
+    is_active = models.BooleanField(default=True, blank=True)
     created = models.DateTimeField(default=now)
     updated = models.DateTimeField(default=now)
 
@@ -86,7 +86,7 @@ class AutoNowNote(models.Model):
     title = models.CharField(max_length=100)
     slug = models.SlugField(unique=True)
     content = models.TextField(blank=True)
-    is_active = models.BooleanField(default=True)
+    is_active = models.BooleanField(default=True, blank=True)
     created = models.DateTimeField(auto_now_add=now, null=True)
     updated = models.DateTimeField(auto_now=now)
 


### PR DESCRIPTION
Django 2.1 refactored the `BooleanField` in preparation for removing the `NullBooleanField`, and along the way removed the default behavior of `blank=True`.

See https://github.com/django/django/commit/5fa4f40f45fcdbb7e48489ed3039a314b5c961d0#diff-bf776a3b8e5dbfac2432015825ef8afeL995

This PR fixes tests that really aren't about this feature by setting `blank=True` explicitly.