### PR TITLE
 Fix race condition between POST / PATCH resources by using update_fields... #1151  Rebuilt against  v0.14.7.

### DIFF
--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1690,6 +1690,24 @@ class Resource(metaclass=DeclarativeMetaclass):
 
         # Now update the bundle in-place.
         deserialized = self.deserialize(request, request.body, format=request.META.get('CONTENT_TYPE', 'application/json'))
+        # Create a place to store the names of those fields we want to update
+        bundle.update_fields = [];
+        bundle.m2m_update_fields = [];
+        # When we get to the obj.save() stage, we need to know which fields have changed
+        # Otherwise we can't do a proper update.  Thus,
+        # For every key in deserialized (e.g. the fields submitted in the PATCH)
+        for key in deserialized:
+            # If the key is a property of the object, lets add it to the list, except:
+            if hasattr(bundle.obj,key):
+                # Can't update_fields an m2m field, so instead add it to patch_m2m_fields
+                if getattr(self.fields[key], 'is_m2m', False):
+                    bundle.m2m_update_fields.append(key)
+                    continue
+                # Don't add if it is the id/pk field, can't patch that.
+                if key == 'id' or key == 'pk':
+                    continue
+                # No more checks.  Add it.
+                bundle.update_fields.append(key)
         self.update_in_place(request, bundle, deserialized)
 
         if not self._meta.always_return_data:
@@ -2393,7 +2411,10 @@ class BaseModelResource(Resource):
         obj_id = self.create_identifier(bundle.obj)
 
         if obj_id not in bundle.objects_saved or bundle.obj._state.adding:
-            bundle.obj.save()
+            if hasattr(bundle,'update_fields'):
+                bundle.obj.save(update_fields=bundle.update_fields)
+            else:
+                bundle.obj.save()
             obj_id = self.create_identifier(bundle.obj)
             bundle.objects_saved.add(obj_id)
 
@@ -2506,6 +2527,19 @@ class BaseModelResource(Resource):
 
             if field_object.readonly:
                 continue
+
+            # If this is a PATCH, make sure that this field name is one of the
+            # patched fields (recorded in the update_fields property of the bundle).
+            # Otherwise, we do not want to save / recreate this field.
+            if hasattr(bundle,'update_fields'):
+                # This bundle is from a PATCH, we should not save an M2M field
+                # unless it was present in the PATCH
+                if field_name not in bundle.m2m_update_fields:
+                    continue # Skip this field_name
+                else: # this field name WAS in the patch, lets save it.
+                    pass
+            else: # Not a PATCH operation, carry on normally.
+                pass
 
             # Get the manager.
             related_mngr = None

--- a/tastypie/resources.py
+++ b/tastypie/resources.py
@@ -1691,14 +1691,14 @@ class Resource(metaclass=DeclarativeMetaclass):
         # Now update the bundle in-place.
         deserialized = self.deserialize(request, request.body, format=request.META.get('CONTENT_TYPE', 'application/json'))
         # Create a place to store the names of those fields we want to update
-        bundle.update_fields = [];
-        bundle.m2m_update_fields = [];
+        bundle.update_fields = []
+        bundle.m2m_update_fields = []
         # When we get to the obj.save() stage, we need to know which fields have changed
         # Otherwise we can't do a proper update.  Thus,
         # For every key in deserialized (e.g. the fields submitted in the PATCH)
         for key in deserialized:
             # If the key is a property of the object, lets add it to the list, except:
-            if hasattr(bundle.obj,key):
+            if hasattr(bundle.obj, key):
                 # Can't update_fields an m2m field, so instead add it to patch_m2m_fields
                 if getattr(self.fields[key], 'is_m2m', False):
                     bundle.m2m_update_fields.append(key)
@@ -2411,7 +2411,7 @@ class BaseModelResource(Resource):
         obj_id = self.create_identifier(bundle.obj)
 
         if obj_id not in bundle.objects_saved or bundle.obj._state.adding:
-            if hasattr(bundle,'update_fields'):
+            if hasattr(bundle, 'update_fields'):
                 bundle.obj.save(update_fields=bundle.update_fields)
             else:
                 bundle.obj.save()
