### PR TITLE
Fix/django2.1 cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
   - MODE=flake8
   - MODE=flake8-strict
   - MODE=docs
-  - DJANGO_VERSION=dj18
   - DJANGO_VERSION=dj111
   - DJANGO_VERSION=dj20
   - DJANGO_VERSION=dj21

--- a/docs/release_notes/dev.rst
+++ b/docs/release_notes/dev.rst
@@ -4,6 +4,12 @@ dev
 The current in-progress version. Put your notes here so they can be easily
 copied to the release notes for the next release.
 
+Major changes
+-------------
+
+* Dropped support for Django 1.8 (EOL).
+* Compatability fixes for upstream changes, most notably the removal of QUERY_TERMS.
+
 Bugfixes
 --------
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -2114,7 +2114,6 @@ class ModelResourceTestCase(TestCase):
         # Make sure that fields that don't have attributes can't be filtered on.
         self.assertRaises(InvalidFilterError, resource.build_filters, filters={'notes__hello_world': 'News'})
 
-
     def test_custom_build_filters(self):
         """
         A test derived from an example in the documentation (under Advanced Filtering).

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36}-dj{18,111,20,21,dev}
+    py{27,34,35,36}-dj{111,20,21,dev}
     py{27,36}-docs,
     py{27,36}-flake8,
     py{27,36}-flake8-strict
@@ -15,17 +15,17 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests
     PYTHONWARNINGS = always
 commands =
-    dj{18,111,20,21,dev}: {[testenv]test-executable} test -p '*' core.tests --settings=settings_core
-    dj{18,111,20,21,dev}: {[testenv]test-executable} test basic.tests --settings=settings_basic
-    dj{18,111,20,21,dev}: {[testenv]test-executable} test related_resource.tests --settings=settings_related
-    dj{18,111,20,21,dev}: {[testenv]test-executable} test alphanumeric.tests --settings=settings_alphanumeric
-    dj{18,111,20,21,dev}: {[testenv]test-executable} test authorization.tests --settings=settings_authorization
-    dj{18,111,20,21,dev}: {[testenv]test-executable} test content_gfk.tests --settings=settings_content_gfk
-    dj{18,111,20,21,dev}: {[testenv]test-executable} test customuser.tests --settings=settings_customuser
-    dj{18,111,20,21,dev}: {[testenv]test-executable} test namespaced.tests --settings=settings_namespaced
-    dj{18,111,20,21,dev}: {[testenv]test-executable} test slashless.tests --settings=settings_slashless
-    dj{18,111,20,21,dev}: {[testenv]test-executable} test validation.tests --settings=settings_validation
-    dj{18,111,20,21,dev}: {[testenv]test-executable} test gis.tests --settings=settings_gis_spatialite
+    dj{111,20,21,dev}: {[testenv]test-executable} test -p '*' core.tests --settings=settings_core
+    dj{111,20,21,dev}: {[testenv]test-executable} test basic.tests --settings=settings_basic
+    dj{111,20,21,dev}: {[testenv]test-executable} test related_resource.tests --settings=settings_related
+    dj{111,20,21,dev}: {[testenv]test-executable} test alphanumeric.tests --settings=settings_alphanumeric
+    dj{111,20,21,dev}: {[testenv]test-executable} test authorization.tests --settings=settings_authorization
+    dj{111,20,21,dev}: {[testenv]test-executable} test content_gfk.tests --settings=settings_content_gfk
+    dj{111,20,21,dev}: {[testenv]test-executable} test customuser.tests --settings=settings_customuser
+    dj{111,20,21,dev}: {[testenv]test-executable} test namespaced.tests --settings=settings_namespaced
+    dj{111,20,21,dev}: {[testenv]test-executable} test slashless.tests --settings=settings_slashless
+    dj{111,20,21,dev}: {[testenv]test-executable} test validation.tests --settings=settings_validation
+    dj{111,20,21,dev}: {[testenv]test-executable} test gis.tests --settings=settings_gis_spatialite
 
     docs: sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
     docs: sphinx-build -W -b doctest -d {envtmpdir}/doctrees . {envtmpdir}/html
@@ -39,7 +39,6 @@ basepython =
     py35: python3.5
     py36: python3.6
 deps =
-    dj18: Django>=1.8,<1.9
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2


### PR DESCRIPTION
Rollup of pre-release changes to get tests passing.

Dropping support for Django 1.8 LTS, which passed EOL back in April.