### PR TITLE
Remove usages of django.conf.urls in favor of django.urls.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,6 +103,7 @@ Contributors:
 * Danny Roberts (dannyroberts) for very small change addressing noisy RemovedInDjango20Warning warnings
 * Sam Thompson (georgedorn) for ongoing maintenance and release management.
 * Matt Briançon (mattbriancon) for various patches
+* Tim Schilling (tim-schilling) for addressing deprecated django.conf.urls usages.
 
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ A basic example looks like:
 
     # urls.py
     # =======
-    from django.conf.urls import url, include
+    from django.urls import include, re_path
     from tastypie.api import Api
     from myapp.api import EntryResource
 
@@ -80,7 +80,7 @@ A basic example looks like:
 
     urlpatterns = [
         # The normal jazz here then...
-        url(r'^api/', include(v1_api.urls)),
+        re_path(r'^api/', include(v1_api.urls)),
     ]
 
 That gets you a fully working, read-write API for the ``Entry`` model that

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,7 +17,7 @@ Quick Start
 A sample api definition might look something like (usually located in a
 URLconf)::
 
-    from django.conf.urls import url, include
+    from django.urls import include, re_path
     from tastypie.api import Api
     from myapp.api.resources import UserResource, EntryResource
 
@@ -27,7 +27,7 @@ URLconf)::
 
     # Standard bits...
     urlpatterns = [
-        url(r'^api/', include(v1_api.urls)),
+        re_path(r'^api/', include(v1_api.urls)),
     ]
 
 For namespaced urls see :ref:`namespaces`

--- a/docs/code/myproject/urls.py
+++ b/docs/code/myproject/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from django.contrib import admin
 
 urlpatterns = [
     # Examples:
-    # url(r'^$', 'myproject.views.home', name='home'),
-    # url(r'^blog/', include('blog.urls')),
+    # re_path(r'^$', 'myproject.views.home', name='home'),
+    # re_path(r'^blog/', include('blog.urls')),
 
-    url(r'^admin/', include(admin.site.urls)),
+    re_path(r'^admin/', include(admin.site.urls)),
 ]

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -242,7 +242,7 @@ something like the following:
 .. testcode::
 
     # myapp/api/resources.py
-    from django.conf.urls import url
+    from django.urls import re_path
     from django.contrib.auth.models import User
 
 
