### PR TITLE
Django 4.2 compatibility

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        django-version: ["3.2", "4.0", "4.1"]  # Todo: add "dev" back
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        django-version: ["3.2", "4.0", "4.1", "4.2"]  # Todo: add "dev" back
         exclude:
            - python-version: "3.6"
              django-version: "4.0"
@@ -26,6 +26,8 @@ jobs:
              django-version: "4.1"
            - python-version: "3.7"
              django-version: "4.1"
+           - python-version: "3.7"
+             django-version: "4.2"
 #           - python-version: "3.6"
 #             django-version: "dev"
 #           - python-version: "3.7"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,6 +26,8 @@ jobs:
              django-version: "4.1"
            - python-version: "3.7"
              django-version: "4.1"
+           - python-version: "3.6"
+             django-version: "4.2"
            - python-version: "3.7"
              django-version: "4.2"
 #           - python-version: "3.6"

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Core
 ----
 
 * Python 3.6+, preferably 3.8+ (Whatever is supported by your version of Django)
-* Django 2.2, 3.2 (LTS releases), 4.0, or Django 4.1 (latest release)
+* Django 4.2, 3.2 (LTS releases), or Django 4.0 / 4.1 (intermediate releases)
 * dateutil (http://labix.org/python-dateutil) >= 2.1
 
 Format Support

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
     py{3.6,3.7,3.8,3.9,3.10}-dj{3.2,}
-    py{3.8,3.9,3.10}-dj{4.0,4.1,dev}
-    py{3.6,3.7,3.8,3.9,3.10}-docs,
-    py{3.6,3.7,3.8,3.9,3.10}-flake8,
-    py{3.8,3.9,3.10}-flake8-strict
+    py{3.8,3.9,3.10,3.11}-dj{4.0,4.1,4.2,dev}
+    py{3.6,3.7,3.8,3.9,3.10,3.11}-docs,
+    py{3.6,3.7,3.8,3.9,3.10,3.11}-flake8,
+    py{3.8,3.9,3.10,3.11}-flake8-strict
 
 skipsdist=True
 
@@ -14,20 +14,20 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests
     PYTHONWARNINGS = always
 	TESTEXE = {envbindir}/coverage run --append --source=tastypie,tests {envbindir}/django-admin.py
-	dj{4.0,4.1,dev}: TESTEXE = {envbindir}/coverage run --append --source=tastypie,tests {envbindir}/django-admin
+	dj{4.0,4.1,4.2,dev}: TESTEXE = {envbindir}/coverage run --append --source=tastypie,tests {envbindir}/django-admin
 
 commands =
-    dj{3.2,4.0,4.1,dev}: {env:TESTEXE} test -p '*' core.tests --settings=settings_core
-    dj{3.2,4.0,4.1,dev}: {env:TESTEXE} test basic.tests --settings=settings_basic
-    dj{3.2,4.0,4.1,dev}: {env:TESTEXE} test related_resource.tests --settings=settings_related
-    dj{3.2,4.0,4.1,dev}: {env:TESTEXE} test alphanumeric.tests --settings=settings_alphanumeric
-    dj{3.2,4.0,4.1,dev}: {env:TESTEXE} test authorization.tests --settings=settings_authorization
-    dj{3.2,4.0,4.1,dev}: {env:TESTEXE} test content_gfk.tests --settings=settings_content_gfk
-    dj{3.2,4.0,4.1,dev}: {env:TESTEXE} test customuser.tests --settings=settings_customuser
-    dj{3.2,4.0,4.1,dev}: {env:TESTEXE} test namespaced.tests --settings=settings_namespaced
-    dj{3.2,4.0,4.1,dev}: {env:TESTEXE} test slashless.tests --settings=settings_slashless
-    dj{3.2,4.0,4.1,dev}: {env:TESTEXE} test validation.tests --settings=settings_validation
-    dj{3.2,4.0,4.1,dev}: {env:TESTEXE} test gis.tests --settings=settings_gis_spatialite
+    dj{3.2,4.0,4.1,4.2,dev}: {env:TESTEXE} test -p '*' core.tests --settings=settings_core
+    dj{3.2,4.0,4.1,4.2,dev}: {env:TESTEXE} test basic.tests --settings=settings_basic
+    dj{3.2,4.0,4.1,4.2,dev}: {env:TESTEXE} test related_resource.tests --settings=settings_related
+    dj{3.2,4.0,4.1,4.2,dev}: {env:TESTEXE} test alphanumeric.tests --settings=settings_alphanumeric
+    dj{3.2,4.0,4.1,4.2,dev}: {env:TESTEXE} test authorization.tests --settings=settings_authorization
+    dj{3.2,4.0,4.1,4.2,dev}: {env:TESTEXE} test content_gfk.tests --settings=settings_content_gfk
+    dj{3.2,4.0,4.1,4.2,dev}: {env:TESTEXE} test customuser.tests --settings=settings_customuser
+    dj{3.2,4.0,4.1,4.2,dev}: {env:TESTEXE} test namespaced.tests --settings=settings_namespaced
+    dj{3.2,4.0,4.1,4.2,dev}: {env:TESTEXE} test slashless.tests --settings=settings_slashless
+    dj{3.2,4.0,4.1,4.2,dev}: {env:TESTEXE} test validation.tests --settings=settings_validation
+    dj{3.2,4.0,4.1,4.2,dev}: {env:TESTEXE} test gis.tests --settings=settings_gis_spatialite
 
     docs: sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
     docs: sphinx-build -W -b doctest -d {envtmpdir}/doctrees . {envtmpdir}/html
@@ -41,18 +41,20 @@ basepython =
     py3.8: python3.8
     py3.9: python3.9
     py3.10: python3.10
+    py3.11: python3.11
 deps =
     dj3.2: Django>=3.2,<3.3
     dj4.0: Django>=4.0,<4.1
     dj4.1: Django>=4.1,<4.2
+    dj4.2: Django>=4.2,<4.3
     djdev: https://github.com/django/django/archive/refs/heads/main.zip
 
-    dj{3.2,4.0,4.1,dev}: python3-digest>=1.8b4
-    dj{3.2,4.0,4.1,dev}: -r{toxinidir}/tests/requirements.txt
-    dj{3.2,4.0,4.1,dev}: -r{toxinidir}/requirements.txt
+    dj{3.2,4.0,4.1,4.2,dev}: python3-digest>=1.8b4
+    dj{3.2,4.0,4.1,4.2,dev}: -r{toxinidir}/tests/requirements.txt
+    dj{3.2,4.0,4.1,4.2,dev}: -r{toxinidir}/requirements.txt
 
     py{3.6,3.7}-docs: Django~=3.2
-    py{3.8,3.9,3.10}-docs: Django<4.2
+    py{3.8,3.9,3.10,3.11}-docs: Django<4.3
     docs: Sphinx
     docs: mock
     docs: sphinx_rtd_theme


### PR DESCRIPTION
TastyPie v0.14.5 is already compatible with Django 4.2, but the readme and test matrix needs to be updated to reflect that.