### PR TITLE
Add filter aliases resource options

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,6 +103,7 @@ Contributors:
 * Danny Roberts (dannyroberts) for very small change addressing noisy RemovedInDjango20Warning warnings
 * Sam Thompson (georgedorn) for ongoing maintenance and release management.
 * Matt Briançon (mattbriancon) for various patches
+* Jay Patel (jaypatel11) for introducing 'filter_aliases' to help create readable filter params not exposing Django models
 
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2063,6 +2063,9 @@ class BaseModelResource(Resource):
         Valid values are either a list of Django filter types (i.e.
         ``['startswith', 'exact', 'lte']``), the ``ALL`` constant or the
         ``ALL_WITH_RELATIONS`` constant.
+
+        If aliases exist for the filters in the request in 'filter_aliases', it will be replaced with the filter mapped
+        to the alias.
         """
         # At the declarative level:
         #     filtering = {

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2078,9 +2078,9 @@ class BaseModelResource(Resource):
 
         qs_filters = {}
 
-        self._map_filter_aliases(filters)
-
         for filter_expr, value in filters.items():
+
+            filter_expr = self._meta.filter_aliases.get(filter_expr, filter_expr)
             filter_bits = filter_expr.split(LOOKUP_SEP)
             field_name = filter_bits.pop(0)
             filter_type = 'exact'
@@ -2116,12 +2116,6 @@ class BaseModelResource(Resource):
             qs_filters[qs_filter] = value
 
         return dict_strip_unicode_keys(qs_filters)
-
-    def _map_filter_aliases(self, filters):
-        for alias_filter, mapped_filter in self._meta.filter_aliases.items():
-            if filters.get(alias_filter, None) is not None:
-                filters[mapped_filter] = filters[alias_filter]
-                del filters[alias_filter]
 
     def apply_sorting(self, obj_list, options=None):
         """

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -2140,7 +2140,6 @@ class ModelResourceTestCase(TestCase):
         resource_2 = AnotherSubjectResource()
         self.assertEqual(resource_2.build_filters(filters={alias_filter_name: 'Daniel'}), {actual_filter_name: 'Daniel'})
 
-
     def test_custom_build_filters(self):
         """
         A test derived from an example in the documentation (under Advanced Filtering).

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -925,6 +925,10 @@ class NoteResource(ModelResource):
             'title': ALL,
             'slug': ['exact'],
         }
+        filter_aliases = {
+            'titles': 'title__in',
+        }
+
         ordering = ['title', 'slug', 'resource_uri']
         queryset = Note.objects.filter(is_active=True)
         serializer = Serializer(formats=['json', 'jsonp', 'xml', 'yaml', 'plist'])
@@ -1226,6 +1230,9 @@ class AnotherSubjectResource(ModelResource):
         excludes = ['notes']
         filtering = {
             'notes': ALL_WITH_RELATIONS,
+        }
+        filter_aliases = {
+            'author_prefix' : 'notes__user__startswith'
         }
         authorization = Authorization()
 
@@ -2113,6 +2120,26 @@ class ModelResourceTestCase(TestCase):
         resource = AnotherSubjectResource()
         # Make sure that fields that don't have attributes can't be filtered on.
         self.assertRaises(InvalidFilterError, resource.build_filters, filters={'notes__hello_world': 'News'})
+
+    def test_build_filters_alias(self):
+        """
+        Test filter aliases are replaced with the mapped filter
+        """
+        resource_1 = NoteResource()
+        self.assertEqual(resource_1.build_filters(filters={'title__exact': 'Hello world.'}), {'title__exact': 'Hello world.'})
+
+        alias_filter_name = 'titles'
+        actual_filter_name = 'title__in'
+        self.assertEqual(resource_1.build_filters(filters={alias_filter_name: 'foo,bar'}), {actual_filter_name: ['foo', 'bar']})
+
+        unexisting_alias_filter_name = 'unexisting_alias'
+        self.assertEqual(resource_1.build_filters(filters={unexisting_alias_filter_name: 'foo'}), {})
+
+        alias_filter_name = 'author_prefix'
+        actual_filter_name = 'notes__author__startswith'
+        resource_2 = AnotherSubjectResource()
+        self.assertEqual(resource_2.build_filters(filters={alias_filter_name: 'Daniel'}), {actual_filter_name: 'Daniel'})
+
 
     def test_custom_build_filters(self):
         """


### PR DESCRIPTION
Context:
Tastypie resource allows filtering using django filters. There are scenarios where we would want to design a GET API with filters which are readable for the client and does not expose the underlying Django model. For eg. `v1/users/?posts__comments_created__gte=2015-10-21` can be simply expressed as  `v1/users/?comments_after=2015-10-21`. Right now, custom filters can be applied to such cases, but that would require overriding `build_filters` and `apply_filters`. This is where declaring an "alias" for filter like:
```
filter_aliases = {
 'comments_after' : 'posts__comments_created__gte'
}
```
would be handy