@@ -253,7 +253,7 @@ something like the following:
 
         def prepend_urls(self):
             return [
-                url(r"^(?P<resource_name>%s)/(?P<username>[\w\d_.-]+)/$" % self._meta.resource_name, self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
+                re_path(r"^(?P<resource_name>%s)/(?P<username>[\w\d_.-]+)/$" % self._meta.resource_name, self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
             ]
 
 .. testoutput::
@@ -285,13 +285,13 @@ Another alternative approach is to override the ``dispatch`` method:
             return super(MyModelResource, self).dispatch(request_type, request, **kwargs)
 
     # urls.py
-    from django.conf.urls import url, include
+    from django.urls import include, re_path
 
     mymodel_resource = MyModelResource()
 
     urlpatterns = [
         # The normal jazz here, then...
-        url(r'^api/(?P<username>\w+)/', include(mymodel_resource.urls)),
+        re_path(r'^api/(?P<username>\w+)/', include(mymodel_resource.urls)),
     ]
 
 .. testoutput::
@@ -320,7 +320,7 @@ handle the children:
 
         def prepend_urls(self):
             return [
-                url(r"^(?P<resource_name>%s)/(?P<pk>\w[\w/-]*)/children%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('get_children'), name="api_get_children"),
+                re_path(r"^(?P<resource_name>%s)/(?P<pk>\w[\w/-]*)/children%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('get_children'), name="api_get_children"),
             ]
 
         def get_children(self, request, **kwargs):
@@ -350,7 +350,7 @@ approach uses Haystack_, though you could hook it up to any search technology.
 We leave the CRUD methods of the resource alone, choosing to add a new endpoint
 at ``/api/v1/notes/search/``::
 
-    from django.conf.urls import url, include
+    from django.urls import include, re_path
     from django.core.paginator import Paginator, InvalidPage
     from django.http import Http404
     from haystack.query import SearchQuerySet
@@ -366,7 +366,7 @@ at ``/api/v1/notes/search/``::
 
         def prepend_urls(self):
             return [
-                url(r"^(?P<resource_name>%s)/search%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('get_search'), name="api_get_search"),
+                re_path(r"^(?P<resource_name>%s)/search%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('get_search'), name="api_get_search"),
             ]
 
         def get_search(self, request, **kwargs):
@@ -560,10 +560,10 @@ of syntax additional to the default URL scheme:
             the response format as a file extension, e.g. /api/v1/users.json
             """
             return [
-                url(r"^(?P<resource_name>%s)\.(?P<format>\w+)$" % self._meta.resource_name, self.wrap_view('dispatch_list'), name="api_dispatch_list"),
-                url(r"^(?P<resource_name>%s)/schema\.(?P<format>\w+)$" % self._meta.resource_name, self.wrap_view('get_schema'), name="api_get_schema"),
-                url(r"^(?P<resource_name>%s)/set/(?P<pk_list>\w[\w/;-]*)\.(?P<format>\w+)$" % self._meta.resource_name, self.wrap_view('get_multiple'), name="api_get_multiple"),
-                url(r"^(?P<resource_name>%s)/(?P<pk>\w[\w/-]*)\.(?P<format>\w+)$" % self._meta.resource_name, self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
+                re_path(r"^(?P<resource_name>%s)\.(?P<format>\w+)$" % self._meta.resource_name, self.wrap_view('dispatch_list'), name="api_dispatch_list"),
+                re_path(r"^(?P<resource_name>%s)/schema\.(?P<format>\w+)$" % self._meta.resource_name, self.wrap_view('get_schema'), name="api_get_schema"),
+                re_path(r"^(?P<resource_name>%s)/set/(?P<pk_list>\w[\w/;-]*)\.(?P<format>\w+)$" % self._meta.resource_name, self.wrap_view('get_multiple'), name="api_get_multiple"),
+                re_path(r"^(?P<resource_name>%s)/(?P<pk>\w[\w/-]*)\.(?P<format>\w+)$" % self._meta.resource_name, self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
             ]
 
         def determine_format(self, request):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ Quick Start
 
 4. In your root URLconf, add the following code (around where the admin code might be)::
 
-    from django.conf.urls import url, include
+    from django.urls import include, re_path
     from tastypie.api import Api
     from my_app.api.resources import MyModelResource
 
@@ -71,7 +71,7 @@ Quick Start
     urlpatterns = [
       # ...more URLconf bits here...
       # Then add:
-      url(r'^api/', include(v1_api.urls)),
+      re_path(r'^api/', include(v1_api.urls)),
     ]
 
 5. Hit http://localhost:8000/api/v1/?format=json in your browser!

--- a/docs/interacting.rst
+++ b/docs/interacting.rst
@@ -45,7 +45,7 @@ We'll assume that we're interacting with the following Tastypie code::
 
 
     # urls.py
-    from django.conf.urls import url, include
+    from django.urls import include, re_path
     from tastypie.api import Api
     from myapp.api.resources import EntryResource, UserResource
 
@@ -55,8 +55,8 @@ We'll assume that we're interacting with the following Tastypie code::
 
     urlpatterns = [
         # The normal jazz here...
-        url(r'^blog/', include('myapp.urls')),
-        url(r'^api/', include(v1_api.urls)),
+        re_path(r'^blog/', include('myapp.urls')),
+        re_path(r'^api/', include(v1_api.urls)),
     ]
 
 Let's fire up a shell & start exploring the API!

--- a/docs/namespaces.rst
+++ b/docs/namespaces.rst
@@ -8,7 +8,7 @@ For various reasons you might want to deploy your API under a namespaced URL pat
 
 A sample definition of your API in this case would be something like::
 
-    from django.conf.urls import url, include
+    from django.urls import include, re_path
     from tastypie.api import NamespacedApi
     from my_application.api.resources import NamespacedUserResource
 
@@ -16,7 +16,7 @@ A sample definition of your API in this case would be something like::
     api.register(NamespacedUserResource())
 
     urlpatterns = [
-        url(r'^api/', include(api.urls, namespace='special')),
+        re_path(r'^api/', include(api.urls, namespace='special')),
     ]
 
 And your model resource::

--- a/docs/throttling.rst
+++ b/docs/throttling.rst
@@ -116,7 +116,7 @@ An example of this might be::
 
         def prepend_urls(self):
             return [
-                url(r"^(?P<resource_name>%s)/search%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('get_search'), name="api_get_search"),
+                re_path(r"^(?P<resource_name>%s)/search%s$" % (self._meta.resource_name, trailing_slash()), self.wrap_view('get_search'), name="api_get_search"),
             ]
 
         def search(self, request, **kwargs):

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -131,15 +131,15 @@ do this, we simply instantiate the resource in our URLconf and hook up its
 ``urls``::
 
     # urls.py
-    from django.conf.urls import url, include
+    from django.urls import include, re_path
     from myapp.api import EntryResource
 
     entry_resource = EntryResource()
 
     urlpatterns = [
         # The normal jazz here...
-        url(r'^blog/', include('myapp.urls')),
-        url(r'^api/', include(entry_resource.urls)),
+        re_path(r'^blog/', include('myapp.urls')),
+        re_path(r'^api/', include(entry_resource.urls)),
     ]
 
 Now it's just a matter of firing up server (``./manage.py runserver``) and
@@ -258,7 +258,7 @@ We'll go back to our URLconf (``urls.py``) and change it to match the
 following::
 
     # urls.py
-    from django.conf.urls import url, include
+    from django.urls import include, re_path
     from tastypie.api import Api
     from myapp.api import EntryResource, UserResource
 
@@ -268,8 +268,8 @@ following::
 
     urlpatterns = [
         # The normal jazz here...
-        url(r'^blog/', include('myapp.urls')),
-        url(r'^api/', include(v1_api.urls)),
+        re_path(r'^blog/', include('myapp.urls')),
+        re_path(r'^api/', include(v1_api.urls)),
     ]
 
 Note that we're now creating an :class:`~tastypie.api.Api` instance,

--- a/tastypie/api.py
+++ b/tastypie/api.py
@@ -1,15 +1,14 @@
 from __future__ import unicode_literals
 import warnings
-from django.conf.urls import url, include
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse, HttpResponseBadRequest
+from django.urls import include, re_path
 from tastypie.compat import reverse
 from tastypie.exceptions import NotRegistered, BadRequest
 from tastypie.serializers import Serializer
 from tastypie.utils import is_valid_jsonp_callback_value, string_to_python, trailing_slash
 from tastypie.utils.mime import determine_format, build_content_type
 from tastypie.resources import Resource
-from django.urls.conf import re_path
 
 
 class Api(object):
@@ -109,7 +108,7 @@ class Api(object):
 
         for name in sorted(self._registry.keys()):
             self._registry[name].api_name = self.api_name
-            pattern_list.append(url(r"^(?P<api_name>%s)/" % self.api_name, include(self._registry[name].urls)))
+            pattern_list.append(re_path(r"^(?P<api_name>%s)/" % self.api_name, include(self._registry[name].urls)))
 
         urlpatterns = self.prepend_urls()
 

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -10,7 +10,6 @@ import warnings
 from wsgiref.handlers import format_date_time
 
 from django.conf import settings
-from django.conf.urls import url
 from django.core.exceptions import (
     ObjectDoesNotExist, MultipleObjectsReturned, ValidationError, FieldDoesNotExist
 )
@@ -30,6 +29,7 @@ except ImportError:
         ReverseOneToOneDescriptor
 
 from django.http import HttpResponse, HttpResponseNotFound, Http404
+from django.urls import re_path
 from django.utils.cache import patch_cache_control, patch_vary_headers
 from django.utils.html import escape
 from django.views.decorators.csrf import csrf_exempt
@@ -338,10 +338,10 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         The standard URLs this ``Resource`` should respond to.
         """
         return [
-            url(r"^(?P<resource_name>%s)%s$" % (self._meta.resource_name, trailing_slash), self.wrap_view('dispatch_list'), name="api_dispatch_list"),
-            url(r"^(?P<resource_name>%s)/schema%s$" % (self._meta.resource_name, trailing_slash), self.wrap_view('get_schema'), name="api_get_schema"),
-            url(r"^(?P<resource_name>%s)/set/(?P<%s_list>.*?)%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash), self.wrap_view('get_multiple'), name="api_get_multiple"),
-            url(r"^(?P<resource_name>%s)/(?P<%s>.*?)%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash), self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
+            re_path(r"^(?P<resource_name>%s)%s$" % (self._meta.resource_name, trailing_slash), self.wrap_view('dispatch_list'), name="api_dispatch_list"),
+            re_path(r"^(?P<resource_name>%s)/schema%s$" % (self._meta.resource_name, trailing_slash), self.wrap_view('get_schema'), name="api_get_schema"),
+            re_path(r"^(?P<resource_name>%s)/set/(?P<%s_list>.*?)%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash), self.wrap_view('get_multiple'), name="api_get_multiple"),
+            re_path(r"^(?P<resource_name>%s)/(?P<%s>.*?)%s$" % (self._meta.resource_name, self._meta.detail_uri_name, trailing_slash), self.wrap_view('dispatch_detail'), name="api_dispatch_detail"),
         ]
 
     def override_urls(self):

--- a/tests/alphanumeric/urls.py
+++ b/tests/alphanumeric/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 
 urlpatterns = [
-    url(r'^api/', include('alphanumeric.api.urls')),
+    re_path(r'^api/', include('alphanumeric.api.urls')),
 ]

--- a/tests/authorization/urls.py
+++ b/tests/authorization/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import include, re_path
 
 from tastypie.api import Api
 
@@ -12,5 +12,5 @@ v1_api.register(SiteResource())
 v1_api.register(UserResource())
 
 urlpatterns = [
-    url(r'^api/', include(v1_api.urls)),
+    re_path(r'^api/', include(v1_api.urls)),
 ]

--- a/tests/basic/urls.py
+++ b/tests/basic/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 
 urlpatterns = [
-    url(r'^api/', include('basic.api.urls')),
+    re_path(r'^api/', include('basic.api.urls')),
 ]

--- a/tests/content_gfk/urls.py
+++ b/tests/content_gfk/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 
 urlpatterns = [
-    url(r'^api/', include('content_gfk.api.urls')),
+    re_path(r'^api/', include('content_gfk.api.urls')),
 ]

--- a/tests/core/tests/api_urls.py
+++ b/tests/core/tests/api_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from core.tests.api import Api, NoteResource, UserResource
 
@@ -8,5 +8,5 @@ api.register(NoteResource())
 api.register(UserResource())
 
 urlpatterns = [
-    url(r'^api/', include(api.urls)),
+    re_path(r'^api/', include(api.urls)),
 ]

--- a/tests/core/tests/manual_urls.py
+++ b/tests/core/tests/manual_urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from core.tests.resources import NoteResource
 
 
 note_resource = NoteResource()
 
 urlpatterns = [
-    url(r'^', include(note_resource.urls)),
+    re_path(r'^', include(note_resource.urls)),
 ]

--- a/tests/core/tests/resource_urls.py
+++ b/tests/core/tests/resource_urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import include, url
 from django.contrib.auth.models import User
+from django.urls import include, re_path
 from tastypie import fields
 from tastypie.resources import ModelResource
 from core.models import Note, Subject
@@ -33,5 +33,5 @@ api.register(UserResource())
 api.register(SubjectResource())
 
 urlpatterns = [
-    url(r'^api/', include(api.urls)),
+    re_path(r'^api/', include(api.urls)),
 ]

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -18,13 +18,13 @@ from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core.exceptions import FieldError, MultipleObjectsReturned, ObjectDoesNotExist, ImproperlyConfigured
 from django.core import mail
+from django.http import HttpRequest, QueryDict, Http404
+from django.test import TestCase
+from django.test.utils import override_settings
 try:
     from django.urls import reverse
 except ImportError:
     from django.core.urlresolvers import reverse
-from django.http import HttpRequest, QueryDict, Http404
-from django.test import TestCase
-from django.test.utils import override_settings
 from django.utils import timezone
 
 from tastypie.authentication import BasicAuthentication

--- a/tests/gis/urls.py
+++ b/tests/gis/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 
 urlpatterns = [
-    url(r'^api/', include('gis.api.urls')),
+    re_path(r'^api/', include('gis.api.urls')),
 ]

--- a/tests/namespaced/api/urls.py
+++ b/tests/namespaced/api/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from tastypie.api import NamespacedApi
 from namespaced.api.resources import NamespacedNoteResource, NamespacedUserResource
 
@@ -14,5 +14,5 @@ else:
     included = include(api.urls, namespace='special')
 
 urlpatterns = [
-    url(r'^api/', included),
+    re_path(r'^api/', included),
 ]

--- a/tests/profilingtests/urls.py
+++ b/tests/profilingtests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from tastypie.api import Api
 
@@ -10,5 +10,5 @@ api.register(NoteResource())
 api.register(UserResource())
 
 urlpatterns = [
-    url(r'^api/', include(api.urls)),
+    re_path(r'^api/', include(api.urls)),
 ]

--- a/tests/related_resource/tests.py
+++ b/tests/related_resource/tests.py
@@ -3,13 +3,13 @@ import json
 
 import django
 from django.contrib.auth.models import User
+from django.db.models.signals import pre_save
+from django.test.testcases import TestCase
+from django.test.utils import override_settings
 try:
     from django.urls import reverse
 except ImportError:
     from django.core.urlresolvers import reverse
-from django.db.models.signals import pre_save
-from django.test.testcases import TestCase
-from django.test.utils import override_settings
 
 from tastypie import fields
 from tastypie.exceptions import ApiFieldError, NotFound

--- a/tests/slashless/api/urls.py
+++ b/tests/slashless/api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 from tastypie.api import Api
 from slashless.api.resources import NoteResource, UserResource
 
@@ -8,5 +8,5 @@ api.register(NoteResource(), canonical=True)
 api.register(UserResource(), canonical=True)
 
 urlpatterns = [
-    url(r'^api/', include(api.urls)),
+    re_path(r'^api/', include(api.urls)),
 ]

--- a/tests/validation/api/urls.py
+++ b/tests/validation/api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from tastypie.api import Api
 
@@ -12,5 +12,5 @@ api.register(UserResource(), canonical=True)
 api.register(AnnotatedNoteResource(), canonical=True)
 
 urlpatterns = [
-    url(r'^api/', include(api.urls)),
+    re_path(r'^api/', include(api.urls)),
 ]


### PR DESCRIPTION
Replaces all usages of django.conf.urls.url with
django.urls.re_path.

These usages have been deprecated since v2.2. They will be removed
in v4.0