### PR TITLE
Add in support for Django 5.0 by adding in compat functionality for datetime_safe

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,14 +16,18 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-        django-version: ["2.2", "3.2", "4.0"]  # Todo: add "dev" back
+        django-version: ["2.2", "3.2", "4.0", "4.1"]  # Todo: add "dev" back
         exclude:
            - python-version: "3.6"
              django-version: "4.0"
-#           - python-version: "3.6"
-#             django-version: "dev"
            - python-version: "3.7"
              django-version: "4.0"
+           - python-version: "3.6"
+             django-version: "4.1"
+           - python-version: "3.7"
+             django-version: "4.1"
+#           - python-version: "3.6"
+#             django-version: "dev"
 #           - python-version: "3.7"
 #             django-version: "dev"
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,6 +30,8 @@ jobs:
              django-version: "4.2"
            - python-version: "3.7"
              django-version: "4.2"
+           - python-version: "3.6"
+             django-version: "5.0"
            - python-version: "3.7"
              django-version: "5.0"
            - python-version: "3.8"

--- a/AUTHORS
+++ b/AUTHORS
@@ -105,7 +105,7 @@ Contributors:
 * Matt Briançon (mattbriancon) for various patches
 * Blayze Wilhelm (blayzen-w) for a small patch that fixed an issue with saving (PR #1628)
 * Ryan Young (ryanneilyoung) for removing python 2 code
-* Chander Ganesan (chander) for minor patches
+* Chander Ganesan (chander) for minor patches, added support for django 4.1 and 5.0
 
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.

--- a/AUTHORS
+++ b/AUTHORS
@@ -105,6 +105,7 @@ Contributors:
 * Matt Briançon (mattbriancon) for various patches
 * Blayze Wilhelm (blayzen-w) for a small patch that fixed an issue with saving (PR #1628)
 * Ryan Young (ryanneilyoung) for removing python 2 code
+* Chander Ganesan (chander) for minor patches
 
 
 Thanks to Tav for providing validate_jsonp.py, placed in public domain.

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Core
 ----
 
 * Python 3.6+, preferably 3.8+ (Whatever is supported by your version of Django)
-* Django 2.2, 3.2 (LTS releases) or Django 4.0 (latest release)
+* Django 2.2, 3.2 (LTS releases) or Django 4.1 (latest release)
 * dateutil (http://labix.org/python-dateutil) >= 2.1
 
 Format Support

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Core
 ----
 
 * Python 3.6+, preferably 3.8+ (Whatever is supported by your version of Django)
-* Django 2.2, 3.2 (LTS releases) or Django 4.1 (latest release)
+* Django 2.2, 3.2 (LTS releases), 4.0, or Django 4.1 (latest release)
 * dateutil (http://labix.org/python-dateutil) >= 2.1
 
 Format Support

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -609,7 +609,7 @@ their own.:
 
 
     class UserModelAdmin(UserAdmin):
-        inlines = UserAdmin.inlines + [ApiKeyInline]
+        inlines = list(UserAdmin.inlines) + [ApiKeyInline]
 
 
     admin.site.unregister(User)

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -91,7 +91,7 @@ modifying ``get_object_list``:
 
 .. testcode::
 
-    from django.utils import timezone
+    from tastypie.compat import timezone
     from myapp.models import MyModel
 
 

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -91,8 +91,7 @@ modifying ``get_object_list``:
 
 .. testcode::
 
-    from datetime import timezone
-
+    from django.utils import timezone
     from myapp.models import MyModel
 
 

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -91,7 +91,8 @@ modifying ``get_object_list``:
 
 .. testcode::
 
-    from django.utils import timezone
+    from datetime import timezone
+
     from myapp.models import MyModel
 
 

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -328,10 +328,7 @@ class SessionAuthentication(Authentication):
 
         request_csrf_token = request.META.get('HTTP_X_CSRFTOKEN', '')
         try:
-            if _sanitize_token:
-                request_csrf_token = _sanitize_token(request_csrf_token)
-            else:
-                _check_token_format(csrf_token)
+            request_csrf_token = check_token_format(request_csrf_token)
         except InvalidTokenFormat:
             return False
 

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -340,7 +340,10 @@ class SessionAuthentication(Authentication):
         except InvalidTokenFormat:
             return False
 
-        if not compare_sanitized_tokens(request_csrf_token, csrf_token):
+        try:
+            if not compare_sanitized_tokens(request_csrf_token, csrf_token):
+                return False
+        except AssertionError:
             return False
 
         return request.user.is_authenticated

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -8,15 +8,8 @@ import warnings
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.exceptions import ImproperlyConfigured
+from compat import check_token_format
 
-try:
-    from django.middleware.csrf import _check_token_format
-
-    _sanitize_token = None
-except ImportError:
-    from django.middleware.csrf import _sanitize_token
-
-    _check_token_format = None
 from django.utils.translation import gettext as _
 
 from urllib.parse import urlparse
@@ -319,10 +312,9 @@ class SessionAuthentication(Authentication):
         if getattr(request, '_dont_enforce_csrf_checks', False):
             return request.user.is_authenticated
         csrf_token = request.COOKIES.get(settings.CSRF_COOKIE_NAME, '')
-        if _sanitize_token:
-            csrf_token = _sanitize_token(csrf_token)
-        else:
-            _check_token_format(csrf_token)
+
+        csrf_token = check_token_format(csrf_token)
+
 
         if request.is_secure():
             referer = request.META.get('HTTP_REFERER')

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -315,7 +315,6 @@ class SessionAuthentication(Authentication):
 
         csrf_token = check_token_format(csrf_token)
 
-
         if request.is_secure():
             referer = request.META.get('HTTP_REFERER')
 

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -8,14 +8,13 @@ import warnings
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.exceptions import ImproperlyConfigured
-from compat import check_token_format
 
 from django.utils.translation import gettext as _
 
 from urllib.parse import urlparse
 
 from tastypie.compat import (
-    get_user_model, get_username_field, compare_sanitized_tokens, InvalidTokenFormat
+    get_user_model, get_username_field, compare_sanitized_tokens, InvalidTokenFormat, check_token_format
 )
 from tastypie.http import HttpUnauthorized
 

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -8,12 +8,15 @@ import warnings
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.exceptions import ImproperlyConfigured
+
 try:
     from django.middleware.csrf import _check_token_format
-    _sanitize_token=None
+
+    _sanitize_token = None
 except ImportError:
     from django.middleware.csrf import _sanitize_token
-    _check_token_format=None
+
+    _check_token_format = None
 from django.utils.translation import gettext as _
 
 from urllib.parse import urlparse
@@ -299,6 +302,7 @@ class SessionAuthentication(Authentication):
 
     Requires a valid CSRF token.
     """
+
     def is_authenticated(self, request, **kwargs):
         """
         Checks to make sure the user is logged in & has a Django session.
@@ -383,7 +387,8 @@ class DigestAuthentication(Authentication):
         self.realm = realm
 
         if python_digest is None:
-            raise ImproperlyConfigured("The 'python_digest' package could not be imported. It is required for use with the 'DigestAuthentication' class.")
+            raise ImproperlyConfigured(
+                "The 'python_digest' package could not be imported. It is required for use with the 'DigestAuthentication' class.")
 
     def _unauthorized(self):
         response = HttpUnauthorized()
@@ -486,14 +491,17 @@ class OAuthAuthentication(Authentication):
     This does *NOT* provide OAuth authentication in your API, strictly
     consumption.
     """
+
     def __init__(self, **kwargs):
         super(OAuthAuthentication, self).__init__(**kwargs)
 
         if oauth2 is None:
-            raise ImproperlyConfigured("The 'python-oauth2' package could not be imported. It is required for use with the 'OAuthAuthentication' class.")
+            raise ImproperlyConfigured(
+                "The 'python-oauth2' package could not be imported. It is required for use with the 'OAuthAuthentication' class.")
 
         if oauth_provider is None:
-            raise ImproperlyConfigured("The 'django-oauth-plus' package could not be imported. It is required for use with the 'OAuthAuthentication' class.")
+            raise ImproperlyConfigured(
+                "The 'django-oauth-plus' package could not be imported. It is required for use with the 'OAuthAuthentication' class.")
 
     def is_authenticated(self, request, **kwargs):
         from oauth_provider.store import store
@@ -503,9 +511,11 @@ class OAuthAuthentication(Authentication):
             consumer = store.get_consumer(request, oauth_request, oauth_request.get_parameter('oauth_consumer_key'))
 
             try:
-                token = store.get_access_token(request, oauth_request, consumer, oauth_request.get_parameter('oauth_token'))
+                token = store.get_access_token(request, oauth_request, consumer,
+                                               oauth_request.get_parameter('oauth_token'))
             except oauth_provider.store.InvalidTokenError:
-                return oauth_provider.utils.send_oauth_error(oauth2.Error(_('Invalid access token: %s') % oauth_request.get_parameter('oauth_token')))
+                return oauth_provider.utils.send_oauth_error(
+                    oauth2.Error(_('Invalid access token: %s') % oauth_request.get_parameter('oauth_token')))
 
             try:
                 self.validate_token(request, consumer, token)
@@ -520,7 +530,8 @@ class OAuthAuthentication(Authentication):
                 request.user = user
                 return True
 
-            return oauth_provider.utils.send_oauth_error(oauth2.Error(_('You are not allowed to access this resource.')))
+            return oauth_provider.utils.send_oauth_error(
+                oauth2.Error(_('You are not allowed to access this resource.')))
 
         return oauth_provider.utils.send_oauth_error(oauth2.Error(_('Invalid request parameters.')))
 
@@ -557,6 +568,7 @@ class MultiAuthentication(object):
     """
     An authentication backend that tries a number of backends in order.
     """
+
     def __init__(self, *backends, **kwargs):
         super(MultiAuthentication, self).__init__(**kwargs)
         self.backends = backends

--- a/tastypie/authentication.py
+++ b/tastypie/authentication.py
@@ -8,7 +8,10 @@ import warnings
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.core.exceptions import ImproperlyConfigured
-from django.middleware.csrf import _sanitize_token
+try:
+    from django.middleware.csrf import _check_token_format as _sanitize_token
+except ImportError:
+    from django.middleware.csrf import _sanitize_token
 from django.utils.translation import gettext as _
 
 from urllib.parse import urlparse

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -14,22 +14,16 @@ if django.VERSION < (4, 1):
     from django.middleware.csrf import _sanitize_token
 else:
     from django.middleware.csrf import _check_token_format
+
+
+# Django 5.0 eliminated the former datetime_safe function, this provides
+# some level of backwards compatability for existing tastypie use cases
 if django.VERSION < (5, 0):
-    from django.utils import datetime_safe as dj_datetime_safe
+    from django.utils import datetime_safe
 else:
-    import datetime
+    import datetime as datetime_safe
 
 AUTH_USER_MODEL = settings.AUTH_USER_MODEL
-
-
-def datetime_safe(*args, **kwargs):
-    """
-    Django 5.0 eliminated the former datetime_safe function, this provide
-    some level of backwards compatability for existing tastypie use cases
-    """
-    if django.VERSION < (5, 0):
-        return dj_datetime_safe(*args, **kwargs)
-    return datetime(*args, **kwargs)
 
 
 def get_username_field():

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -16,8 +16,6 @@ if django.VERSION < (4, 1):
 else:
     from django.middleware.csrf import _check_token_format
 
-
-
 # Django 5.0 eliminated the former datetime_safe function, this provides
 # some level of backwards compatability for existing tastypie use cases
 if django.VERSION < (5, 0):

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -70,7 +70,6 @@ if compare_sanitized_tokens is None:
     try:
         from django.middleware.csrf import _unsalt_cipher_token, constant_time_compare
 
-
         def compare_sanitized_tokens(request_csrf_token, csrf_token):
             return constant_time_compare(_unsalt_cipher_token(request_csrf_token),
                                          _unsalt_cipher_token(csrf_token))

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -1,6 +1,7 @@
 import django
 from django.conf import settings
 from django.contrib.auth import get_user_model  # noqa
+from django.utils import timezone
 
 try:
     from django.urls import NoReverseMatch, reverse, Resolver404, get_script_prefix  # noqa
@@ -16,12 +17,17 @@ else:
     from django.middleware.csrf import _check_token_format
 
 
+
 # Django 5.0 eliminated the former datetime_safe function, this provides
 # some level of backwards compatability for existing tastypie use cases
 if django.VERSION < (5, 0):
     from django.utils import datetime_safe  # noqa: F401
 else:
     import datetime as datetime_safe  # noqa: F401
+    # Django 5.0 removed this alias - restore it for backwards compatability.
+    # Django 5.0 essentially completed a lot of the move to zoneinfo, prior to that
+    # this was an alias that was added in 4.0.
+    timezone.utc = datetime_safe.timezone.utc
 
 AUTH_USER_MODEL = settings.AUTH_USER_MODEL
 

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -19,7 +19,6 @@ except ImportError:
 
     _check_token_format = None
 
-
 AUTH_USER_MODEL = settings.AUTH_USER_MODEL
 
 
@@ -48,22 +47,24 @@ if django.VERSION < (2, 2):
 else:
     from django.utils.encoding import force_str  # noqa
 
-
 compare_sanitized_tokens = None
 
 # django 4.0
 try:
     from django.middleware.csrf import _does_token_match, InvalidTokenFormat
+
     compare_sanitized_tokens = _does_token_match
 except ImportError:
     pass
-
 
 # django 3.2
 if compare_sanitized_tokens is None:
     try:
         from django.middleware.csrf import _compare_masked_tokens
+
         compare_sanitized_tokens = _compare_masked_tokens
+
+
         class InvalidTokenFormat(Exception):  # noqa
             pass
     except ImportError:
@@ -74,9 +75,11 @@ if compare_sanitized_tokens is None:
     try:
         from django.middleware.csrf import _unsalt_cipher_token, constant_time_compare
 
+
         def compare_sanitized_tokens(request_csrf_token, csrf_token):
             return constant_time_compare(_unsalt_cipher_token(request_csrf_token),
                                          _unsalt_cipher_token(csrf_token))
+
 
         class InvalidTokenFormat(Exception):  # noqa
             pass
@@ -85,6 +88,9 @@ if compare_sanitized_tokens is None:
 
 
 def check_token_format(csrf_token):
+    """
+    Handle the pre-4.0 version of sanitizing the token as well as the post-4.0 version of the same.
+    """
     if _sanitize_token:
         csrf_token = _sanitize_token(csrf_token)
     else:

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -19,9 +19,9 @@ else:
 # Django 5.0 eliminated the former datetime_safe function, this provides
 # some level of backwards compatability for existing tastypie use cases
 if django.VERSION < (5, 0):
-    from django.utils import datetime_safe
+    from django.utils import datetime_safe  # noqa: F401
 else:
-    import datetime as datetime_safe
+    import datetime as datetime_safe  # noqa: F401
 
 AUTH_USER_MODEL = settings.AUTH_USER_MODEL
 

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -75,7 +75,6 @@ if compare_sanitized_tokens is None:
     try:
         from django.middleware.csrf import _unsalt_cipher_token, constant_time_compare
 
-
         def compare_sanitized_tokens(request_csrf_token, csrf_token):
             return constant_time_compare(_unsalt_cipher_token(request_csrf_token),
                                          _unsalt_cipher_token(csrf_token))

--- a/tastypie/compat.py
+++ b/tastypie/compat.py
@@ -74,7 +74,6 @@ if compare_sanitized_tokens is None:
 
         compare_sanitized_tokens = _compare_masked_tokens
 
-
         class InvalidTokenFormat(Exception):  # noqa
             pass
     except ImportError:
@@ -85,11 +84,9 @@ if compare_sanitized_tokens is None:
     try:
         from django.middleware.csrf import _unsalt_cipher_token, constant_time_compare
 
-
         def compare_sanitized_tokens(request_csrf_token, csrf_token):
             return constant_time_compare(_unsalt_cipher_token(request_csrf_token),
                                          _unsalt_cipher_token(csrf_token))
-
 
         class InvalidTokenFormat(Exception):  # noqa
             pass

--- a/tastypie/utils/timezone.py
+++ b/tastypie/utils/timezone.py
@@ -1,6 +1,6 @@
 import datetime
+from tastypie.compat import timezone
 from django.conf import settings
-from django.utils import timezone
 
 
 def make_aware(value):

--- a/tastypie/utils/timezone.py
+++ b/tastypie/utils/timezone.py
@@ -1,19 +1,20 @@
 import datetime
 from django.conf import settings
-from django.utils import timezone
+from django.utils import timezone as dj_timezone
+from datetime import timezone
 
 
 def make_aware(value):
-    if settings.USE_TZ and timezone.is_naive(value):
-        default_tz = timezone.get_default_timezone()
-        value = timezone.make_aware(value, default_tz)
+    if settings.USE_TZ and dj_timezone.is_naive(value):
+        default_tz = dj_timezone.get_default_timezone()
+        value = dj_timezone.make_aware(value, default_tz)
     return value
 
 
 def make_naive(value):
-    if settings.USE_TZ and timezone.is_aware(value):
-        default_tz = timezone.get_default_timezone()
-        value = timezone.make_naive(value, default_tz)
+    if settings.USE_TZ and dj_timezone.is_aware(value):
+        default_tz = dj_timezone.get_default_timezone()
+        value = dj_timezone.make_naive(value, default_tz)
     return value
 
 
@@ -22,15 +23,15 @@ def make_naive_utc(value):
     Translate a datetime to UTC, then strip TZ info; useful as a last step before creating the
     Retry-After header.
     """
-    utc_value = timezone.localtime(value, timezone.utc)
-    return timezone.make_naive(utc_value)
+    utc_value = dj_timezone.localtime(value, timezone.utc)
+    return dj_timezone.make_naive(utc_value)
 
 
 def now():
-    d = timezone.now()
+    d = dj_timezone.now()
 
     if d.tzinfo:
-        return timezone.localtime(d)
+        return dj_timezone.localtime(d)
 
     return d
 

--- a/tastypie/utils/timezone.py
+++ b/tastypie/utils/timezone.py
@@ -1,20 +1,19 @@
 import datetime
 from django.conf import settings
-from django.utils import timezone as dj_timezone
-from datetime import timezone
+from django.utils import timezone
 
 
 def make_aware(value):
-    if settings.USE_TZ and dj_timezone.is_naive(value):
-        default_tz = dj_timezone.get_default_timezone()
-        value = dj_timezone.make_aware(value, default_tz)
+    if settings.USE_TZ and timezone.is_naive(value):
+        default_tz = timezone.get_default_timezone()
+        value = timezone.make_aware(value, default_tz)
     return value
 
 
 def make_naive(value):
-    if settings.USE_TZ and dj_timezone.is_aware(value):
-        default_tz = dj_timezone.get_default_timezone()
-        value = dj_timezone.make_naive(value, default_tz)
+    if settings.USE_TZ and timezone.is_aware(value):
+        default_tz = timezone.get_default_timezone()
+        value = timezone.make_naive(value, default_tz)
     return value
 
 
@@ -23,15 +22,15 @@ def make_naive_utc(value):
     Translate a datetime to UTC, then strip TZ info; useful as a last step before creating the
     Retry-After header.
     """
-    utc_value = dj_timezone.localtime(value, timezone.utc)
-    return dj_timezone.make_naive(utc_value)
+    utc_value = timezone.localtime(value, timezone.utc)
+    return timezone.make_naive(utc_value)
 
 
 def now():
-    d = dj_timezone.now()
+    d = timezone.now()
 
     if d.tzinfo:
-        return dj_timezone.localtime(d)
+        return timezone.localtime(d)
 
     return d
 

--- a/tests/core/tests/authentication.py
+++ b/tests/core/tests/authentication.py
@@ -8,12 +8,11 @@ from django.contrib.auth.models import AnonymousUser, User
 from django.http import HttpRequest
 from django.test import TestCase
 
-from tastypie.authentication import Authentication, BasicAuthentication,\
-    ApiKeyAuthentication, SessionAuthentication, DigestAuthentication,\
+from tastypie.authentication import Authentication, BasicAuthentication, \
+    ApiKeyAuthentication, SessionAuthentication, DigestAuthentication, \
     OAuthAuthentication, MultiAuthentication
 from tastypie.http import HttpUnauthorized
 from tastypie.models import ApiKey, create_api_key
-
 
 # Be tricky.
 from tastypie.authentication import python_digest, oauth2, oauth_provider
@@ -90,21 +89,24 @@ class BasicAuthenticationTestCase(TestCase):
         john_doe = User.objects.get(username='johndoe')
         john_doe.set_password('pass')
         john_doe.save()
-        request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % base64.b64encode('johndoe:pass'.encode('utf-8')).decode('utf-8')
+        request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % base64.b64encode('johndoe:pass'.encode('utf-8')).decode(
+            'utf-8')
         self.assertEqual(auth.is_authenticated(request), True)
 
         # Regression: Password with colon.
         john_doe = User.objects.get(username='johndoe')
         john_doe.set_password('pass:word')
         john_doe.save()
-        request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % base64.b64encode('johndoe:pass:word'.encode('utf-8')).decode('utf-8')
+        request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % base64.b64encode('johndoe:pass:word'.encode('utf-8')).decode(
+            'utf-8')
         self.assertEqual(auth.is_authenticated(request), True)
 
         # Capitalization shouldn't matter.
         john_doe = User.objects.get(username='johndoe')
         john_doe.set_password('pass:word')
         john_doe.save()
-        request.META['HTTP_AUTHORIZATION'] = 'bAsIc %s' % base64.b64encode('johndoe:pass:word'.encode('utf-8')).decode('utf-8')
+        request.META['HTTP_AUTHORIZATION'] = 'bAsIc %s' % base64.b64encode('johndoe:pass:word'.encode('utf-8')).decode(
+            'utf-8')
         self.assertEqual(auth.is_authenticated(request), True)
 
     def test_check_active_true(self):
@@ -114,7 +116,8 @@ class BasicAuthenticationTestCase(TestCase):
         bob_doe = User.objects.get(username='bobdoe')
         bob_doe.set_password('pass')
         bob_doe.save()
-        request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % base64.b64encode('bobdoe:pass'.encode('utf-8')).decode('utf-8')
+        request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % base64.b64encode('bobdoe:pass'.encode('utf-8')).decode(
+            'utf-8')
         auth_res = auth.is_authenticated(request)
         # is_authenticated() returns HttpUnauthorized for inactive users in Django >= 1.10, False for < 1.10
         self.assertTrue(auth_res is False or isinstance(auth_res, HttpUnauthorized))
@@ -571,7 +574,8 @@ class MultiAuthenticationTestCase(TestCase):
         john_doe.set_password('pass')
         john_doe.save()
 
-        request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % base64.b64encode('johndoe:pass'.encode('utf-8')).decode('utf-8')
+        request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % base64.b64encode('johndoe:pass'.encode('utf-8')).decode(
+            'utf-8')
 
         self.assertEqual(auth.is_authenticated(request), True)
         self.assertEqual(auth.get_identifier(request), john_doe.username)
@@ -584,7 +588,8 @@ class MultiAuthenticationTestCase(TestCase):
         john_doe.set_password('pass')
         john_doe.save()
 
-        request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % base64.b64encode('john doe:pass'.encode('utf-8')).decode('utf-8')
+        request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % base64.b64encode('john doe:pass'.encode('utf-8')).decode(
+            'utf-8')
 
         self.assertEqual(auth.is_authenticated(request), True)
         self.assertEqual(auth.get_identifier(request), john_doe.username)

--- a/tests/core/tests/authentication.py
+++ b/tests/core/tests/authentication.py
@@ -256,11 +256,9 @@ class SessionAuthenticationTestCase(TestCase):
         request.COOKIES = {
             settings.CSRF_COOKIE_NAME: 'abcdef1234567890abcdef1234567890'
         }
-        request.META = {
-            'HTTP_X_CSRFTOKEN': 'abcdef1234567890abcdef1234567890'
-        }
-        request.META['HTTP_HOST'] = 'example.com'
-        request.META['HTTP_REFERER'] = ''
+        request.META = {'HTTP_X_CSRFTOKEN': 'abcdef1234567890abcdef1234567890',
+                        'HTTP_HOST': 'example.com',
+                        'HTTP_REFERER': ''}
         request.user = User.objects.get(username='johndoe')
         self.assertFalse(auth.is_authenticated(request))
 

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -24,7 +24,8 @@ except ImportError:
 from django.http import HttpRequest, QueryDict, Http404
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils import timezone
+
+from tastypie.compat import timezone
 
 from tastypie.authentication import BasicAuthentication
 from tastypie.authorization import Authorization

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -24,7 +24,8 @@ except ImportError:
 from django.http import HttpRequest, QueryDict, Http404
 from django.test import TestCase
 from django.test.utils import override_settings
-from datetime import timezone
+from django.utils import timezone
+
 from tastypie.authentication import BasicAuthentication
 from tastypie.authorization import Authorization
 from tastypie.bundle import Bundle

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -24,8 +24,7 @@ except ImportError:
 from django.http import HttpRequest, QueryDict, Http404
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.utils import timezone
-
+from datetime import timezone
 from tastypie.authentication import BasicAuthentication
 from tastypie.authorization import Authorization
 from tastypie.bundle import Bundle

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -64,7 +64,7 @@ PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.MD5PasswordHasher',
 ]
 # Django 5.0 removed this hasher
-if DJANGO_VERSION >= DJANGO_42:
+if DJANGO_VERSION > DJANGO_42:
     PASSWORD_HASHERS.remove('django.contrib.auth.hashers.CryptPasswordHasher')
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -55,14 +55,14 @@ CACHE_BACKEND = 'locmem://'
 SECRET_KEY = 'verysecret'
 
 # weaker password hashing shoulod allow for faster tests
-PASSWORD_HASHERS = (
+PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.CryptPasswordHasher',
     'django.contrib.auth.hashers.PBKDF2PasswordHasher',
     'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
     'django.contrib.auth.hashers.BCryptPasswordHasher',
     'django.contrib.auth.hashers.SHA1PasswordHasher',
     'django.contrib.auth.hashers.MD5PasswordHasher',
-)
+]
 # Django 5.0 removed this hasher
 if DJANGO_VERSION >= DJANGO_42:
     PASSWORD_HASHERS.remove('django.contrib.auth.hashers.CryptPasswordHasher')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -12,6 +12,7 @@ DJANGO_20 = StrictVersion('2.0')
 DJANGO_11 = StrictVersion('1.11')
 DJANGO_19 = StrictVersion('1.9')
 DJANGO_18 = StrictVersion('1.8')
+DJANGO_42 = StrictVersion('4.2')
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
@@ -62,6 +63,10 @@ PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.SHA1PasswordHasher',
     'django.contrib.auth.hashers.MD5PasswordHasher',
 )
+# Django 5.0 removed this hasher
+if DJANGO_VERSION >= DJANGO_42:
+    PASSWORD_HASHERS.remove('django.contrib.auth.hashers.CryptPasswordHasher')
+
 
 LOGGING = {
     'version': 1,

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
     dj{3.2,4.0,4.1,4.2,5.0,dev}: -r{toxinidir}/requirements.txt
 
     py{3.6,3.7}-docs: Django~=3.2
-    py{3.9,3.10,3.11}-docs: Django~=5.0
+    py{3.8,3.9,3.10,3.11}-docs: Django<4.3
     docs: Sphinx
     docs: mock
     docs: sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
     dj{2.2,3.2,4.0,4.1,dev}: -r{toxinidir}/tests/requirements.txt
 
     py{3.6,3.7}-docs: Django~=2.2
-    py{3.7,3.8,3.9,3.10}-docs: Django<4.2
+    py{3.8,3.9,3.10}-docs: Django<4.2
     docs: Sphinx
     docs: mock
     docs: sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ deps =
     dj{3.2,4.0,4.1,4.2,5.0,dev}: -r{toxinidir}/requirements.txt
 
     py{3.6,3.7}-docs: Django~=3.2
+    py{3.8,3.9}-docs: Django<4.3
     py{3.10,3.11}-docs: Django~=5.0
     docs: Sphinx
     docs: mock

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
     dj{3.2,4.0,4.1,4.2,5.0,dev}: -r{toxinidir}/requirements.txt
 
     py{3.6,3.7}-docs: Django~=3.2
-    py{3.8,3.9,3.10,3.11}-docs: Django<4.3
+    py{3.10,3.11}-docs: Django~=5.0
     docs: Sphinx
     docs: mock
     docs: sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,6 @@ deps =
     dj{3.2,4.0,4.1,4.2,5.0,dev}: -r{toxinidir}/requirements.txt
 
     py{3.6,3.7}-docs: Django~=3.2
-    py{3.8,3.9,3.10,3.11}-docs: Django<4.3
     py{3.9,3.10,3.11}-docs: Django~=5.0
     docs: Sphinx
     docs: mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{3.6,3.7,3.8,3.9,3.10}-dj{2.2,3.2}
-    py{3.8,3.9,3.10}-dj{4.0,dev}
+    py{3.8,3.9,3.10}-dj{4.0,4.1,dev}
     py{3.6,3.7,3.8,3.9,3.10}-docs,
     py{3.6,3.7,3.8,3.9,3.10}-flake8,
     py{3.8,3.9,3.10}-flake8-strict
@@ -14,20 +14,20 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/tests
     PYTHONWARNINGS = always
 	TESTEXE = {envbindir}/coverage run --append --source=tastypie,tests {envbindir}/django-admin.py
-	dj{4.0,dev}: TESTEXE = {envbindir}/coverage run --append --source=tastypie,tests {envbindir}/django-admin
+	dj{4.0,4.1,dev}: TESTEXE = {envbindir}/coverage run --append --source=tastypie,tests {envbindir}/django-admin
 
 commands =
-    dj{2.2,3.2,4.0,dev}: {env:TESTEXE} test -p '*' core.tests --settings=settings_core
-    dj{2.2,3.2,4.0,dev}: {env:TESTEXE} test basic.tests --settings=settings_basic
-    dj{2.2,3.2,4.0,dev}: {env:TESTEXE} test related_resource.tests --settings=settings_related
-    dj{2.2,3.2,4.0,dev}: {env:TESTEXE} test alphanumeric.tests --settings=settings_alphanumeric
-    dj{2.2,3.2,4.0,dev}: {env:TESTEXE} test authorization.tests --settings=settings_authorization
-    dj{2.2,3.2,4.0,dev}: {env:TESTEXE} test content_gfk.tests --settings=settings_content_gfk
-    dj{2.2,3.2,4.0,dev}: {env:TESTEXE} test customuser.tests --settings=settings_customuser
-    dj{2.2,3.2,4.0,dev}: {env:TESTEXE} test namespaced.tests --settings=settings_namespaced
-    dj{2.2,3.2,4.0,dev}: {env:TESTEXE} test slashless.tests --settings=settings_slashless
-    dj{2.2,3.2,4.0,dev}: {env:TESTEXE} test validation.tests --settings=settings_validation
-    dj{2.2,3.2,4.0,dev}: {env:TESTEXE} test gis.tests --settings=settings_gis_spatialite
+    dj{2.2,3.2,4.0,4.1,dev}: {env:TESTEXE} test -p '*' core.tests --settings=settings_core
+    dj{2.2,3.2,4.0,4.1,dev}: {env:TESTEXE} test basic.tests --settings=settings_basic
+    dj{2.2,3.2,4.0,4.1,dev}: {env:TESTEXE} test related_resource.tests --settings=settings_related
+    dj{2.2,3.2,4.0,4.1,dev}: {env:TESTEXE} test alphanumeric.tests --settings=settings_alphanumeric
+    dj{2.2,3.2,4.0,4.1,dev}: {env:TESTEXE} test authorization.tests --settings=settings_authorization
+    dj{2.2,3.2,4.0,4.1,dev}: {env:TESTEXE} test content_gfk.tests --settings=settings_content_gfk
+    dj{2.2,3.2,4.0,4.1,dev}: {env:TESTEXE} test customuser.tests --settings=settings_customuser
+    dj{2.2,3.2,4.0,4.1,dev}: {env:TESTEXE} test namespaced.tests --settings=settings_namespaced
+    dj{2.2,3.2,4.0,4.1,dev}: {env:TESTEXE} test slashless.tests --settings=settings_slashless
+    dj{2.2,3.2,4.0,4.1,dev}: {env:TESTEXE} test validation.tests --settings=settings_validation
+    dj{2.2,3.2,4.0,4.1,dev}: {env:TESTEXE} test gis.tests --settings=settings_gis_spatialite
 
     docs: sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
     docs: sphinx-build -W -b doctest -d {envtmpdir}/doctrees . {envtmpdir}/html
@@ -45,13 +45,14 @@ deps =
     dj2.2: Django>=2.2,<2.3
     dj3.2: Django>=3.2,<3.3
     dj4.0: Django>=4.0,<4.1
+    dj4.1: Django>=4.1,<4.2
     djdev: https://github.com/django/django/archive/refs/heads/main.zip
 
-    dj{2.2,3.2,4.0,dev}: python3-digest>=1.8b4
-    dj{2.2,3.2,4.0,dev}: -r{toxinidir}/tests/requirements.txt
+    dj{2.2,3.2,4.0,4.1,dev}: python3-digest>=1.8b4
+    dj{2.2,3.2,4.0,4.1,dev}: -r{toxinidir}/tests/requirements.txt
 
     py{3.6,3.7}-docs: Django~=2.2
-    py{3.7,3.8,3.9,3.10}-docs: Django<4.1
+    py{3.7,3.8,3.9,3.10}-docs: Django<4.2
     docs: Sphinx
     docs: mock
     docs: sphinx_rtd_theme


### PR DESCRIPTION
This change adds in support for Django 5.0 in Tastypie by doing the following:

1.  Add in a compatability function.
2. Update the tests to properly indicate the versions of python and django suitable for testing with this release.
3. Ensure that tox tests pass properly.

> Running Sphinx v7.2.6
> making output directory... done
> building [mo]: targets for 0 po files that are out of date
> writing output... 
> building [doctest]: targets for 51 source files that are out of date
> updating environment: [new config] 51 added, 0 changed, 0 removed
> reading sources... [100%] who_uses
> looking for now-outdated files... none found
> pickling environment... done
> checking consistency... done
> running tests...
> 
> Document: cookbook
> ------------------
> 1 items passed all tests:
>   16 tests in default
> 16 tests in 1 items.
> 16 passed and 0 failed.
> Test passed.
> 
> Doctest summary
> ===============
>    16 tests
>     0 failures in tests
>     0 failures in setup code
>     0 failures in cleanup code
> build succeeded.
> 
> Testing of doctests in the sources finished, look at the results in ../tmp/html/output.txt.
> 