### PR TITLE
Add race condition tests to core innit.

### DIFF
--- a/tests/core/tests/__init__.py
+++ b/tests/core/tests/__init__.py
@@ -15,7 +15,7 @@ from core.tests.serializers import *  # noqa
 from core.tests.throttle import *  # noqa
 from core.tests.utils import *  # noqa
 from core.tests.validation import *  # noqa
-
+from core.tests.race_condition import *  # noqa
 
 # Explicitly add doctests to suite; Django's test runner stopped
 # running them automatically around version 1.6


### PR DESCRIPTION
@georgedorn I think the answer is much simpler, it doesn't fail because i failed to add it to the __init_ and thus it didn't get discovered. 
I'm PRing this to your bug branch.