@@ -2531,14 +2531,14 @@ class BaseModelResource(Resource):
             # If this is a PATCH, make sure that this field name is one of the
             # patched fields (recorded in the update_fields property of the bundle).
             # Otherwise, we do not want to save / recreate this field.
-            if hasattr(bundle,'update_fields'):
+            if hasattr(bundle, 'update_fields'):
                 # This bundle is from a PATCH, we should not save an M2M field
                 # unless it was present in the PATCH
                 if field_name not in bundle.m2m_update_fields:
-                    continue # Skip this field_name
-                else: # this field name WAS in the patch, lets save it.
+                    continue  # Skip this field_name
+                else:  # this field name WAS in the patch, lets save it.
                     pass
-            else: # Not a PATCH operation, carry on normally.
+            else:  # Not a PATCH operation, carry on normally.
                 pass
 
             # Get the manager.

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -1,3 +1,4 @@
+import time
 from itertools import count
 import uuid
 
@@ -46,6 +47,13 @@ class Note(models.Model):
     class Meta:
         app_label = 'core'
 
+
+class SlowNote(Note):
+    class Meta:
+        proxy = True
+    def save(self, *args, **kwargs):
+        time.sleep(1)
+        return super(SlowNote, self).save(*args, **kwargs)
 
 class NoteWithEditor(Note):
     editor = models.ForeignKey(AUTH_USER_MODEL, related_name='notes_edited',

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -51,9 +51,11 @@ class Note(models.Model):
 class SlowNote(Note):
     class Meta:
         proxy = True
+
     def save(self, *args, **kwargs):
         time.sleep(1)
         return super(SlowNote, self).save(*args, **kwargs)
+
 
 class NoteWithEditor(Note):
     editor = models.ForeignKey(AUTH_USER_MODEL, related_name='notes_edited',

--- a/tests/core/models.py
+++ b/tests/core/models.py
@@ -51,6 +51,7 @@ class Note(models.Model):
 class SlowNote(Note):
     class Meta:
         proxy = True
+        app_label = 'core'
 
     def save(self, *args, **kwargs):
         time.sleep(1)

--- a/tests/core/tests/__init__.py
+++ b/tests/core/tests/__init__.py
@@ -15,6 +15,7 @@ from core.tests.serializers import *  # noqa
 from core.tests.throttle import *  # noqa
 from core.tests.utils import *  # noqa
 from core.tests.validation import *  # noqa
+from core.tests.race_condition import *  # noqa
 
 
 # Explicitly add doctests to suite; Django's test runner stopped

--- a/tests/core/tests/api.py
+++ b/tests/core/tests/api.py
@@ -22,6 +22,7 @@ class NoteResource(ModelResource):
         queryset = Note.objects.filter(is_active=True)
         authorization = Authorization()
 
+
 class SlowNoteResource(ModelResource):
     class Meta:
         resource_name = 'slownotes'

--- a/tests/core/tests/api.py
+++ b/tests/core/tests/api.py
@@ -6,11 +6,12 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from tastypie.api import Api
+from tastypie.authorization import Authorization
 from tastypie.exceptions import NotRegistered, BadRequest
 from tastypie.resources import ModelResource
 from tastypie.serializers import Serializer
 
-from core.models import Note
+from core.models import Note, SlowNote
 from core.utils import adjust_schema
 User = get_user_model()
 
@@ -19,6 +20,13 @@ class NoteResource(ModelResource):
     class Meta:
         resource_name = 'notes'
         queryset = Note.objects.filter(is_active=True)
+        authorization = Authorization()
+
+class SlowNoteResource(ModelResource):
+    class Meta:
+        resource_name = 'slownotes'
+        queryset = SlowNote.objects.filter(is_active=True)
+        authorization = Authorization()
 
 
 class UserResource(ModelResource):

--- a/tests/core/tests/api_urls.py
+++ b/tests/core/tests/api_urls.py
@@ -2,10 +2,12 @@ from django.urls.conf import include, re_path
 
 from core.tests.api import Api, NoteResource, UserResource
 
+from tests.core.tests.api import SlowNoteResource
 
 api = Api()
 api.register(NoteResource())
 api.register(UserResource())
+api.register(SlowNoteResource())
 
 urlpatterns = [
     re_path(r'^api/', include(api.urls)),

--- a/tests/core/tests/race_condition.py
+++ b/tests/core/tests/race_condition.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+import threading
+
+from django.contrib.auth import get_user_model
+
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
+from django.test import LiveServerTestCase, Client
+
+from core.models import (
+    Note
+)
+
+User = get_user_model()
+
+
+class ApiConcurrentPatchTestCase(LiveServerTestCase):
+
+    fixtures = ['note_testdata.json']
+
+    def setUp(self):
+        super(ApiConcurrentPatchTestCase, self).setUp()
+        self.user = User.objects.get(username='johndoe')
+        self.note = Note.objects.get(pk=1)
+        self.client = Client()
+
+    def test_concurrent_patch_requests(self):
+        mapping_url = f"{self.live_server_url}{reverse('api_dispatch_detail', kwargs={'api_name': 'v1', 'resource_name': 'slownotes', 'pk': self.note.pk})}"
+
+        response1 = self.client.patch(
+            mapping_url, data={
+                'title': 'original_title', 'slug': 'original_slug', 'content': 'original_content'
+            }, content_type='application/json'
+        )
+        print(f"Concurrent PATCH request with HTTP status code: {response1.status_code}")
+        self.assertEqual(response1.status_code, 202)  # 202 Accepted
+
+        def patch_request(data):
+            local_client = Client()
+            response = local_client.patch(
+                mapping_url,
+                data=data,
+                content_type='application/json'
+            )
+            print(f"Concurrent PATCH request with data {data} HTTP status code: {response.status_code}")
+
+        # Define PATCH requests data
+        data1 = {'title': 'new_title'}
+        data2 = {'slug': 'new_slug'}
+        data3 = {'content': 'new_content'}
+
+        # Get headers for authentication
+
+
+        # Create threads to simulate concurrent requests
+        thread1 = threading.Thread(target=patch_request, args=(data1,))
+        thread2 = threading.Thread(target=patch_request, args=(data2,))
+        thread3 = threading.Thread(target=patch_request, args=(data3,))
+
+        # Start threads
+        thread1.start()
+        thread2.start()
+        thread3.start()
+
+        # Wait for threads to finish
+        thread1.join()
+        thread2.join()
+        thread3.join()
+
+        # Refresh the object from the database
+        self.note.refresh_from_db()
+
+        # Check final values (exact value check since race conditions should be handled)
+        self.assertEqual(self.note.title, "new_title")
+        self.assertEqual(self.note.slug, "new_slug")
+        self.assertEqual(self.note.content, "new_content")
+

--- a/tests/core/tests/race_condition.py
+++ b/tests/core/tests/race_condition.py
@@ -51,9 +51,6 @@ class ApiConcurrentPatchTestCase(LiveServerTestCase):
         data2 = {'slug': 'new_slug'}
         data3 = {'content': 'new_content'}
 
-        # Get headers for authentication
-
-
         # Create threads to simulate concurrent requests
         thread1 = threading.Thread(target=patch_request, args=(data1,))
         thread2 = threading.Thread(target=patch_request, args=(data2,))
@@ -76,4 +73,3 @@ class ApiConcurrentPatchTestCase(LiveServerTestCase):
         self.assertEqual(self.note.title, "new_title")
         self.assertEqual(self.note.slug, "new_slug")
         self.assertEqual(self.note.content, "new_content")
-


### PR DESCRIPTION
Manually rebasing @quietlyconfident's work in #1151 against the current release, in case anybody is interested in picking it back up.  I took an educated guess about how to merge that code into the current release; some of `BaseModelResource.save()` has already changed, but I cannot guarantee my guess is correct as I cannot replicate the issue.

Thus, the process for getting this merged:
1. Test this in a scenario known to cause the issue, to make sure my guess about merging is correct, and fix it if not.
2. Fix the current failing tests, making sure the new code doesn't introduce regressions.  It is possible the new code is the wrong way to do this.
3. Write new tests covering this new behavior; it would be nice if the race condition could be replicated via the live server test cases, but if it is a true race condition that may not be possible.

Again, I cannot take step 1 in this list, as I do not have a scenario known to cause the issue.