### PR TITLE
Improve ApiField null value handling

### DIFF
--- a/tastypie/fields.py
+++ b/tastypie/fields.py
@@ -182,8 +182,10 @@ class ApiField(object):
                     pass
             if self.instance_name:
                 try:
-                    if hasattr(bundle.obj, self.instance_name):
-                        return getattr(bundle.obj, self.instance_name)
+                    val = getattr(bundle.obj, self.instance_name, None)
+
+                    if val is not None:
+                        return val
                 except ObjectDoesNotExist:
                     pass
             if self.has_default():

--- a/tests/core/tests/resources.py
+++ b/tests/core/tests/resources.py
@@ -972,7 +972,7 @@ class AlwaysDataNoteResource(NoteResource):
 
 
 class AlwaysDataNoteResourceUseIn(NoteResource):
-    author = fields.CharField(attribute='author__username', use_in="detail")
+    author = fields.CharField(attribute='author__username', use_in="detail", null=True)
     constant = fields.IntegerField(default=20, use_in="list")
 
     class Meta:
@@ -983,7 +983,7 @@ class AlwaysDataNoteResourceUseIn(NoteResource):
 
 
 class NoteResourceNonUniqueDetailUriName(NoteResource):
-    author = fields.CharField(attribute='author__username', use_in="detail")
+    author = fields.CharField(attribute='author__username', use_in="detail", null=True)
     constant = fields.IntegerField(default=20, use_in="list")
 
     class Meta:

--- a/tests/related_resource/api/resources.py
+++ b/tests/related_resource/api/resources.py
@@ -213,7 +213,7 @@ class PostResource(ModelResource):
 
 class PaymentResource(ModelResource):
     job = fields.ToOneField('related_resource.api.resources.JobResource',
-        'job')
+        'job', null=True)
 
     class Meta:
         queryset = Payment.objects.all()


### PR DESCRIPTION
Dont return None values looked up using 'instance_name'. This follows how values are handled with the 'attribute' lookup.

Fixes #1698