### PR TITLE
Fix for BaseModelResource.build_filters and check_filtering

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,7 +103,7 @@ Contributors:
 * Danny Roberts (dannyroberts) for very small change addressing noisy RemovedInDjango20Warning warnings
 * Sam Thompson (georgedorn) for ongoing maintenance and release management.
 * Matt Briançon (mattbriancon) for various patches
-
+* Daniel Harvey (dharvey-consbio) for various patches
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -2007,7 +2007,7 @@ class BaseModelResource(Resource):
             raise InvalidFilterError("The '%s' field does not allow filtering." % field_name)
 
         # Check to see if it's an allowed lookup type.
-        if self._meta.filtering[field_name] not in (ALL, ALL_WITH_RELATIONS):
+        if filter_type != 'exact' and self._meta.filtering[field_name] not in (ALL, ALL_WITH_RELATIONS):
             # Must be an explicit whitelist.
             if filter_type not in self._meta.filtering[field_name]:
                 raise InvalidFilterError("'%s' is not an allowed filter on the '%s' field." % (filter_type, field_name))
@@ -2015,8 +2015,16 @@ class BaseModelResource(Resource):
         if self.fields[field_name].attribute is None:
             raise InvalidFilterError("The '%s' field has no 'attribute' for searching with." % field_name)
 
-        # Check to see if it's a relational lookup and if that's allowed.
-        if len(filter_bits):
+        if len(filter_bits) == 0:
+            # Only a field provided, match with provided filter type
+            return [self.fields[field_name].attribute] + [filter_type]
+
+        elif len(filter_bits) == 1 and filter_bits[0] in self.get_query_terms(field_name):
+            # Match with valid filter type (i.e. contains, startswith, Etc.)
+            return [self.fields[field_name].attribute] + filter_bits
+
+        else:
+            # Check to see if it's a relational lookup and if that's allowed.
             if not getattr(self.fields[field_name], 'is_related', False):
                 raise InvalidFilterError("The '%s' field does not support relations." % field_name)
 
@@ -2027,9 +2035,12 @@ class BaseModelResource(Resource):
             # if any. We should ensure that all along the way, we're allowed
             # to filter on that field by the related resource.
             related_resource = self.fields[field_name].get_related_resource(None)
-            return [self.fields[field_name].attribute] + related_resource.check_filtering(filter_bits[0], filter_type, filter_bits[1:])
 
-        return [self.fields[field_name].attribute]
+            next_field_name = filter_bits[0]
+            next_filter_bits = filter_bits[1:]
+            next_filter_type = related_resource.resolve_filter_type(next_field_name, next_filter_bits, filter_type)
+
+            return [self.fields[field_name].attribute] + related_resource.check_filtering(next_field_name, next_filter_type, next_filter_bits)
 
     def filter_value_to_python(self, value, field_name, filters, filter_expr,
             filter_type):
@@ -2051,6 +2062,31 @@ class BaseModelResource(Resource):
 
         return value
 
+    def get_query_terms(self, field_name):
+        """ Helper to determine supported filter operations for a field """
+
+        try:
+            django_field_name = self.fields[field_name].attribute
+            django_field = self._meta.object_class._meta.get_field(django_field_name)
+            if hasattr(django_field, 'field'):
+                django_field = django_field.field  # related field
+        except FieldDoesNotExist:
+            raise InvalidFilterError("The '%s' field is not a valid field name" % field_name)
+
+        return django_field.get_lookups().keys()
+
+    def resolve_filter_type(self, field_name, filter_bits, default_filter_type=None):
+        """ Helper to derive filter type from next segment in filter bits """
+
+        if not filter_bits:
+            # No filter type to resolve, use default
+            return default_filter_type
+        elif filter_bits[0] not in self.get_query_terms(field_name):
+            # Not valid, maybe related field, use default
+            return default_filter_type
+        else:
+            # A valid filter type
+            return filter_bits[0]
     def build_filters(self, filters=None, ignore_bad_filters=False):
         """
         Given a dictionary of filters, create the necessary ORM-level filters.
@@ -2078,24 +2114,11 @@ class BaseModelResource(Resource):
         for filter_expr, value in filters.items():
             filter_bits = filter_expr.split(LOOKUP_SEP)
             field_name = filter_bits.pop(0)
-            filter_type = 'exact'
+            filter_type = self.resolve_filter_type(field_name, filter_bits, 'exact')
 
             if field_name not in self.fields:
                 # It's not a field we know about. Move along citizen.
                 continue
-
-            # Validate filter types other than 'exact' that are supported by the field type
-            try:
-                django_field_name = self.fields[field_name].attribute
-                django_field = self._meta.object_class._meta.get_field(django_field_name)
-                if hasattr(django_field, 'field'):
-                    django_field = django_field.field  # related field
-            except FieldDoesNotExist:
-                raise InvalidFilterError("The '%s' field is not a valid field name" % field_name)
-
-            query_terms = django_field.get_lookups().keys()
-            if len(filter_bits) and filter_bits[-1] in query_terms:
-                filter_type = filter_bits.pop()
 
             try:
                 lookup_bits = self.check_filtering(field_name, filter_type, filter_bits)
@@ -2106,8 +2129,7 @@ class BaseModelResource(Resource):
                     raise
             value = self.filter_value_to_python(value, field_name, filters, filter_expr, filter_type)
 
-            db_field_name = LOOKUP_SEP.join(lookup_bits)
-            qs_filter = "%s%s%s" % (db_field_name, LOOKUP_SEP, filter_type)
+            qs_filter = LOOKUP_SEP.join(lookup_bits)
             qs_filters[qs_filter] = value
 
         return dict_strip_unicode_keys(qs_filters)


### PR DESCRIPTION
### Summary

Addresses Issue #1618

In versions following `14.1`, Tastypie model resources no longer support related field queries in request filters. The issue lies in how the following two methods interact:

1. `BaseModelResource.build_filters` (loops over filters in request)
2. `BaseModelResource.check_filtering` (recurses to validate filters and related models)

### Details

The problem arises with requests that contain filtering data like the following:
```python
url = reverse('api_dispatch_list', args=('v1', 'base_rsrc'))
data = {'related_rsrc__related_field__startswith': 'related text'}
```
The first issue is that  `BaseModelResource.build_filters` always appends `exact` to every filter provided, which changes the provided filter to `related_rsrc__related_field__startswith__exact`. This results in this error:
> 'exact' is not an allowed filter on the 'related_field' field.

Adding "exact" to the filtering configuration for `related_field` in `related_rsrc`, still results in this:
> The 'related_field' field does not support relations.

This is because `BaseModelResource.build_filters` determines the query terms based on the first field (`related_rsrc`) and not the target field of that model (`related_field`). When `related_field` is a `CharField`, which supports `startswith`, because the recursive method `BaseModelResource.check_filtering` is not validating query terms at each level, the `startswith` portion of the filter is treated as another related resource.